### PR TITLE
Fixed a global variable leak

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -991,7 +991,7 @@ function parseOptions(str, map) {
 
   // All options are false by default
   var options = {};
-  for (letter in map)
+  for (var letter in map)
     options[map[letter]] = false;
 
   if (!str)


### PR DESCRIPTION
Mocha complains quite a bit if you leak a global variable during a test, and I'm guessing that this really doesn't need to be global.
