### PR TITLE
Stop execution on errors.

### DIFF
--- a/make.js
+++ b/make.js
@@ -1,5 +1,7 @@
+var shell = require('./shell');
 require('./global');
 
+shell.config.exitOnErrors = true;
 global.target = {};
 
 // This ensures we only execute the script targets after the entire script has

--- a/shell.js
+++ b/shell.js
@@ -16,6 +16,10 @@ var fs = require('fs'),
 // Node shims for < v0.7
 fs.existsSync = fs.existsSync || path.existsSync;
 
+var config = exports.config = {
+  exitOnErrors: false
+};
+
 var state = {
       error: null,
       fatal: false,
@@ -1046,7 +1050,9 @@ function error(msg, _continue) {
   log(state.error);
 
   if (!_continue) {
-    state.fatal = true;
+    if (config.exitOnErrors) {
+      state.fatal = true;
+    }
     throw '';
   }
 }


### PR DESCRIPTION
As I learned today commands that trigger errors don't stop script execution.

For example:
cd('some_non_existent_dir');
rm('-rf', '*');

You'd expect it to die trying to cd into a directory that doesn't exist (like make), but it doesn't and it executes the rm in the current directory.
