### PR TITLE
Replace the "node" shell command in shell.js with process.execPath

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -1770,7 +1770,8 @@ function execSync(cmd, opts) {
   if (fs.existsSync(codeFile)) _unlinkSync(codeFile);
 
   fs.writeFileSync(scriptFile, script);
-  child.exec('node '+scriptFile, {
+  // the execPath is quoted for things like C:\Program Files\ 
+  child.exec('"'+process.execPath+'" '+scriptFile, {
     env: process.env,
     cwd: exports.pwd()
   });


### PR DESCRIPTION
On platforms like Ubuntu/Debian where the node command has been taken by a throwback command (node(8) - Node front end for AX.25, NET/ROM, Rose and TCP), the shell js exec goes into an infinite loop because the node command exits with status 1.

I ran into this error while figuring out how to build pdf.js 

https://github.com/mozilla/pdf.js/pull/2608

I use process.execPath to invoke the node command again, so that it picks up and runs the sub command with "/usr/bin/nodejs" instead of "node".

This had to be quoted again for the shell, to accommodate win32 versions as well which need to run "C:\Program Files\" which has a space in it.
