### PR TITLE
test('-L', badlink) should return true

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -584,14 +584,19 @@ function _test(options, path) {
   if (!canInterpret)
     error('could not interpret expression');
 
+  if (options.link) {
+    try {
+      return fs.lstatSync(path).isSymbolicLink();
+    } catch(e) {
+      return false;
+    }
+  }
+  
   if (!fs.existsSync(path))
     return false;
 
   if (options.exists)
     return true;
-
-  if (options.link)
-    return fs.lstatSync(path).isSymbolicLink();
 
   var stats = fs.statSync(path);
 

--- a/test/resources/badlink
+++ b/test/resources/badlink
@@ -1,0 +1,1 @@
+not_existed_file

--- a/test/test.js
+++ b/test/test.js
@@ -80,4 +80,12 @@ var result = shell.test('-L', 'resources/link');
 assert.equal(shell.error(), null);
 assert.equal(result, true);//true
 
+var result = shell.test('-L', 'resources/badlink');
+assert.equal(shell.error(), null);
+assert.equal(result, true);//true
+
+var result = shell.test('-L', 'resources/404');
+assert.equal(shell.error(), null);
+assert.equal(result, false);//false
+
 shell.exit(123);


### PR DESCRIPTION
If a symbolic link is broken, test('-L', badlink) should still return true. 

test('-L', 404) should return false.
