### PR TITLE
tempdir: use `os.tmpDir` when possible

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -1698,22 +1698,19 @@ function tempDir() {
   if (state.tempDir)
     return state.tempDir; // from cache
 
-  state.tempDir = os.tmpDir ?
-    // node 0.8+ has `os.tmpDir()`
-    os.tmpDir() :
-    // back-compat for older node installs
-    writeableDir(process.env['TMPDIR']) ||
-    writeableDir(process.env['TEMP']) ||
-    writeableDir(process.env['TMP']) ||
-    writeableDir(process.env['Wimp$ScrapDir']) || // RiscOS
-    writeableDir('C:\\TEMP') || // Windows
-    writeableDir('C:\\TMP') || // Windows
-    writeableDir('\\TEMP') || // Windows
-    writeableDir('\\TMP') || // Windows
-    writeableDir('/tmp') ||
-    writeableDir('/var/tmp') ||
-    writeableDir('/usr/tmp') ||
-    writeableDir('.'); // last resort
+  state.tempDir = writeableDir(os.tempDir && os.tempDir()) || // node 0.8+
+                  writeableDir(process.env['TMPDIR']) ||
+                  writeableDir(process.env['TEMP']) ||
+                  writeableDir(process.env['TMP']) ||
+                  writeableDir(process.env['Wimp$ScrapDir']) || // RiscOS
+                  writeableDir('C:\\TEMP') || // Windows
+                  writeableDir('C:\\TMP') || // Windows
+                  writeableDir('\\TEMP') || // Windows
+                  writeableDir('\\TMP') || // Windows
+                  writeableDir('/tmp') ||
+                  writeableDir('/var/tmp') ||
+                  writeableDir('/usr/tmp') ||
+                  writeableDir('.'); // last resort
 
   return state.tempDir;
 }

--- a/test/tempdir.js
+++ b/test/tempdir.js
@@ -22,10 +22,6 @@ shell.mkdir('tmp');
 //
 
 var tmp = shell.tempdir();
-// node 0.8+
-if (os.tmpDir) {
-  assert.equal(os.tmpDir(), tmp);
-}
 assert.equal(shell.error(), null);
 assert.equal(fs.existsSync(tmp), true);
 


### PR DESCRIPTION
use node's native `tmpDir` when possible, but fallback to the python's algorithm in old (really old) versions of node
