### PR TITLE
new execsync via node-ffi with hack fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   "devDependencies": {
     "jshint": "~1.1.0"
   },
-  "optionalDependencies": {},
+  "optionalDependencies": {
+    "execsync-ng": "0.0.6"
+  },
   "engines": {
     "node": "*"
   }

--- a/shell.js
+++ b/shell.js
@@ -13,6 +13,19 @@ var fs = require('fs'),
     child = require('child_process'),
     os = require('os');
 
+var execSyncNG;
+
+
+// Try to load execsync-ng based on node-ffi, unless
+// execsync-ng failed to install or node-ffi is
+// unable to load the msvcrt library (on windows),
+try {
+  execSyncNG = require('execsync-ng');
+} catch (e) {
+  execSyncNG = null;
+}
+
+
 // Node shims for < v0.7
 fs.existsSync = fs.existsSync || path.existsSync;
 
@@ -1510,6 +1523,8 @@ function wrap(cmd, fn, options) {
 // (Using readFileSync() + writeFileSync() could easily cause a memory overflow
 //  with large files)
 function copyFileSync(srcFile, destFile) {
+
+  //console.log("copying", srcFile, "to", destFile);
   if (!fs.existsSync(srcFile))
     error('copyFileSync: no such file or directory: ' + srcFile);
 
@@ -1540,6 +1555,7 @@ function copyFileSync(srcFile, destFile) {
 
   fs.closeSync(fdr);
   fs.closeSync(fdw);
+  //console.log("done copying", srcFile, "to", destFile);
 }
 
 // Recursively copies 'sourceDir' into 'destDir'
@@ -1742,20 +1758,31 @@ function execAsync(cmd, opts, callback) {
   return c;
 }
 
+
+
+
+function execSyncFfi(cmd, opts) {
+  var res = execSyncNG.exec(cmd, opts);
+  return { 
+    code: res.code, 
+    output: res.stdout 
+  };
+
+}
+
+
 // Hack to run child_process.exec() synchronously (sync avoids callback hell)
 // Uses a custom wait loop that checks for a flag file, created when the child process is done.
 // (Can't do a wait loop that checks for internal Node variables/messages as
 // Node is single-threaded; callbacks and other internal state changes are done in the
 // event loop).
-function execSync(cmd, opts) {
+
+function execSyncHack(cmd, options) {
   var stdoutFile = path.resolve(tempDir()+'/'+randomFileName()),
       codeFile = path.resolve(tempDir()+'/'+randomFileName()),
       scriptFile = path.resolve(tempDir()+'/'+randomFileName()),
       sleepFile = path.resolve(tempDir()+'/'+randomFileName());
 
-  var options = extend({
-    silent: config.silent
-  }, opts);
 
   var previousStdoutContent = '';
   // Echoes stdout changes from running process, if not silent
@@ -1824,7 +1851,24 @@ function execSync(cmd, opts) {
     output: stdout
   };
   return obj;
-} // execSync()
+} // execSyncHack()
+
+
+function execSync(cmd, opts) {
+  var options = extend({
+    silent: config.silent,
+    _native: true
+  }, opts);
+
+  // Use the ffi execsync module if available
+  if (execSyncNG && options._native)
+    return execSyncFfi(cmd, options);
+  // Otherwise fallback to the hack.
+  else
+    return execSyncHack(cmd, options);
+}
+
+
 
 // Expands wildcards with matching file names. For a given array of file names 'list', returns
 // another array containing all file names as per ls(list[i]).

--- a/test/exec.js
+++ b/test/exec.js
@@ -31,42 +31,55 @@ assert.ok(result.code > 0);
 // sync
 //
 
-// check if stdout goes to output
-var result = shell.exec('node -e \"console.log(1234);\"');
-assert.equal(shell.error(), null);
-assert.equal(result.code, 0);
-assert.ok(result.output === '1234\n' || result.output === '1234\nundefined\n'); // 'undefined' for v0.4
+function testSync(opt) {
+  var result;
+  // check if stdout goes to output
+  result = shell.exec('node -e \"console.log(1234);\"', opt);
+  assert.equal(shell.error(), null);
+  assert.equal(result.code, 0);
+  assert.ok(result.output === '1234\n' || result.output === '1234\nundefined\n'); // 'undefined' for v0.4
 
-// check if stderr goes to output
-var result = shell.exec('node -e \"console.error(1234);\"');
-assert.equal(shell.error(), null);
-assert.equal(result.code, 0);
-assert.ok(result.output === '1234\n' || result.output === '1234\nundefined\n'); // 'undefined' for v0.4
+  // check if stderr goes to output
+  result = shell.exec('node -e \"console.error(1234);\"', opt);
+  assert.equal(shell.error(), null);
+  assert.equal(result.code, 0);
+  assert.ok(result.output === '1234\n' || result.output === '1234\nundefined\n'); // 'undefined' for v0.4
 
-// check if stdout + stderr go to output
-var result = shell.exec('node -e \"console.error(1234); console.log(666);\"');
-assert.equal(shell.error(), null);
-assert.equal(result.code, 0);
-assert.ok(result.output === '1234\n666\n' || result.output === '1234\n666\nundefined\n');  // 'undefined' for v0.4
+  // check if stdout + stderr go to output
+  result = shell.exec('node -e \"console.error(1234); console.log(666);\"', opt);
+  assert.equal(shell.error(), null);
+  assert.equal(result.code, 0);
+  assert.ok(result.output === '1234\n666\n' || result.output === '1234\n666\nundefined\n');  // 'undefined' for v0.4
 
-// check exit code
-var result = shell.exec('node -e \"process.exit(12);\"');
-assert.equal(shell.error(), null);
-assert.equal(result.code, 12);
+  // check exit code
+  result = shell.exec('node -e \"process.exit(12);\"', opt);
+  assert.equal(shell.error(), null);
+  assert.equal(result.code, 12);
 
-// interaction with cd
-shell.cd('resources/external');
-var result = shell.exec('node node_script.js');
-assert.equal(shell.error(), null);
-assert.equal(result.code, 0);
-assert.equal(result.output, 'node_script_1234\n');
-shell.cd('../..');
+  // interaction with cd
+  shell.cd('resources/external');
+  result = shell.exec('node node_script.js', opt);
+  assert.equal(shell.error(), null);
+  assert.equal(result.code, 0);
+  assert.equal(result.output, 'node_script_1234\n');
+  shell.cd('../..');
 
-// check quotes escaping
-var result = shell.exec( util.format('node -e "console.log(%s);"', "\\\"\\'+\\'_\\'+\\'\\\"") );
-assert.equal(shell.error(), null);
-assert.equal(result.code, 0);
-assert.equal(result.output, "'+'_'+'\n");
+  // check quotes escaping
+  result = shell.exec( util.format('node -e "console.log(%s);"', "\\\"\\'+\\'_\\'+\\'\\\""), opt );
+  assert.equal(shell.error(), null);
+  assert.equal(result.code, 0);
+  assert.equal(result.output, "'+'_'+'\n");
+
+
+
+}
+
+// test native sync implementation first
+testSync();
+
+// test hack sync implementation second
+testSync({_native:false});
+
 
 //
 // async


### PR DESCRIPTION
New implementation of execsync based on execsync-ng, which is based on node-ffi to address #66 

execsync-ng is listed as an optional dependency. This means that if node-ffi cannot be installed or (on Windows machines) msvcrt.dll cannot be loaded, the old hack approach will be used as a fallback.

exec now takes another private parameter called `_native` which defaults to true. If set to false, the hack implementation will be used. This parameter is not documented and is used only in `test/exec.js` to run the tests against both the default and the hack implementation.

edit: the latest execsync-ng also supports a silent parameter which when set to false causes it to output data to stdout as it comes (without buffering it). This means that it now works exactly the same as the hack version.
