### PR TITLE
Fix a small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Examples:
 
 ```javascript
 if (test('-d', path)) { /* do something with dir */ };
-if (!test('-f', path)) continue; // skip if it's a regular file
+if (!test('-f', path)) continue; // skip if it's not a regular file
 ```
 
 Evaluates expression using the available primaries and returns corresponding value.


### PR DESCRIPTION
The negated -f test is checking whether the path is _not_ a regular file, so I have updated the comment to match.
