### PR TITLE
Make shell.exec() treat process error return codes as shelljs errors

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -82,6 +82,10 @@ function execSync(cmd, opts) {
   try { common.unlinkSync(codeFile); } catch(e) {}
   try { common.unlinkSync(sleepFile); } catch(e) {}
 
+  // some shell return codes are defined as errors, per http://tldp.org/LDP/abs/html/exitcodes.html
+  if (code === 1 || code === 2 || code >= 126)  {
+      common.error('Exec returned error code' + code, true);
+  }
   // True if successful, false if not
   var obj = {
     code: code,

--- a/test/exec.js
+++ b/test/exec.js
@@ -22,6 +22,22 @@ assert.ok(shell.error());
 var result = shell.exec('asdfasdf'); // could not find command
 assert.ok(result.code > 0);
 
+// Test 'fatal' mode for exec, temporarily overriding process.exit
+var old_fatal = shell.config.fatal;
+var old_exit = process.exit;
+
+var exitcode = 9999;
+process.exit = function (_exitcode) {
+    exitcode = _exitcode;
+};
+
+shell.config.fatal = true;
+
+var result = shell.exec('asdfasdf'); // could not find command
+assert.equal(exitcode, 1);
+
+shell.config.fatal = old_fatal;
+process.exit = old_exit;
 
 //
 // Valids


### PR DESCRIPTION
This PR makes shell.exec() handle error return codes the same way as other shelljs errors -- by calling common.error(). Especially in fatal mode, this makes error handling of exec more consistent with other shelljs functions.

To test, I temporarily override process.exit(), then put it back... let me know if you have any better suggestions :)
