### PR TITLE
ref #79 cp DOES NOT include files beginning with `.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Available options:
 + `-f`: force
 + `-r, -R`: recursive
 
+This DOES NOT include files beginning with `.` (ref #79)
+
 Examples:
 
 ```javascript


### PR DESCRIPTION
When could not be solved, should be shown in documentation.
