### PR TITLE
Search PATHEXT instead of 3 hardcoded values

### DIFF
--- a/src/which.js
+++ b/src/which.js
@@ -62,7 +62,6 @@ function _which(options, cmd) {
             pathExtArray = splitPath(pathExtEnv),
             len = pathExtArray.length;
         
-        // parse PATHEXT
         for (var i = 0; i < len; i++) {
           attempt = baseAttempt + pathExtArray[i];
           if (checkPath(attempt)) {


### PR DESCRIPTION
Better to search the PATHEXT variable instead of hard-coding an incomplete list for Windows executables. A default fallback consisting of XP's default value is also introduced just in case. The fallback value is hardcoded as a constant at the top of the file.