### PR TITLE
Use inspect() to show a list in console instead of raw array object

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -30,8 +30,9 @@ if (exec(JSHINT_BIN + ' *.js test/*.js').code !== 0) {
 //
 cd(__dirname + '/../test');
 ls('*.js').forEach(function(file) {
-  echo('Running test:', file);
-  if (exec('node ' + file).code !== 123) { // 123 avoids false positives (e.g. premature exit)
+  var name = file.name
+  echo('Running test:', name);
+  if (exec('node ' + name).code !== 123) { // 123 avoids false positives (e.g. premature exit)
     failed = true;
     echo('*** TEST FAILED! (missing exit code "123")');
     echo();

--- a/src/cd.js
+++ b/src/cd.js
@@ -1,12 +1,18 @@
-var fs = require('fs');
+var fs   = require('fs');
+var path = require('path');
+
 var common = require('./common');
 
 //@
 //@ ### cd('dir')
 //@ Changes to directory `dir` for the duration of the script
 function _cd(options, dir) {
-  if (!dir)
-    common.error('directory not specified');
+  var env = process.env
+
+  if (!dir) dir = env.HOME;
+
+  dir.replace(/^~\//, function () { return env.HOME + '/' });
+  dir = path.resolve(env.PWD, dir);
 
   if (!fs.existsSync(dir))
     common.error('no such file or directory: ' + dir);
@@ -15,5 +21,6 @@ function _cd(options, dir) {
     common.error('not a directory: ' + dir);
 
   process.chdir(dir);
+  env.PWD = dir;
 }
 module.exports = _cd;

--- a/src/common.js
+++ b/src/common.js
@@ -99,17 +99,17 @@ function expand(list) {
       var rest = match[2];
       var restRegex = rest.replace(/\*\*/g, ".*").replace(/\*/g, "[^\\/]*");
       restRegex = new RegExp(restRegex);
-      
+
       _ls('-R', root).filter(function (e) {
-        return restRegex.test(e);
+        return restRegex.test(e.name);
       }).forEach(function(file) {
-        expanded.push(file);
+        expanded.push(file.name);
       });
     }
     // Wildcard present on file names ?
     else if (listEl.search(/\*/) > -1) {
       _ls('', listEl).forEach(function(file) {
-        expanded.push(file);
+        expanded.push(file.name);
       });
     } else {
       expanded.push(listEl);

--- a/src/dirs.js
+++ b/src/dirs.js
@@ -25,6 +25,10 @@ function _actualDirStack() {
   return [process.cwd()].concat(_dirStack);
 }
 
+function inspect(depth) {
+  return this.join('\n')
+}
+
 //@
 //@ ### pushd([options,] [dir | '-N' | '+N'])
 //@
@@ -60,6 +64,7 @@ function _pushd(options, dir) {
   var dirs = _actualDirStack();
 
   if (dir === '+0') {
+    Object.defineProperty(dirs, 'inspect', {value: inspect});
     return dirs; // +0 is a noop
   } else if (!dir) {
     if (dirs.length > 1) {
@@ -180,11 +185,10 @@ function _dirs(options, index) {
       index = stack.length + index;
     }
 
-    common.log(stack[index]);
     return stack[index];
   }
 
-  common.log(stack.join(' '));
+  Object.defineProperty(stack, 'inspect', {value: inspect});
 
   return stack;
 }

--- a/src/echo.js
+++ b/src/echo.js
@@ -14,7 +14,27 @@ var common = require('./common');
 //@ like `.to()`.
 function _echo() {
   var messages = [].slice.call(arguments, 0);
-  console.log.apply(this, messages);
-  return common.ShellString(messages.join(' '));
+
+  var opts = { newline: true, 'escape': false };
+  for (var i = 0; i < messages.length; i++) {
+      if (messages[i] === '-n') {
+          opts.newline = false;
+          args.splice(i--, 1);
+      }
+      else if (messages[i] === '-e') {
+          opts['escape'] = true;
+          messages.splice(i--, 1);
+      }
+      else if (messages[i] === '-E') {
+          opts['escape'] = false;
+          messages.splice(i--, 1);
+      }
+  }
+
+  var result = messages.join(' ');
+//  if (opts.newline) result += '\n';
+
+  console.log(result)
+  return common.ShellString(result);
 }
 module.exports = _echo;

--- a/src/exec.js
+++ b/src/exec.js
@@ -108,15 +108,19 @@ function execAsync(cmd, opts, callback) {
   });
 
   c.stdout.on('data', function(data) {
-    output += data;
+    if (callback)
+      output += data;
+
     if (!options.silent)
       process.stdout.write(data);
   });
 
   c.stderr.on('data', function(data) {
-    output += data;
+    if (callback)
+      output += data;
+
     if (!options.silent)
-      process.stdout.write(data);
+      process.stderr.write(data);
   });
 
   return c;

--- a/src/find.js
+++ b/src/find.js
@@ -41,7 +41,7 @@ function _find(options, paths) {
 
     if (fs.statSync(file).isDirectory()) {
       _ls('-RA', file+'/*').forEach(function(subfile) {
-        pushFile(subfile);
+        pushFile(subfile.name);
       });
     }
   });

--- a/src/find.js
+++ b/src/find.js
@@ -46,6 +46,11 @@ function _find(options, paths) {
     }
   });
 
+  function inspect(depth) {
+    return this.join('\n')
+  }
+  Object.defineProperty(list, 'inspect', {value: inspect});
+
   return list;
 }
 module.exports = _find;

--- a/src/grep.js
+++ b/src/grep.js
@@ -31,7 +31,7 @@ function _grep(options, regex, files) {
 
   files = common.expand(files);
 
-  var grep = '';
+  var list = [];
   files.forEach(function(file) {
     if (!fs.existsSync(file)) {
       common.error('no such file or directory: ' + file, true);
@@ -43,10 +43,15 @@ function _grep(options, regex, files) {
     lines.forEach(function(line) {
       var matched = line.match(regex);
       if ((options.inverse && !matched) || (!options.inverse && matched))
-        grep += line + '\n';
+        list.push(line);
     });
   });
 
-  return common.ShellString(grep);
+  function inspect(depth) {
+    return this.join('\n')
+  }
+  Object.defineProperty(list, 'inspect', {value: inspect});
+
+  return list;
 }
 module.exports = _grep;

--- a/src/ls.js
+++ b/src/ls.js
@@ -1,5 +1,7 @@
 var path = require('path');
 var fs = require('fs');
+var constants = require('constants');
+
 var common = require('./common');
 var _cd = require('./cd');
 var _pwd = require('./pwd');
@@ -10,6 +12,7 @@ var _pwd = require('./pwd');
 //@ Available options:
 //@
 //@ + `-l`: long list format
+//@ + `-C`: classify
 //@ + `-R`: recursive
 //@ + `-A`: all files (include files beginning with `.`, except for `.` and `..`)
 //@
@@ -25,6 +28,7 @@ var _pwd = require('./pwd');
 function _ls(options, paths) {
   options = common.parseOptions(options, {
     'l': 'long',
+    'C': 'classify',
     'R': 'recursive',
     'A': 'all',
     'a': 'all_deprecated'
@@ -144,6 +148,20 @@ function _ls(options, paths) {
       }
 
       result += file.name
+
+      if(options.classify)
+      {
+        var S_IX = constants.S_IXUSR
+                 | constants.S_IXGRP
+                 | constants.S_IXOTH
+
+        if(file.isDirectory())         result += '/'
+        else if(file.isSocket())       result += '='
+//        else if(file.isDoor())         result += '>'
+        else if(file.isSymbolicLink()) result += '@'
+        else if(file.isFIFO())         result += '|'
+        else if(file.mode & S_IX)      result += '*'
+      }
 
       return result
     }).join('\n')

--- a/src/ls.js
+++ b/src/ls.js
@@ -121,6 +121,11 @@ function _ls(options, paths) {
     common.error('no such file or directory: ' + p, true);
   });
 
+  function inspect(depth) {
+    return this.join('\n')
+  }
+  Object.defineProperty(list, 'inspect', {value: inspect});
+
   return list;
 }
 module.exports = _ls;

--- a/src/ls.js
+++ b/src/ls.js
@@ -65,6 +65,7 @@ function _ls(options, paths) {
   paths.forEach(function(p) {
     if (fs.existsSync(p)) {
       var stats = fs.statSync(p);
+
       // Simple file?
       if (stats.isFile()) {
         pushFile(p, p);

--- a/test/cd.js
+++ b/test/cd.js
@@ -16,9 +16,6 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-shell.cd();
-assert.ok(shell.error());
-
 assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
 shell.cd('/adsfasdf'); // dir does not exist
 assert.ok(shell.error());
@@ -30,6 +27,10 @@ assert.ok(shell.error());
 //
 // Valids
 //
+
+shell.cd();
+assert.equal(shell.error(), null);
+assert.equal(process.env.PWD, process.env.HOME);
 
 shell.cd(cur);
 shell.cd('tmp');

--- a/test/common.js
+++ b/test/common.js
@@ -47,5 +47,3 @@ assert.equal(shell.error(), null);
 assert.deepEqual(result.sort(), ["resources/file1.js","resources/file2.js","resources/ls/file1.js","resources/ls/file2.js"].sort());
 
 shell.exit(123);
-
-

--- a/test/grep.js
+++ b/test/grep.js
@@ -28,39 +28,41 @@ assert.ok(shell.error());
 
 var result = shell.grep('line', 'resources/a.txt');
 assert.equal(shell.error(), null);
-assert.equal(result.split('\n').length - 1, 4);
+assert.equal(result.length, 4);
 
 var result = shell.grep('-v', 'line', 'resources/a.txt');
 assert.equal(shell.error(), null);
-assert.equal(result.split('\n').length - 1, 8);
+assert.equal(result.length, 8);
 
 var result = shell.grep('line one', 'resources/a.txt');
 assert.equal(shell.error(), null);
-assert.equal(result, 'This is line one\n');
+assert.deepEqual(result, ['This is line one']);
 
 // multiple files
 var result = shell.grep(/test/, 'resources/file1.txt', 'resources/file2.txt');
 assert.equal(shell.error(), null);
-assert.equal(result, 'test1\ntest2\n');
+assert.deepEqual(result, ['test1','test2']);
 
 // multiple files, array syntax
 var result = shell.grep(/test/, ['resources/file1.txt', 'resources/file2.txt']);
 assert.equal(shell.error(), null);
-assert.equal(result, 'test1\ntest2\n');
+assert.deepEqual(result, ['test1','test2']);
 
 // multiple files, glob syntax, * for file name
 var result = shell.grep(/test/, 'resources/file*.txt');
 assert.equal(shell.error(), null);
-assert.ok(result == 'test1\ntest2\n' || result == 'test2\ntest1\n');
+assert.ok(result[0] == 'test1' && result[1] == 'test2' ||
+          result[0] == 'test2' && result[1] == 'test1');
 
 // multiple files, glob syntax, * for directory name
 var result = shell.grep(/test/, '*/file*.txt');
 assert.equal(shell.error(), null);
-assert.ok(result == 'test1\ntest2\n' || result == 'test2\ntest1\n');
+assert.ok(result[0] == 'test1' && result[1] == 'test2' ||
+          result[0] == 'test2' && result[1] == 'test1');
 
 // multiple files, glob syntax, ** for directory name
 var result = shell.grep(/test/, '**/file*.js');
 assert.equal(shell.error(), null);
-assert.equal(result, 'test\ntest\ntest\ntest\n');
+assert.deepEqual(result, ['test','test','test','test']);
 
 shell.exit(123);

--- a/test/ls.js
+++ b/test/ls.js
@@ -30,6 +30,7 @@ assert.equal(shell.error(), null);
 // no args
 shell.cd('resources/ls');
 var result = shell.ls();
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.indexOf('file1') > -1, true);
 assert.equal(result.indexOf('file2') > -1, true);
@@ -42,6 +43,7 @@ shell.cd('../..');
 
 // simple arg
 var result = shell.ls('resources/ls');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.indexOf('file1') > -1, true);
 assert.equal(result.indexOf('file2') > -1, true);
@@ -54,6 +56,7 @@ assert.equal(result.length, 6);
 // no args, 'all' option
 shell.cd('resources/ls');
 var result = shell.ls('-A');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.indexOf('file1') > -1, true);
 assert.equal(result.indexOf('file2') > -1, true);
@@ -69,6 +72,7 @@ shell.cd('../..');
 // no args, 'all' option
 shell.cd('resources/ls');
 var result = shell.ls('-a'); // (deprecated) backwards compatibility test
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.indexOf('file1') > -1, true);
 assert.equal(result.indexOf('file2') > -1, true);
@@ -83,6 +87,7 @@ shell.cd('../..');
 
 // wildcard, simple
 var result = shell.ls('resources/ls/*');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.indexOf('resources/ls/file1') > -1, true);
 assert.equal(result.indexOf('resources/ls/file2') > -1, true);
@@ -94,6 +99,7 @@ assert.equal(result.length, 6);
 
 // wildcard, hidden only
 var result = shell.ls('resources/ls/.*');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.indexOf('resources/ls/.hidden_file') > -1, true);
 assert.equal(result.indexOf('resources/ls/.hidden_dir') > -1, true);
@@ -101,6 +107,7 @@ assert.equal(result.length, 2);
 
 // wildcard, mid-file
 var result = shell.ls('resources/ls/f*le*');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.length, 5);
 assert.equal(result.indexOf('resources/ls/file1') > -1, true);
@@ -111,6 +118,7 @@ assert.equal(result.indexOf('resources/ls/filename(with)[chars$]^that.must+be-es
 
 // wildcard, mid-file with dot (should escape dot for regex)
 var result = shell.ls('resources/ls/f*le*.js');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.length, 2);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
@@ -123,6 +131,7 @@ assert.equal(result.length, 0);
 
 // wildcard, all files with extension
 var result = shell.ls('resources/ls/*.*');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.length, 3);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
@@ -131,6 +140,7 @@ assert.equal(result.indexOf('resources/ls/filename(with)[chars$]^that.must+be-es
 
 // wildcard, with additional path
 var result = shell.ls('resources/ls/f*le*.js', 'resources/ls/a_dir');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.length, 4);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
@@ -140,6 +150,7 @@ assert.equal(result.indexOf('nada') > -1, true); // no wildcard == no path prefi
 
 // wildcard for both paths
 var result = shell.ls('resources/ls/f*le*.js', 'resources/ls/a_dir/*');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.length, 4);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
@@ -149,6 +160,7 @@ assert.equal(result.indexOf('resources/ls/a_dir/nada') > -1, true);
 
 // wildcard for both paths, array
 var result = shell.ls(['resources/ls/f*le*.js', 'resources/ls/a_dir/*']);
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.length, 4);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
@@ -159,6 +171,7 @@ assert.equal(result.indexOf('resources/ls/a_dir/nada') > -1, true);
 // recursive, no path
 shell.cd('resources/ls');
 var result = shell.ls('-R');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.indexOf('a_dir') > -1, true);
 assert.equal(result.indexOf('a_dir/b_dir') > -1, true);
@@ -168,6 +181,7 @@ shell.cd('../..');
 
 // recusive, path given
 var result = shell.ls('-R', 'resources/ls');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.indexOf('a_dir') > -1, true);
 assert.equal(result.indexOf('a_dir/b_dir') > -1, true);
@@ -176,6 +190,7 @@ assert.equal(result.length, 9);
 
 // recusive, path given - 'all' flag
 var result = shell.ls('-RA', 'resources/ls');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.indexOf('a_dir') > -1, true);
 assert.equal(result.indexOf('a_dir/b_dir') > -1, true);
@@ -185,6 +200,7 @@ assert.equal(result.length, 14);
 
 // recursive, wildcard
 var result = shell.ls('-R', 'resources/ls/*');
+result = result.map(function(file){return file.name;});
 assert.equal(shell.error(), null);
 assert.equal(result.indexOf('resources/ls/a_dir') > -1, true);
 assert.equal(result.indexOf('resources/ls/a_dir/b_dir') > -1, true);


### PR DESCRIPTION
As shown on http://nodejs.org/api/util.html#util_customizing_util_inspect_colors, objects can has a ```inspect()``` method that will be used by ```util.inspect()``` on the Node.js REPL, so we can show on the console an output more similar to the actual one on the shell, while still returning the actual array so it can be used by other functions:

```Javascript
> require('./global')
{}
> var a = ls()
undefined
> a
LICENSE
README.md
bin
global.js
make.js
package.json
scripts
shell.js
src
test
> a instanceof Array
true
> a.join()
'LICENSE,README.md,bin,global.js,make.js,package.json,scripts,shell.js,src,test'
> a.inspect
[Function: inspect]
> a.inspect()
'LICENSE\nREADME.md\nbin\nglobal.js\nmake.js\npackage.json\nscripts\nshell.js\nsrc\ntest'
> JSON.stringify(a)
'["LICENSE","README.md","bin","global.js","make.js","package.json","scripts","shell.js","src","test"]'
```

I've only apply this to the array returned by ```ls()```, but it could be done in some other places. A good candidate to do so is ```grep()```, where it's currently returning a [multiline string](https://github.com/arturadib/shelljs/blob/master/src/grep.js#L46) while it could be better to return an array (with ```inspect()``` method) instead as ```ls()``` does.

I'm using ```Object.defineProperty()``` to set ```inspect()``` so it doesn't became an enumerable property.