### PR TITLE
Added option to print the unix like command itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Available options (all `false` by default):
 
 + `async`: Asynchronous execution. Defaults to true if a callback is provided.
 + `silent`: Do not echo program output to console.
++ `logCmd`: Prints the unix like command itself to the console. Similar to `set -o verbose` in shell scripts.
 
 Examples:
 
@@ -569,3 +570,14 @@ cp('this_file_does_not_exist', '/dev/null'); // dies here
 ```
 
 If `true` the script will die on errors. Default is `false`.
+
+### config.logCmd
+Example:
+
+```javascript
+config.logCmd = true;
+mkdir("-p","newfolder");  // prints "mkdir -p newfolder" instead of just doing it 'silently'.
+/* more commands... */
+```
+If `true` the script will print the command itself. Default is `false`.
+Will even print the command, if `config.silent` is set to `true`.

--- a/src/common.js
+++ b/src/common.js
@@ -5,7 +5,8 @@ var _ls = require('./ls');
 // Module globals
 var config = {
   silent: false,
-  fatal: false
+  fatal: false,
+  logCmd: false
 };
 exports.config = config;
 
@@ -177,6 +178,15 @@ function wrap(cmd, fn, options) {
 
     try {
       var args = [].slice.call(arguments, 0);
+
+      if (config.logCmd === true)
+      {
+          var logCmdOutput = args.slice();
+          if (cmd !== 'exec') {
+              logCmdOutput.unshift(cmd);
+          }
+          console.log.apply(this, logCmdOutput);
+      }
 
       if (options && options.notUnix) {
         retValue = fn.apply(this, args);

--- a/test/config.js
+++ b/test/config.js
@@ -22,6 +22,40 @@ assert.equal(shell.config.silent, false);
 assert.equal(shell.config.fatal, false); // default
 
 //
+// config.logCmd
+//
+
+assert.equal(shell.config.logCmd, false); // default
+
+
+shell.mkdir('-p', 'tmp');
+
+// doing, when logCmd is turned off -> stdout should be empty
+var file = 'tmp/tempscript'+Math.random()+".js";
+var script = 'require(\'../../global.js\'); config.silent=true; config.logCmd=false; mkdir("-p","somefolder1");';
+script.to(file);
+child.exec('node '+file, function(err, stdout) {
+    assert.ok(stdout.match(''));
+});
+
+// issuing a dedicated shelljs command with a parameter, while logCmd is turned on > should print the command and its parameters
+var file = 'tmp/tempscript'+Math.random()+'.js';
+var script = 'require(\'../../global.js\'); config.silent=true; config.logCmd=true; mkdir("-p","somefolder2");';
+script.to(file);
+child.exec('node '+file, function(err, stdout) {
+    assert.ok(stdout.match('mkdir -p somefolder2'));
+});
+
+// doing the same with the exec command, while the exec command should not be printed (only its args, shall be printed)
+var file = 'tmp/tempscript'+Math.random()+'.js';
+var script = 'require(\'../../global.js\'); config.silent=true; config.logCmd=true; exec("mkdir somefolder3");';
+script.to(file);
+child.exec('node '+file, function(err, stdout) {
+    assert.ok(stdout.match('mkdir somefolder3'));
+});
+
+
+//
 // config.fatal = false
 //
 shell.mkdir('-p', 'tmp');


### PR DESCRIPTION
This is similar to the option `set -o verbose` in regular shell scripts. Partially related to #8.
Without this option some commands are completely silent, e.g. `mkdir('somedir')` would just create a directory silently. With the logCmd option it will additionally print `mkdir somedir`, to give the user an idea what the script is actually doing.