### PR TITLE
Fixed force linking to an existing directory

### DIFF
--- a/src/ln.js
+++ b/src/ln.js
@@ -40,8 +40,12 @@ function _ln(options, source, dest) {
     if (!options.force) {
       common.error('Destination file exists', true);
     }
-
-    fs.unlinkSync(dest);
+    var stat = fs.lstatSync(dest);
+    if (stat.isDirectory()) {
+      fs.rmdirSync(dest);
+    } else {
+      fs.unlinkSync(dest);
+    }
   }
 
   if (options.symlink) {

--- a/src/ln.js
+++ b/src/ln.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var common = require('./common');
 var os = require('os');
+var rm = require('./rm');
 
 //@
 //@ ### ln(options, source, dest)
@@ -40,12 +41,7 @@ function _ln(options, source, dest) {
     if (!options.force) {
       common.error('Destination file exists', true);
     }
-    var stat = fs.lstatSync(dest);
-    if (stat.isDirectory()) {
-      fs.rmdirSync(dest);
-    } else {
-      fs.unlinkSync(dest);
-    }
+    rm('-rf', dest);
   }
 
   if (options.symlink) {

--- a/test/ln.js
+++ b/test/ln.js
@@ -96,4 +96,13 @@ assert.equal(
   'new content 3'
 );
 
+// Force link directory
+shell.mkdir('tmp/dir');
+shell.ln('-sf', 'tmp/file1', 'tmp/dir');
+assert(fs.existsSync('tmp/dir'));
+assert.equal(
+  fs.readFileSync('tmp/file1').toString(),
+  fs.readFileSync('tmp/dir').toString()
+);
+
 shell.exit(123);


### PR DESCRIPTION
Previously, trying to symlink to an existing directory with the `force` flag would error.  It was calling `unlink` on a directory.  This fixes that by checking if it is a directory before removing.

Let me know if there is anything else you need to merge this!