### PR TITLE
support costom echo in exec command

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -96,11 +96,12 @@ function execSync(cmd, opts) {
 
 // Wrapper around exec() to enable echoing output to console in real time
 function execAsync(cmd, opts, callback) {
-  var output = '';
-
   var options = common.extend({
     silent: common.config.silent
   }, opts);
+
+  var echo = options.echo || process.stdout.write,
+    output = '';
 
   var c = child.exec(cmd, {env: process.env, maxBuffer: 20*1024*1024}, function(err) {
     if (callback)
@@ -110,13 +111,13 @@ function execAsync(cmd, opts, callback) {
   c.stdout.on('data', function(data) {
     output += data;
     if (!options.silent)
-      process.stdout.write(data);
+      echo(data);
   });
 
   c.stderr.on('data', function(data) {
     output += data;
     if (!options.silent)
-      process.stdout.write(data);
+      echo(data);
   });
 
   return c;

--- a/test/exec.js
+++ b/test/exec.js
@@ -81,8 +81,11 @@ assert.equal(result.output, "'+'_'+'\n");
 // async
 //
 
-// no callback
-var c = shell.exec('node -e \"console.log(1234)\"', {async:true});
+// no callback, with custom echo
+var myecho = function(data) {
+  assert.ok(data === '1234\n' || data === '1234\nundefined\n');  // 'undefined' for v0.4
+};
+var c = shell.exec('node -e \"console.log(1234)\"', {async:true, echo: myecho});
 assert.equal(shell.error(), null);
 assert.ok('stdout' in c, 'async exec returns child process object');
 


### PR DESCRIPTION
`shelljs` makes me happy when writing automatical scripts. Thanks so much! :+1: 

But when executing parallel jobs, to distinguish different child process' console out, I had to make my custom execAsync:
```javascript
function execAsync(cmd, opts, callback) {
  opts = opts || {};

  var c = child.exec(cmd, { env: process.env }, function (err) {
    if (callback) callback(err ? err.code : 0);
  });

  var echo = opts.echo || process.stdout.write;
  c.stdout.on('data', function (data) {
  	echo(data);
  });

  c.stderr.on('data', function (data) {
  	echo(data);
  });

  return c;
}
exports.execAsync = execAsync;
```

Which enable me pass in my custom echo.

And my custom echo will auto add a specified prefix to every echo message. Its factory function is like this:
```javascript
function prefixEcho(prefix) {
  return function (message) {
    echo('[' + prefix + '] ' + message.replace(/\n$/, ''));
  }
}
exports.prefixEcho = prefixEcho;
```

Realizing this feature will also be useful for other people, I made the pull request.

**Can you help review and give your suggestions?**