### PR TITLE
Add array of commands in exec

### DIFF
--- a/test/exec.js
+++ b/test/exec.js
@@ -115,4 +115,12 @@ shell.exec('node -e \"console.log(5678);\"', function(code, output) {
 
 });
 
+// series exec
+var result = shell.exec(['node -e \"console.log(1234);\"', 'node -e \"console.log(4321);\"'], function(code, output) {
+  assert.equal(shell.error(), null);
+  assert.equal(code, 0);
+  assert.ok(output === '1234\n4321\n' || output === '1234\nundefined\n4321\nundefined\n');  // 'undefined' for v0.4
+});
+
+
 assert.equal(shell.error(), null);

--- a/test/exec.js
+++ b/test/exec.js
@@ -1,5 +1,4 @@
 var shell = require('..');
-
 var assert = require('assert'),
     util = require('util');
 
@@ -116,7 +115,7 @@ shell.exec('node -e \"console.log(5678);\"', function(code, output) {
 });
 
 // series exec
-var result = shell.exec(['node -e \"console.log(1234);\"', 'node -e \"console.log(4321);\"'], function(code, output) {
+shell.exec(['node -e \"console.log(1234);\"', 'node -e \"console.log(4321);\"'], function(code, output) {
   assert.equal(shell.error(), null);
   assert.equal(code, 0);
   assert.ok(output === '1234\n4321\n' || output === '1234\nundefined\n4321\nundefined\n');  // 'undefined' for v0.4


### PR DESCRIPTION
Hi everyone.
I suggest to add possibility to set array of commands in first argument of exec method.
Example:
    
    shell.exec(['git pull', 'npm i'], function(code, output) {
    
    });

Fixes #103