### PR TITLE
handling symlink with '-L' option for copying

### DIFF
--- a/src/cp.js
+++ b/src/cp.js
@@ -132,7 +132,7 @@ function cpdirSyncRecursive(sourceDir, destDir, opts) {
 //@
 //@ + `-f`: force
 //@ + `-r, -R`: recursive
-//@ + `-L`: symbolic links are followed
+//@ + `-L`: follow symbolic links
 //@
 //@ Examples:
 //@

--- a/src/cp.js
+++ b/src/cp.js
@@ -85,6 +85,9 @@ function cpdirSyncRecursive(sourceDir, destDir, opts) {
     var srcFile = sourceDir + "/" + files[i];
     var destFile = destDir + "/" + files[i];
     var srcFileStat = fs.lstatSync(srcFile);
+    if (fs.existsSync(destFile)) {
+        if (fs.lstatSync(destFile).isSymbolicLink() && opts.force) fs.unlinkSync(destFile);
+    }
 
     if (srcFileStat.isDirectory()) {
       /* recursion this thing right on back. */


### PR DESCRIPTION
Related Issue & Code changes
* https://github.com/arturadib/shelljs/issues/69
* https://github.com/eisnerd/shelljs/commit/2e0ab9d9256e6b59ed128358eebc8b05d4bdd9d7

```
shelljs.cp('-r', src, dst);  // copy symbolic links as it is.
shelljs.cp('-rL', src, dst); // copy real files of symbolic link
```