### PR TITLE
pushd and popd no longer print output automatically.

### DIFF
--- a/src/dirs.js
+++ b/src/dirs.js
@@ -86,7 +86,7 @@ function _pushd(options, dir) {
   }
 
   _dirStack = dirs;
-  return _dirs('');
+  return _dirs('-q');
 }
 exports.pushd = _pushd;
 
@@ -137,7 +137,7 @@ function _popd(options, index) {
     _cd('', dir);
   }
 
-  return _dirs('');
+  return _dirs('-q');
 }
 exports.popd = _popd;
 
@@ -163,7 +163,8 @@ function _dirs(options, index) {
   }
 
   options = common.parseOptions(options, {
-    'c' : 'clear'
+    'c' : 'clear',
+    'q' : 'quiet'
   });
 
   if (options['clear']) {
@@ -184,7 +185,9 @@ function _dirs(options, index) {
     return stack[index];
   }
 
-  common.log(stack.join(' '));
+  if(!options.quiet) {
+    common.log(stack.join(' '));
+  }
 
   return stack;
 }


### PR DESCRIPTION
This is a little controversial since the shell itself _does_ print by default. But in my opinion it's just noise and if I really want to print out the dir stack I can just call dirs() so I don't really see why pushd / popd do it too.

In the shell I can pipe it to /dev/null but here in shelljs I cannot without resorting to exec('pushd ' + dir + ' > /dev/null') or something similar. I will do that if you reject this pull request but it would be nice if it was just better by default :smile: 

Optionally, if you would prefer I could add a silent option to pushd / popd and only pass -q on to _dirs if silent is passed. e.g. `pushd('-q')` and `popd('-q')`