### PR TITLE
If rename fails w/ EXDEV attempt cp & rm instead

### DIFF
--- a/src/mv.js
+++ b/src/mv.js
@@ -85,7 +85,8 @@ function _mv(options, sources, dest) {
       }
 
       // Can't rename across devices, but you can copy & then unlink!
-      cp((options.force ? "-f" : ""), src, thisDest);
+      // Copy is always recursive, since it's acting like move
+      cp((options.force ? "-rf" : "-r"), src, thisDest);
       rm((options.force ? "-f" : ""), src);
     }
   }); // forEach(src)

--- a/src/mv.js
+++ b/src/mv.js
@@ -85,8 +85,8 @@ function _mv(options, sources, dest) {
       }
 
       // Can't rename across devices, but you can copy & then unlink!
-      cp(options, src, thisDest);
-      rm(options, src);
+      cp((options.force ? "-f" : ""), src, thisDest);
+      rm((options.force ? "-f" : ""), src);
     }
   }); // forEach(src)
 } // mv


### PR DESCRIPTION
Fixes #1

Uses suggestions from https://github.com/joyent/node/issues/2703. Not sure how kosher it is to include other tasks directly like this, or to pass the options object through to them like this. Feel free to suggest alternatives! `mv`, `cp`, and `rm`, all share the `-f` option so it seemed safe.

Tests for `mv.js` still passing for me locally. A bunch of other tests are failing but I suspect that's because I am on windows.