### PR TITLE
global returns shell so we wont require twice

### DIFF
--- a/global.js
+++ b/global.js
@@ -1,3 +1,4 @@
 var shell = require('./shell.js');
 for (var cmd in shell)
   global[cmd] = shell[cmd];
+module.exports = shell;


### PR DESCRIPTION
The rationale behind this, is that if we want to use the names of the functions exported by shelljs, we would either have to do an ugly swap, or we would have to require shelljs twice.

I say just return the shell instance and use it if/when the time needs - I think that's what the user expects of the require.