### PR TITLE
ln: add possibility creating relative links

### DIFF
--- a/src/ln.js
+++ b/src/ln.js
@@ -29,10 +29,10 @@ function _ln(options, source, dest) {
     common.error('Missing <source> and/or <dest>');
   }
 
-  source = path.resolve(process.cwd(), String(source));
+  source = String(source);
   dest = path.resolve(process.cwd(), String(dest));
 
-  if (!fs.existsSync(source)) {
+  if (!fs.existsSync(path.resolve(process.cwd(), String(source)))) {
     common.error('Source file does not exist', true);
   }
 


### PR DESCRIPTION
hi,
in some cases relative links are prefer.
but now `ln.js` is not provide the feature.

my case: `ln('config/dev', 'config/current')` and root dir of the `config` dir may be move on fs.

so, absolute links are not broken, too. using:
`ln('/var/www', '/home/www')`

excuse my beginner's English