### PR TITLE
Add kill fn to shelljs to stop a child_process created by an async exec

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -103,6 +103,10 @@ exports.env = process.env;
 var _exec = require('./src/exec');
 exports.exec = common.wrap('exec', _exec, {notUnix:true});
 
+//@include ./src/kill
+var _kill = require('./src/kill');
+exports.kill = common.wrap('kill', _kill);
+
 //@include ./src/chmod
 var _chmod = require('./src/chmod');
 exports.chmod = common.wrap('chmod', _chmod);

--- a/src/kill.js
+++ b/src/kill.js
@@ -1,0 +1,42 @@
+/**
+ * Created by shuding on 9/25/15.
+ * <ds303077135@gmail.com>
+ */
+
+// Send the kill signal to child_process
+// Returns true if killed successfully
+function _kill(process, callback) {
+    if (!process || !process.constructor) {
+        return process;
+    }
+
+    // Trick to get constructor name
+    // See issue: https://github.com/nodejs/node/issues/1751
+    // There's no quick way to get the ChildProcess constructor to check the class of `process` object
+    var constructorName;
+    try {
+        constructorName = /function (.{1,})\(/.exec(process.constructor.toString())[1];
+    } catch (err) {
+        return process;
+    }
+    if (constructorName !== 'ChildProcess') {
+        return process;
+    }
+
+    if (process.killed || process.exitCode || process.signalCode) {
+        // Already stopped
+        return process;
+    }
+
+    if (!process.on || !process.kill) {
+        return process;
+    }
+
+    process.on('close', function () {
+        callback && callback(arguments);
+    });
+
+    return process.kill();
+}
+
+module.exports = _kill;


### PR DESCRIPTION
After executing some async commands, I "lost" them cause I cannot stop them later. So I add a ChildProcess `kill` wrapper function.

```javascript
var shell = require('shelljs');

// An async process
var nodeProcess = shell.exec('node', { async: true });

// ...do some things

// In event triggers or conditions
if (needToKillNode)
    shell.kill(nodeProcess, function (code, signal) {
        // The stop callback
        console.log('node process was killed successfully');
    });
```

