### PR TITLE
Fix `os.tmpdir` bug

### DIFF
--- a/src/tempdir.js
+++ b/src/tempdir.js
@@ -37,7 +37,8 @@ function _tempDir() {
   if (state.tempDir)
     return state.tempDir; // from cache
 
-  state.tempDir = writeableDir(os.tempDir && os.tempDir()) || // node 0.8+
+  state.tempDir = writeableDir(os.tmpdir && os.tmpdir()) || // node 0.10+
+                  writeableDir(os.tmpDir && os.tmpDir()) || // node 0.8+
                   writeableDir(process.env['TMPDIR']) ||
                   writeableDir(process.env['TEMP']) ||
                   writeableDir(process.env['TMP']) ||


### PR DESCRIPTION
The checked method on `os` module was `tempDir` which was not existing on any version of Node (should have been `tmpDir`). With Node 0.10, the name became `tmpdir`.