### PR TITLE
Add new CLI script for running commands

### DIFF
--- a/bin/shl
+++ b/bin/shl
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+var shell = require('../shell');
+
+if (process.argv.length < 3) {
+  console.log('ShellJS: missing argument (command name)');
+  console.log();
+  process.exit(1);
+}
+
+var command = process.argv[2];
+var args = process.argv.slice(3);
+
+var res = shell[command].apply(null, args);
+if (res) {
+  console.log(res);
+}
+if (shell.error()) {
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "node scripts/run-tests"
   },
   "bin": {
-    "shjs": "./bin/shjs"
+    "shjs": "./bin/shjs",
+    "shl": "./bin/shl"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
I've added a new CLI script called `shl` for running one-off commands as discussed in #202.
This is more a proposal and we can polish it some more before merging as I have the impression that a second CLI script will add some confusion.
To use the script you simple pass the command name as the first argument and any subsequent arguments will be passed to the command itself. Eg.:

`shl rm -rf some_dir`

We also need to figure out the best way to print the output of commands like `ls` which in this case returns an array.