### PR TITLE
Fix wildcard use in middle of filename

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -103,7 +103,7 @@ function expand(list) {
       _ls('-R', root).filter(function (e) {
         return restRegex.test(e);
       }).forEach(function(file) {
-        expanded.push(file);
+        expanded.push(root + file);
       });
     }
     // Wildcard present on file names ?


### PR DESCRIPTION
This is a fix for #245.