### PR TITLE
Use rechoir and interpret for scripts.

### DIFF
--- a/bin/shjs
+++ b/bin/shjs
@@ -32,24 +32,8 @@ for (var i = 0, l = args.length; i < l; i++) {
   }
 }
 
-if (scriptName.match(/\.coffee$/)) {
-  //
-  // CoffeeScript
-  //
-  if (which('coffee')) {
-    exec('coffee "' + scriptName + '" ' + args.join(' '), function(code) {
-      process.exit(code);
-    });
-  } else {
-    console.log('ShellJS: CoffeeScript interpreter not found');
-    console.log();
-    process.exit(1);
-  }
-} else {
-  //
-  // JavaScript
-  //
-  exec('node "' + scriptName + '" ' + args.join(' '), function(code) {
-    process.exit(code);
-  });
-}
+var path = require('path');
+var extensions = require('interpret').extensions;
+var rechoir = require('rechoir');
+rechoir.prepare(extensions, scriptName);
+require(require.resolve(path.join(process.cwd(), scriptName)));

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
   "bin": {
     "shjs": "./bin/shjs"
   },
-  "dependencies": {},
+  "dependencies": {
+    "interpret": "^1.0.0",
+    "rechoir": "^0.6.2"
+  },
   "devDependencies": {
     "coffee-script": "^1.10.0",
     "jshint": "~2.1.11"

--- a/test/shjs.js
+++ b/test/shjs.js
@@ -4,10 +4,9 @@ var assert = require('assert');
 
 function runScript(name) {
   // prefix with 'node ' for Windows, don't prefix for OSX/Linux
-  return shell.exec((process.platform === 'win32' ? 'node ' : '') +
-                    path.resolve(__dirname, '../bin/shjs') +
-                    ' ' +
-                    path.resolve(__dirname, 'resources', 'shjs', name), { silent: true });
+  var cmd = (process.platform === 'win32' ? 'node' : '') + path.resolve(__dirname, '../bin/shjs');
+  var script = path.join('resources', 'shjs', name);
+  return shell.exec(cmd + ' ' + script, { silent: true });
 }
 
 // Exit Codes


### PR DESCRIPTION
This adds support for babel, iced coffeescript, typescript, jsx (maybe somebody is generating HTML in a script, eh?), [etc](https://github.com/js-cli/js-interpret/blob/a62691b31731f0006e8e04cd06cfaf4c47afa722/index.js).

This can be modified to still execute out-of-process which may be desirable because of the `require('../global')` statement. Alternatively, we could require non-globally and leave everything in the `shjs` file.