### PR TITLE
issue #17: fix space in username on windows

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -44,7 +44,7 @@ function execSync(cmd, opts) {
   if (fs.existsSync(stdoutFile)) common.unlinkSync(stdoutFile);
   if (fs.existsSync(codeFile)) common.unlinkSync(codeFile);
 
-  var execCommand = '"'+process.execPath+'" '+scriptFile;
+  var execCommand = '"'+process.execPath+'" "'+scriptFile+'"';
   var execOptions = {
     env: process.env,
     cwd: _pwd(),


### PR DESCRIPTION
Avoiding this error:
```sh
$ npm test

> shelljs@0.5.3 test c:\Users\Arve Seljebu\Documents\GitHub\shelljs
> node scripts/run-tests

module.js:340
    throw err;
    ^

Error: Cannot find module 'c:\Users\Arve'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:289:25)
    at Function.Module.runMain (module.js:457:10)
    at startup (node.js:138:18)
    at node.js:974:3
 shell.js: internal error
Error: Command failed: "c:\Program Files\nodejs\node.exe" c:\Users\Arve Seljebu\AppData\Local\Temp\shelljs_94059e280f6ce03ce67b
    at checkExecSyncError (child_process.js:464:13)
    at Object.execSync (child_process.js:504:13)
    at execSync (c:\Users\Arve Seljebu\Documents\GitHub\shelljs\src\exec.js:81:11)
    at _exec (c:\Users\Arve Seljebu\Documents\GitHub\shelljs\src\exec.js:214:12)
    at c:\Users\Arve Seljebu\Documents\GitHub\shelljs\src\common.js:182:23
    at Object.<anonymous> (c:\Users\Arve Seljebu\Documents\GitHub\shelljs\scripts\run-tests.js:19:5)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
npm ERR! Test failed.  See above for more details.
```