### PR TITLE
shjs script will now exit with proper status code, fixing silent failures

### DIFF
--- a/bin/shjs
+++ b/bin/shjs
@@ -37,7 +37,9 @@ if (scriptName.match(/\.coffee$/)) {
   // CoffeeScript
   //
   if (which('coffee')) {
-    exec('coffee "' + scriptName + '" ' + args.join(' '), { async: true });
+    exec('coffee "' + scriptName + '" ' + args.join(' '), function(code) {
+      process.exit(code);
+    });
   } else {
     console.log('ShellJS: CoffeeScript interpreter not found');
     console.log();
@@ -47,5 +49,7 @@ if (scriptName.match(/\.coffee$/)) {
   //
   // JavaScript
   //
-  exec('node "' + scriptName + '" ' + args.join(' '), { async: true });
+  exec('node "' + scriptName + '" ' + args.join(' '), function(code) {
+    process.exit(code);
+  });
 }


### PR DESCRIPTION
This is a fix for #133. This is based off the fix in #168, but this is up to date, and changes less (doesn't affect `package.json` and doesn't fiddle with how coffeescript is found in the path).

I've tested this on my Ubuntu 15.10 system, and it behaves as expected. To test the behavior, try something such as:

```Bash
$ cat input.js
require('shelljs/global');
exit(123);
$ shjs input.js; echo $? # the current version outputs '0'
123
```

This demonstrates that `shjs` now respects the exit code produced by `node` when running the script, and returns it as expected.