### PR TITLE
Commands that have multiple errors now produce cleaner log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,24 +481,24 @@ Available options (all `false` by default):
 Examples:
 
 ```javascript
-var version = exec('node --version', {silent:true}).output;
+var version = exec('node --version', {silent:true}).stdout;
 
 var child = exec('some_long_running_process', {async:true});
 child.stdout.on('data', function(data) {
   /* ... do something with data ... */
 });
 
-exec('some_long_running_process', function(code, output, stderr) {
+exec('some_long_running_process', function(code, stdout, stderr) {
   console.log('Exit code:', code);
-  console.log('Program output:', output);
+  console.log('Program output:', stdout);
   console.log('Program stderr:', stderr);
 });
 ```
 
 Executes the given `command` _synchronously_, unless otherwise specified.  When in synchronous
-mode returns the object `{ code:..., output:... , stderr:... }`, containing the program's
-`output` (stdout), `stderr`, and its exit `code`. Otherwise returns the child process object,
-and the `callback` gets the arguments `(code, output, stderr)`.
+mode returns the object `{ code:..., stdout:... , stderr:... }`, containing the program's
+`stdout`, `stderr`, and its exit `code`. Otherwise returns the child process object,
+and the `callback` gets the arguments `(code, stdout, stderr)`.
 
 **Note:** For long-lived processes, it's best to run `exec()` asynchronously as
 the current synchronous implementation uses a lot of CPU. This should be getting

--- a/README.md
+++ b/README.md
@@ -488,16 +488,17 @@ child.stdout.on('data', function(data) {
   /* ... do something with data ... */
 });
 
-exec('some_long_running_process', function(code, output) {
+exec('some_long_running_process', function(code, output, stderr) {
   console.log('Exit code:', code);
   console.log('Program output:', output);
+  console.log('Program stderr:', stderr);
 });
 ```
 
-Executes the given `command` _synchronously_, unless otherwise specified.
-When in synchronous mode returns the object `{ code:..., output:... }`, containing the program's
-`output` (stdout + stderr)  and its exit `code`. Otherwise returns the child process object, and
-the `callback` gets the arguments `(code, output)`.
+Executes the given `command` _synchronously_, unless otherwise specified.  When in synchronous
+mode returns the object `{ code:..., output:... , stderr:... }`, containing the program's
+`output` (stdout), `stderr`, and its exit `code`. Otherwise returns the child process object,
+and the `callback` gets the arguments `(code, output, stderr)`.
 
 **Note:** For long-lived processes, it's best to run `exec()` asynchronously as
 the current synchronous implementation uses a lot of CPU. This should be getting

--- a/src/common.js
+++ b/src/common.js
@@ -21,7 +21,7 @@ exports.platform = platform;
 
 function log() {
   if (!config.silent)
-    console.log.apply(this, arguments);
+    console.error.apply(this, arguments);
 }
 exports.log = log;
 
@@ -29,10 +29,14 @@ exports.log = log;
 function error(msg, _continue) {
   if (state.error === null)
     state.error = '';
-  state.error += state.currentCmd + ': ' + msg + '\n';
+  var log_entry = state.currentCmd + ': ' + msg;
+  if (state.error === '')
+    state.error = log_entry;
+  else
+    state.error += '\n' + log_entry;
 
   if (msg.length > 0)
-    log(state.error);
+    log(log_entry);
 
   if (config.fatal)
     process.exit(1);

--- a/src/exec.js
+++ b/src/exec.js
@@ -142,7 +142,8 @@ function execSync(cmd, opts) {
   // True if successful, false if not
   var obj = {
     code: code,
-    output: stdout,
+    output: stdout, // deprecated
+    stdout: stdout,
     stderr: stderr
   };
   return obj;
@@ -150,7 +151,7 @@ function execSync(cmd, opts) {
 
 // Wrapper around exec() to enable echoing output to console in real time
 function execAsync(cmd, opts, callback) {
-  var output = '';
+  var stdout = '';
   var stderr = '';
 
   var options = common.extend({
@@ -159,11 +160,11 @@ function execAsync(cmd, opts, callback) {
 
   var c = child.exec(cmd, {env: process.env, maxBuffer: 20*1024*1024}, function(err) {
     if (callback)
-      callback(err ? err.code : 0, output, stderr);
+      callback(err ? err.code : 0, stdout, stderr);
   });
 
   c.stdout.on('data', function(data) {
-    output += data;
+    stdout += data;
     if (!options.silent)
       process.stdout.write(data);
   });
@@ -187,24 +188,24 @@ function execAsync(cmd, opts, callback) {
 //@ Examples:
 //@
 //@ ```javascript
-//@ var version = exec('node --version', {silent:true}).output;
+//@ var version = exec('node --version', {silent:true}).stdout;
 //@
 //@ var child = exec('some_long_running_process', {async:true});
 //@ child.stdout.on('data', function(data) {
 //@   /* ... do something with data ... */
 //@ });
 //@
-//@ exec('some_long_running_process', function(code, output, stderr) {
+//@ exec('some_long_running_process', function(code, stdout, stderr) {
 //@   console.log('Exit code:', code);
-//@   console.log('Program output:', output);
+//@   console.log('Program output:', stdout);
 //@   console.log('Program stderr:', stderr);
 //@ });
 //@ ```
 //@
 //@ Executes the given `command` _synchronously_, unless otherwise specified.  When in synchronous
-//@ mode returns the object `{ code:..., output:... , stderr:... }`, containing the program's
-//@ `output` (stdout), `stderr`, and its exit `code`. Otherwise returns the child process object,
-//@ and the `callback` gets the arguments `(code, output, stderr)`.
+//@ mode returns the object `{ code:..., stdout:... , stderr:... }`, containing the program's
+//@ `stdout`, `stderr`, and its exit `code`. Otherwise returns the child process object,
+//@ and the `callback` gets the arguments `(code, stdout, stderr)`.
 //@
 //@ **Note:** For long-lived processes, it's best to run `exec()` asynchronously as
 //@ the current synchronous implementation uses a lot of CPU. This should be getting

--- a/test/cp.js
+++ b/test/cp.js
@@ -1,13 +1,10 @@
 var shell = require('..');
 
 var assert = require('assert'),
-    fs = require('fs');
+    fs = require('fs'),
+    numLines = require('./utils/utils').numLines;
 
 shell.config.silent = true;
-
-function numLines(str) {
-  return typeof str === 'string' ? str.match(/\n/g).length : 0;
-}
 
 shell.rm('-rf', 'tmp');
 shell.mkdir('tmp');

--- a/test/exec.js
+++ b/test/exec.js
@@ -50,13 +50,15 @@ assert.ok(result.output === '1234\n' || result.output === '1234\nundefined\n'); 
 var result = shell.exec('node -e \"console.error(1234);\"');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.ok(result.output === '1234\n' || result.output === '1234\nundefined\n'); // 'undefined' for v0.4
+assert.ok(result.output === '' || result.output === 'undefined\n'); // 'undefined' for v0.4
+assert.ok(result.stderr === '1234\n' || result.stderr === '1234\nundefined\n'); // 'undefined' for v0.4
 
 // check if stdout + stderr go to output
 var result = shell.exec('node -e \"console.error(1234); console.log(666);\"');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.ok(result.output === '1234\n666\n' || result.output === '1234\n666\nundefined\n');  // 'undefined' for v0.4
+assert.ok(result.output === '666\n' || result.output === '666\nundefined\n');  // 'undefined' for v0.4
+assert.ok(result.stderr === '1234\n' || result.stderr === '1234\nundefined\n');  // 'undefined' for v0.4
 
 // check exit code
 var result = shell.exec('node -e \"process.exit(12);\"');

--- a/test/exec.js
+++ b/test/exec.js
@@ -44,20 +44,20 @@ process.exit = old_exit;
 var result = shell.exec('node -e \"console.log(1234);\"');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.ok(result.output === '1234\n' || result.output === '1234\nundefined\n'); // 'undefined' for v0.4
+assert.ok(result.stdout === '1234\n' || result.stdout === '1234\nundefined\n'); // 'undefined' for v0.4
 
 // check if stderr goes to output
 var result = shell.exec('node -e \"console.error(1234);\"');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.ok(result.output === '' || result.output === 'undefined\n'); // 'undefined' for v0.4
+assert.ok(result.stdout === '' || result.stdout === 'undefined\n'); // 'undefined' for v0.4
 assert.ok(result.stderr === '1234\n' || result.stderr === '1234\nundefined\n'); // 'undefined' for v0.4
 
 // check if stdout + stderr go to output
 var result = shell.exec('node -e \"console.error(1234); console.log(666);\"');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.ok(result.output === '666\n' || result.output === '666\nundefined\n');  // 'undefined' for v0.4
+assert.ok(result.stdout === '666\n' || result.stdout === '666\nundefined\n');  // 'undefined' for v0.4
 assert.ok(result.stderr === '1234\n' || result.stderr === '1234\nundefined\n');  // 'undefined' for v0.4
 
 // check exit code
@@ -70,14 +70,14 @@ shell.cd('resources/external');
 var result = shell.exec('node node_script.js');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(result.output, 'node_script_1234\n');
+assert.equal(result.stdout, 'node_script_1234\n');
 shell.cd('../..');
 
 // check quotes escaping
 var result = shell.exec( util.format('node -e "console.log(%s);"', "\\\"\\'+\\'_\\'+\\'\\\"") );
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(result.output, "'+'_'+'\n");
+assert.equal(result.stdout, "'+'_'+'\n");
 
 //
 // async
@@ -91,23 +91,26 @@ assert.ok('stdout' in c, 'async exec returns child process object');
 //
 // callback as 2nd argument
 //
-shell.exec('node -e \"console.log(5678);\"', function(code, output) {
+shell.exec('node -e \"console.log(5678);\"', function(code, stdout, stderr) {
   assert.equal(code, 0);
-  assert.ok(output === '5678\n' || output === '5678\nundefined\n');  // 'undefined' for v0.4
+  assert.ok(stdout === '5678\n' || stdout === '5678\nundefined\n');  // 'undefined' for v0.4
+  assert.ok(stderr === '' || stderr === 'undefined\n');  // 'undefined' for v0.4
 
   //
   // callback as 3rd argument
   //
-  shell.exec('node -e \"console.log(5566);\"', {async:true}, function(code, output) {
+  shell.exec('node -e \"console.log(5566);\"', {async:true}, function(code, stdout, stderr) {
     assert.equal(code, 0);
-    assert.ok(output === '5566\n' || output === '5566\nundefined\n');  // 'undefined' for v0.4
+    assert.ok(stdout === '5566\n' || stdout === '5566\nundefined\n');  // 'undefined' for v0.4
+    assert.ok(stderr === '' || stderr === 'undefined\n');  // 'undefined' for v0.4
 
     //
     // callback as 3rd argument (slient:true)
     //
-    shell.exec('node -e \"console.log(5678);\"', {silent:true}, function(code, output) {
+    shell.exec('node -e \"console.log(5678);\"', {silent:true}, function(code, stdout, stderr) {
       assert.equal(code, 0);
-      assert.ok(output === '5678\n' || output === '5678\nundefined\n');  // 'undefined' for v0.4
+      assert.ok(stdout === '5678\n' || stdout === '5678\nundefined\n');  // 'undefined' for v0.4
+      assert.ok(stderr === '' || stderr === 'undefined\n');  // 'undefined' for v0.4
 
       shell.exit(123);
 

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -1,13 +1,10 @@
 var shell = require('..');
 
 var assert = require('assert'),
-    fs = require('fs');
+    fs = require('fs'),
+    numLines = require('./utils/utils').numLines;
 
 shell.config.silent = true;
-
-function numLines(str) {
-  return typeof str === 'string' ? str.match(/\n/g).length : 0;
-}
 
 shell.rm('-rf', 'tmp');
 shell.mkdir('tmp');

--- a/test/mv.js
+++ b/test/mv.js
@@ -1,13 +1,10 @@
 var shell = require('..');
 
 var assert = require('assert'),
-    fs = require('fs');
+    fs = require('fs'),
+    numLines = require('./utils/utils').numLines;
 
 shell.config.silent = true;
-
-function numLines(str) {
-  return typeof str === 'string' ? str.match(/\n/g).length : 0;
-}
 
 shell.rm('-rf', 'tmp');
 shell.mkdir('tmp');

--- a/test/pushd.js
+++ b/test/pushd.js
@@ -183,7 +183,7 @@ assert.deepEqual(trail, [
 
 // Push invalid directory
 shell.pushd('does/not/exist');
-assert.equal(shell.error(), 'pushd: no such file or directory: ' + path.resolve('.', 'does/not/exist') + '\n');
+assert.equal(shell.error(), 'pushd: no such file or directory: ' + path.resolve('.', 'does/not/exist'));
 assert.equal(process.cwd(), trail[0]);
 
 // Push without arguments should swap top two directories when stack length is 2
@@ -219,6 +219,6 @@ assert.equal(process.cwd(), trail[0]);
 
 // Push without arguments invalid when stack is empty
 reset(); shell.pushd();
-assert.equal(shell.error(), 'pushd: no other directory\n');
+assert.equal(shell.error(), 'pushd: no other directory');
 
 shell.exit(123);

--- a/test/utils/utils.js
+++ b/test/utils/utils.js
@@ -1,0 +1,5 @@
+function _numLines(str) {
+  return typeof str === 'string' ? (str.match(/\n/g)||[]).length+1 : 0;
+}
+
+exports.numLines = _numLines;


### PR DESCRIPTION
This is a fix for #267. The new behavior can be seen to be as such:

```
$ # assume that fake1, fake2, and fake3 do not exist
$ cat test.js
require('shelljs/global');
ls('fake1', 'fake2', 'fake3');

$ shjs test.js
ls: no such file or directory: fake1
ls: no such file or directory: fake2
ls: no such file or directory: fake3
```

This is comparable to the Bash behavior:

```
$ ls fake1 fake2 fake3
ls: cannot access fake1: No such file or directory
ls: cannot access fake2: No such file or directory
ls: cannot access fake3: No such file or directory
```

Fixes #267, #209.