### PR TITLE
Implementing error codes and adding the errorCode() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,10 @@ Follows Python's [tempfile algorithm](http://docs.python.org/library/tempfile.ht
 Tests if error occurred in the last command. Returns `null` if no error occurred,
 otherwise returns string explaining the error
 
+### errorCode()
+Returns status code for the last command. Returns 0 upon success, otherwise
+returns a nonzero integer
+
 
 ## Configuration
 

--- a/shell.js
+++ b/shell.js
@@ -122,8 +122,10 @@ exports.tempdir = common.wrap('tempdir', _tempDir);
 
 
 //@include ./src/error
-var _error = require('./src/error');
+var _error = require('./src/error').error;
 exports.error = _error;
+var _errorCode = require('./src/error').errorCode;
+exports.errorCode = _errorCode;
 
 
 

--- a/src/common.js
+++ b/src/common.js
@@ -11,6 +11,7 @@ exports.config = config;
 
 var state = {
   error: null,
+  errorCode: 0,
   currentCmd: 'shell.js',
   previousDir: null,
   tempDir: null
@@ -26,8 +27,19 @@ function log() {
 }
 exports.log = log;
 
+var DEFAULT_ERROR_CODE = 1;
+
 // Shows error message. Throws unless _continue or config.fatal are true
-function error(msg, _continue) {
+function error(msg, _code, _continue) {
+  // Adjust values if `_continue` is passed in but `_code` isn't
+  if (typeof _code === 'boolean') {
+    _continue = _code;
+    _code = DEFAULT_ERROR_CODE;
+  }
+
+  if (typeof _code !== 'number')
+    _code = DEFAULT_ERROR_CODE;
+
   if (state.error === null)
     state.error = '';
   var log_entry = state.currentCmd + ': ' + msg;
@@ -36,11 +48,15 @@ function error(msg, _continue) {
   else
     state.error += '\n' + log_entry;
 
+  // Override previous return code, but prefer a previous non-default code if it exists
+  if (state.errorCode === 0 || _code !== DEFAULT_ERROR_CODE)
+    state.errorCode = _code;
+
   if (msg.length > 0)
     log(log_entry);
 
   if (config.fatal)
-    process.exit(1);
+    process.exit(state.errorCode);
 
   if (!_continue)
     throw '';
@@ -191,6 +207,7 @@ function wrap(cmd, fn, options) {
 
     state.currentCmd = cmd;
     state.error = null;
+    state.errorCode = 0;
 
     try {
       var args = [].slice.call(arguments, 0);

--- a/src/error.js
+++ b/src/error.js
@@ -4,7 +4,16 @@ var common = require('./common');
 //@ ### error()
 //@ Tests if error occurred in the last command. Returns `null` if no error occurred,
 //@ otherwise returns string explaining the error
-function error() {
+function _error() {
   return common.state.error;
 }
-module.exports = error;
+exports.error = _error;
+
+//@
+//@ ### errorCode()
+//@ Returns status code for the last command. Returns 0 upon success, otherwise
+//@ returns a nonzero integer
+function _errorCode() {
+  return common.state.errorCode;
+}
+exports.errorCode = _errorCode;

--- a/src/exec.js
+++ b/src/exec.js
@@ -137,9 +137,8 @@ function execSync(cmd, opts) {
   try { common.unlinkSync(codeFile); } catch(e) {}
   try { common.unlinkSync(sleepFile); } catch(e) {}
 
-  // some shell return codes are defined as errors, per http://tldp.org/LDP/abs/html/exitcodes.html
-  if (code === 1 || code === 2 || code >= 126)  {
-      common.error('', true); // unix/shell doesn't really give an error message after non-zero exit codes
+  if (code !== 0)  {
+    common.error('', code, true); // unix/shell doesn't really give an error message after non-zero exit codes
   }
   // True if successful, false if not
   var obj = {

--- a/src/grep.js
+++ b/src/grep.js
@@ -34,7 +34,7 @@ function _grep(options, regex, files) {
   var grep = '';
   files.forEach(function(file) {
     if (!fs.existsSync(file)) {
-      common.error('no such file or directory: ' + file, true);
+      common.error('no such file or directory: ' + file, 2, true);
       return;
     }
 

--- a/src/ls.js
+++ b/src/ls.js
@@ -122,7 +122,7 @@ function _ls(options, paths) {
       return;
     }
 
-    common.error('no such file or directory: ' + p, true);
+    common.error('no such file or directory: ' + p, 2, true);
   });
 
   return list;

--- a/test/errorCode.js
+++ b/test/errorCode.js
@@ -1,0 +1,31 @@
+var shell = require('..');
+
+var assert = require('assert'),
+    child = require('child_process');
+
+shell.config.silent = true;
+
+//
+// Valids
+//
+
+// Check that we correctly detect commands that fail
+shell.cat();
+assert.equal(shell.errorCode(), 1);
+
+var result = shell.exec('asdfasdf'); // could not find command
+assert.ok(result.code > 0);
+assert.equal(shell.errorCode(), result.code);
+
+// Check that we correctly detect commands that succeed
+shell.pwd(); // safe to assume this will succeed
+assert.equal(shell.errorCode(), 0);
+
+// Check that we return the error code of the last command
+var file = 'tmp/tempscript'+Math.random()+'.js',
+    script = 'require(\'../../global.js\'); config.silent=true; config.fatal=false; cp("this_file_doesnt_exist", "."); echo("this command will succeed");';
+script.to(file);
+child.exec('node '+file, function() {
+  assert.equal(shell.errorCode(), 0);
+  shell.exit(123);
+});

--- a/test/exec.js
+++ b/test/exec.js
@@ -27,7 +27,7 @@ process.exit = function (_exitcode) {
 shell.config.fatal = true;
 
 var result = shell.exec('asdfasdf'); // could not find command
-assert.equal(exitcode, 1);
+assert.ok(exitcode > 0);
 
 shell.config.fatal = old_fatal;
 process.exit = old_exit;
@@ -62,7 +62,7 @@ assert.ok(result.stderr === '1234\n' || result.stderr === '1234\nundefined\n'); 
 
 // check exit code
 var result = shell.exec('node -e \"process.exit(12);\"');
-assert.equal(shell.error(), null);
+assert.equal(shell.error(), 'exec: ');
 assert.equal(result.code, 12);
 
 // interaction with cd


### PR DESCRIPTION
 1. This implements error codes for the builtin commands. Each command will now have an associated error code (`common.status.code`). I changed many of the commands to return the code that the corresponding Linux command would return (ex. `ls('asdfasdf')` returns 2).

 2. **This fixes a bug with `exec()`** as well. Previously, you would see the following results:

 ```
 $ cat test.js
 require('shelljs/global');
 exec('exit 5'); // or any code besides 1, 2, or 126+
 if (error())
   echo('caught the error');
 else
   echo('this error slips by');

 $ shjs test.js
 this error slips by

 ```

 Any non-zero exit code means that `error()` will return a truthy value.

 3. If `config.fatal` is set, then the **process will exit with the last return code that was set, emulating Bash's behavior.**

 4. This adds the **`errorCode()` function to access the last error code**, which is somewhat of a substitute for Bash's `$?` variable. This is good if a command's output may vary, but its return codes can be relied upon to stay consistent (or if output is inconvenient to type). It can be used like so:

 ```Javascript
 require('shelljs/global');
 var assert = require('assert');
 ls('missing_file1');
 var str1 = error(),
     code1 = errorCode();
 ls('missing_file2');
 var str2 = error(),
     code2 = errorCode();
 assert.ok(str1 !== str2);
 assert.ok(code1 === code2);
 ```