### PR TITLE
Implementing cd('-') to behave like Bash's "cd -"

### DIFF
--- a/src/cd.js
+++ b/src/cd.js
@@ -8,12 +8,20 @@ function _cd(options, dir) {
   if (!dir)
     common.error('directory not specified');
 
+  if (dir === '-') {
+    if (!common.state.previousDir)
+      common.error('could not find previous directory');
+    else
+      dir = common.state.previousDir;
+  }
+
   if (!fs.existsSync(dir))
     common.error('no such file or directory: ' + dir);
 
   if (!fs.statSync(dir).isDirectory())
     common.error('not a directory: ' + dir);
 
+  common.state.previousDir = process.cwd();
   process.chdir(dir);
 }
 module.exports = _cd;

--- a/src/common.js
+++ b/src/common.js
@@ -12,6 +12,7 @@ exports.config = config;
 var state = {
   error: null,
   currentCmd: 'shell.js',
+  previousDir: null,
   tempDir: null
 };
 exports.state = state;
@@ -185,7 +186,7 @@ function wrap(cmd, fn, options) {
       if (options && options.notUnix) {
         retValue = fn.apply(this, args);
       } else {
-        if (args.length === 0 || typeof args[0] !== 'string' || args[0][0] !== '-')
+        if (args.length === 0 || typeof args[0] !== 'string' || args[0].length <= 1 || args[0][0] !== '-')
           args.unshift(''); // only add dummy option if '-option' not already present
         retValue = fn.apply(this, args);
       }

--- a/test/cd.js
+++ b/test/cd.js
@@ -27,6 +27,9 @@ assert.equal(fs.existsSync('resources/file1'), true); // sanity check
 shell.cd('resources/file1'); // file, not dir
 assert.ok(shell.error());
 
+shell.cd('-'); // Haven't changed yet, so there is no previous directory
+assert.ok(shell.error());
+
 //
 // Valids
 //
@@ -40,6 +43,12 @@ shell.cd(cur);
 shell.cd('/');
 assert.equal(shell.error(), null);
 assert.equal(process.cwd(), path.resolve('/'));
+
+shell.cd(cur);
+shell.cd('/');
+shell.cd('-');
+assert.equal(shell.error(), null);
+assert.equal(process.cwd(), path.resolve(cur));
 
 // cd + other commands
 


### PR DESCRIPTION
I added a `previousDir` field to `common.state` to allow the `cd()` function to have this option. I also added unit tests for this behavior.

Usage is as follows:

```Javascript
// Setup
mkdir('foo');
mkdir('bar');
cd('foo');
cd('../bar');
echo(pwd()); // outputs "/path/to/bar"
cd('-'); // jump back
echo(pwd()); // outputs "/path/to/foo"
cd('-'); // jump back again
echo(pwd()); // outputs "/path/to/bar"
```