### PR TITLE
shjs utility will also infer the extension of filenames ending in a '.'

### DIFF
--- a/bin/shjs
+++ b/bin/shjs
@@ -12,10 +12,14 @@ var args,
 env['NODE_PATH'] = __dirname + '/../..';
 
 if (!scriptName.match(/\.js/) && !scriptName.match(/\.coffee/)) {
-  if (test('-f', scriptName + '.js'))
-    scriptName += '.js';
-  if (test('-f', scriptName + '.coffee'))
-    scriptName += '.coffee';
+  var prefix = scriptName;
+  if (prefix[prefix.length-1] === '.')
+    prefix = prefix.slice(0, -1);
+
+  if (test('-f', prefix + '.js'))
+    scriptName = prefix + '.js';
+  else if (test('-f', prefix + '.coffee'))
+    scriptName = prefix + '.coffee';
 }
 
 if (!test('-f', scriptName)) {


### PR DESCRIPTION
`shjs` can now infer the file extension if the file ends in `.`. So the following code now works:

```Bash
$ cat input.js
require('shelljs/global');
echo('Hello world');

$ shjs input.js
Hello world

$ shjs input
Hello world

$ shjs input. # this was previously an error
Hello world
```

This is useful in the case of tab completion. If there's another file (say, `input.sh`), then tab completion will result in "`input.`". This is an often enough scenario that, if we're going to do file extension inference at all, we should probably do it here. Since inference is already supported, I see no reason to not support it in this scenario as well.

This fixes #278 