### PR TITLE
update `exec` docs to match implemented behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,8 @@ Object containing environment variables (both getter and setter). Shortcut to pr
 ### exec(command [, options] [, callback])
 Available options (all `false` by default):
 
-+ `async`: Asynchronous execution. Defaults to true if a callback is provided.
++ `async`: Asynchronous execution. If a callback is provided, it will be set to
+  `true`, regardless of the passed value.
 + `silent`: Do not echo program output to console.
 
 Examples:

--- a/src/exec.js
+++ b/src/exec.js
@@ -182,7 +182,8 @@ function execAsync(cmd, opts, callback) {
 //@ ### exec(command [, options] [, callback])
 //@ Available options (all `false` by default):
 //@
-//@ + `async`: Asynchronous execution. Defaults to true if a callback is provided.
+//@ + `async`: Asynchronous execution. If a callback is provided, it will be set to
+//@   `true`, regardless of the passed value.
 //@ + `silent`: Do not echo program output to console.
 //@
 //@ Examples:


### PR DESCRIPTION
Re-implementation of #185 (I didn't have the old fork anymore)

The [exec docs](http://documentup.com/arturadib/shelljs#command-reference/exec-command-options-callback) specify:
> **exec(command [, options] [, callback])**
> Available options (all false by default):
> `async`: Asynchronous execution. Defaults to true if a callback is provided.
> `silent`: Do not echo program output to console.

That seems to imply to me that the following code can be written:
```javascript
exec("sleep 0.5", {async: false}, function() {
    echo("print first");
});
echo("print last");
```
which prints:
```
print last
print first
```

After looking at the code, however, it is clear that `options.async` is overridden to `true` if a callback is provided. This PR updates the README to be more in line with the code. What do you think? 
