### PR TITLE
feat: add tilde expansion to expand()

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -53,6 +53,18 @@ function ShellString(str) {
 }
 exports.ShellString = ShellString;
 
+// Return the home directory in a platform-agnostic way, with consideration for
+// older versions of node
+function getUserHome() {
+  var result;
+  if (os.homedir)
+    result = os.homedir(); // node 3+
+  else
+    result = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
+  return result;
+}
+exports.getUserHome = getUserHome;
+
 // Returns {'alice': true, 'bob': false} when passed a dictionary, e.g.:
 //   parseOptions('-a', {'a':'alice', 'b':'bob'});
 function parseOptions(str, map) {
@@ -187,6 +199,14 @@ function wrap(cmd, fn, options) {
       } else {
         if (args.length === 0 || typeof args[0] !== 'string' || args[0][0] !== '-')
           args.unshift(''); // only add dummy option if '-option' not already present
+        // Expand the '~' if appropriate
+        var homeDir = getUserHome();
+        args = args.map(function(arg) {
+          if (typeof arg === 'string' && arg.slice(0, 2) === '~/' || arg === '~')
+            return arg.replace(/^~/, homeDir);
+          else
+            return arg;
+        });
         retValue = fn.apply(this, args);
       }
     } catch (e) {

--- a/test/cd.js
+++ b/test/cd.js
@@ -2,7 +2,8 @@ var shell = require('..');
 
 var assert = require('assert'),
     path = require('path'),
-    fs = require('fs');
+    fs = require('fs'),
+    common = require('../src/common');
 
 shell.config.silent = true;
 
@@ -53,5 +54,13 @@ assert.equal(shell.error(), null);
 shell.cd('../tmp');
 assert.equal(shell.error(), null);
 assert.equal(fs.existsSync('file1'), true);
+
+// Test tilde expansion
+
+shell.cd('~');
+assert.equal(process.cwd(), common.getUserHome());
+shell.cd('..');
+shell.cd('~'); // Change back to home
+assert.equal(process.cwd(), common.getUserHome());
 
 shell.exit(123);


### PR DESCRIPTION
This adds tilde expansion to the expand() function. Arguments starting with '~/'
will have the tilde expanded to the user's home directory, as with Bash.

Also, if an argument is simply `~`, then it will expand to the home directory as well.

```Javascript
> cd('~'); // Go to home directory
> ls('~/*.js'); // Look for all .js files
> cd('~/..'); // Go to /home, /Users, or C:\Users
```

This does not support all of Bash's tilde expansion (not sure if this would be difficult). For example:

```Bash
$ ls ~otheruser # look into otheruser's home folder
$ # Nothing like this is supported in ShellJS
```