### PR TITLE
fix: jshint works on Windows

### DIFF
--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* globals cd, echo, grep, sed */
 require('../global');
 
 echo('Appending docs to README.md');

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
+/* globals cd, echo, exec, exit, ls, pwd, test */
 require('../global');
-
-var path = require('path');
+var common = require('../src/common');
 
 var failed = false;
 
 //
 // Lint
 //
-JSHINT_BIN = './node_modules/jshint/bin/jshint';
+var JSHINT_BIN = 'node_modules/jshint/bin/jshint';
 cd(__dirname + '/..');
 
 if (!test('-f', JSHINT_BIN)) {
@@ -16,7 +16,12 @@ if (!test('-f', JSHINT_BIN)) {
   exit(1);
 }
 
-if (exec(JSHINT_BIN + ' *.js test/*.js').code !== 0) {
+var jsfiles = common.expand([pwd() + '/*.js',
+                             pwd() + '/scripts/*.js',
+                             // pwd() + '/src/*.js',
+                             pwd() + '/test/*.js'
+                            ]).join(' ');
+if (exec('node ' + pwd() + '/' + JSHINT_BIN + ' ' + jsfiles).code !== 0) {
   failed = true;
   echo('*** JSHINT FAILED! (return code != 0)');
   echo();

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -18,7 +18,7 @@ if (!test('-f', JSHINT_BIN)) {
 
 var jsfiles = common.expand([pwd() + '/*.js',
                              pwd() + '/scripts/*.js',
-                             // pwd() + '/src/*.js',
+                             pwd() + '/src/*.js',
                              pwd() + '/test/*.js'
                             ]).join(' ');
 if (exec('node ' + pwd() + '/' + JSHINT_BIN + ' ' + jsfiles).code !== 0) {

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -183,12 +183,12 @@ function _chmod(options, mode, filePattern) {
           }
 
           if (options.verbose) {
-            log(file + ' -> ' + newPerms.toString(8));
+            console.log(file + ' -> ' + newPerms.toString(8));
           }
 
           if (perms != newPerms) {
             if (!options.verbose && options.changes) {
-              log(file + ' -> ' + newPerms.toString(8));
+              console.log(file + ' -> ' + newPerms.toString(8));
             }
             fs.chmodSync(file, newPerms);
             perms = newPerms; // for the next round of changes!

--- a/src/error.js
+++ b/src/error.js
@@ -6,5 +6,5 @@ var common = require('./common');
 //@ otherwise returns string explaining the error
 function error() {
   return common.state.error;
-};
+}
 module.exports = error;

--- a/src/exec.js
+++ b/src/exec.js
@@ -64,8 +64,10 @@ function execSync(cmd, opts) {
     maxBuffer: 20*1024*1024
   };
 
+  var script;
+
   if (typeof child.execSync === 'function') {
-    var script = [
+    script = [
       "var child = require('child_process')",
       "  , fs = require('fs');",
       "var childProcess = child.exec('"+escape(cmd)+"', {env: process.env, maxBuffer: 20*1024*1024}, function(err) {",
@@ -97,7 +99,7 @@ function execSync(cmd, opts) {
   } else {
     cmd += ' > '+stdoutFile+' 2> '+stderrFile; // works on both win/unix
 
-    var script = [
+    script = [
       "var child = require('child_process')",
       "  , fs = require('fs');",
       "var childProcess = child.exec('"+escape(cmd)+"', {env: process.env, maxBuffer: 20*1024*1024}, function(err) {",

--- a/src/pwd.js
+++ b/src/pwd.js
@@ -4,7 +4,7 @@ var common = require('./common');
 //@
 //@ ### pwd()
 //@ Returns the current directory.
-function _pwd(options) {
+function _pwd() {
   var pwd = path.resolve(process.cwd());
   return common.ShellString(pwd);
 }

--- a/src/rm.js
+++ b/src/rm.js
@@ -53,7 +53,7 @@ function rmdirSyncRecursive(dir, force) {
     while (true) {
       try {
         result = fs.rmdirSync(dir);
-        if (fs.existsSync(dir)) throw { code: "EAGAIN" }
+        if (fs.existsSync(dir)) throw { code: "EAGAIN" };
         break;
       } catch(er) {
         // In addition to error codes, also check if the directory still exists and loop again if true

--- a/src/which.js
+++ b/src/which.js
@@ -14,7 +14,7 @@ function splitPath(p) {
 }
 
 function checkPath(path) {
-  return fs.existsSync(path) && fs.statSync(path).isDirectory() == false;
+  return fs.existsSync(path) && !fs.statSync(path).isDirectory();
 }
 
 //@


### PR DESCRIPTION
`run-tests.js` previously relied on shell wildcard expansion, and did not specify
full paths. This uses common.expand to handle globbing internally, and specifies
the full path, so jshint can find all the files.

This **does not** entirely fix `run-tests`, but this does fix the jshint portion, so we'll at least get it to process javascript files. A full fix would be much more intensive, since `exec()` can't start from the current working directory. So this is only a partial fix for #294.

Also, this adds in lint-checking the `scripts/` folder (and fixes the lint errors I found!). Now the only significant folder this skips is the `src/` folder (which I'm working on providing support for).