### PR TITLE
fix: regexes are more consistent with sed and grep

### DIFF
--- a/src/sed.js
+++ b/src/sed.js
@@ -28,13 +28,20 @@ function _sed(options, regex, replacement, file) {
   else
     common.error('invalid replacement string');
 
+  // Convert all search strings to RegExp
+  if (typeof regex === 'string')
+    regex = RegExp(regex);
+
   if (!file)
     common.error('no file given');
 
   if (!fs.existsSync(file))
     common.error('no such file or directory: ' + file);
 
-  var result = fs.readFileSync(file, 'utf8').replace(regex, replacement);
+  var result = fs.readFileSync(file, 'utf8').split('\n').map(function (line) {
+    return line.replace(regex, replacement);
+  }).join('\n');
+
   if (options.inplace)
     fs.writeFileSync(file, result, 'utf8');
 

--- a/test/grep.js
+++ b/test/grep.js
@@ -63,4 +63,24 @@ var result = shell.grep(/test/, '**/file*.js');
 assert.equal(shell.error(), null);
 assert.equal(result, 'test\ntest\ntest\ntest\n');
 
+// one file, * in regex
+var result = shell.grep(/alpha*beta/, 'resources/grep/file');
+assert.equal(shell.error(), null);
+assert.equal(result, 'alphaaaaaaabeta\nalphbeta\n');
+
+// one file, * in string-regex
+var result = shell.grep('alpha*beta', 'resources/grep/file');
+assert.equal(shell.error(), null);
+assert.equal(result, 'alphaaaaaaabeta\nalphbeta\n');
+
+// one file, * in regex, make sure * is not globbed
+var result = shell.grep(/l*\.js/, 'resources/grep/file');
+assert.equal(shell.error(), null);
+assert.equal(result, 'this line ends in.js\nlllllllllllllllll.js\n');
+
+// one file, * in string-regex, make sure * is not globbed
+var result = shell.grep('l*\\.js', 'resources/grep/file');
+assert.equal(shell.error(), null);
+assert.equal(result, 'this line ends in.js\nlllllllllllllllll.js\n');
+
 shell.exit(123);

--- a/test/resources/grep/file
+++ b/test/resources/grep/file
@@ -1,0 +1,5 @@
+alphaaaaaaabeta
+howareyou
+alphbeta
+this line ends in.js
+lllllllllllllllll.js

--- a/test/sed.js
+++ b/test/sed.js
@@ -43,7 +43,7 @@ assert.equal(shell.error(), null);
 assert.equal(result, '1234');
 
 var replaceFun = function (match) {
-	return match.toUpperCase() + match;
+  return match.toUpperCase() + match;
 };
 var result = shell.sed(/test1/, replaceFun, 'tmp/file1'); // replacement function
 assert.equal(shell.error(), null);
@@ -53,5 +53,25 @@ var result = shell.sed('-i', /test1/, 'hello', 'tmp/file1');
 assert.equal(shell.error(), null);
 assert.equal(result, 'hello');
 assert.equal(shell.cat('tmp/file1'), 'hello');
+
+// make sure * in regex is not globbed
+var result = shell.sed(/alpha*beta/, 'hello', 'resources/grep/file');
+assert.equal(shell.error(), null);
+assert.equal(result, 'hello\nhowareyou\nhello\nthis line ends in.js\nlllllllllllllllll.js\n');
+
+// make sure * in string-regex is not globbed
+var result = shell.sed('alpha*beta', 'hello', 'resources/grep/file');
+assert.ok(!shell.error());
+assert.equal(result, 'hello\nhowareyou\nhello\nthis line ends in.js\nlllllllllllllllll.js\n');
+
+// make sure * in regex is not globbed
+var result = shell.sed(/l*\.js/, '', 'resources/grep/file');
+assert.ok(!shell.error());
+assert.equal(result, 'alphaaaaaaabeta\nhowareyou\nalphbeta\nthis line ends in\n\n');
+
+// make sure * in string-regex is not globbed
+var result = shell.sed('l*\\.js', '', 'resources/grep/file');
+assert.ok(!shell.error());
+assert.equal(result, 'alphaaaaaaabeta\nhowareyou\nalphbeta\nthis line ends in\n\n');
 
 shell.exit(123);


### PR DESCRIPTION
`sed()` will now convert search strings to regex form, so `'a*'` will now work like `/a*/`. Also, new tests for grep and sed ensure that `*` is not expanded for filename globbing.

While the filename globbing isn't currently an issue, I anticipate that it could be a problem if we don't handle `sed()` and `grep()` carefully when doing filename globbing as part of the `wrap()` function (which I think is the way this project should go). These tests are an extra guard to make sure we don't make any mistakes.

So this should probably be merged before #275 to be safe.