### PR TITLE
feat(cd): cd() (no args) changes to home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ target.bundle = function(argsArray) {
 All commands run synchronously, unless otherwise stated.
 
 
-### cd('dir')
-Changes to directory `dir` for the duration of the script
+### cd([dir])
+Changes to directory `dir` for the duration of the script. Changes to home
+directory if no argument is supplied.
 
 
 ### pwd()

--- a/src/cd.js
+++ b/src/cd.js
@@ -2,11 +2,12 @@ var fs = require('fs');
 var common = require('./common');
 
 //@
-//@ ### cd('dir')
-//@ Changes to directory `dir` for the duration of the script
+//@ ### cd([dir])
+//@ Changes to directory `dir` for the duration of the script. Changes to home
+//@ directory if no argument is supplied.
 function _cd(options, dir) {
   if (!dir)
-    common.error('directory not specified');
+    dir = common.getUserHome();
 
   if (dir === '-') {
     if (!common.state.previousDir)

--- a/test/cd.js
+++ b/test/cd.js
@@ -17,9 +17,6 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-shell.cd();
-assert.ok(shell.error());
-
 assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
 shell.cd('/adsfasdf'); // dir does not exist
 assert.ok(shell.error());
@@ -70,6 +67,12 @@ shell.cd('~');
 assert.equal(process.cwd(), common.getUserHome());
 shell.cd('..');
 shell.cd('~'); // Change back to home
+assert.equal(process.cwd(), common.getUserHome());
+
+// Goes to home directory if no arguments are passed
+shell.cd(cur);
+shell.cd();
+assert.ok(!shell.error());
 assert.equal(process.cwd(), common.getUserHome());
 
 shell.exit(123);


### PR DESCRIPTION
`cd()` used to be a error. Now it changes to the home directory instead. This is to match unix behavior:

```Bash
$ pwd # prints whatever the cwd is
$ cd
$ pwd # prints the home directory path
```