### PR TITLE
chore(package): remove v0.8 from engines list

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "optionalDependencies": {},
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.10.0"
   }
 }


### PR DESCRIPTION
We don't really guarantee our stuff works on v0.8, since travis doesn't run on that version (this is because jshint requires v0.10+). So this just removes it from package.json. This doesn't prevent v0.8 users from using shelljs, just removes the promise of support.

See #307 for a discussion about this.