### PR TITLE
fix(gen-docs): fix issue where docs are generated wrong

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,5 @@ os:
   - osx
 script:
   - npm test
+  - node scripts/generate-docs.js
+  - git diff --quiet # make sure no files have changed

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/* globals cd, echo, grep, sed */
+/* globals cat, cd, echo, grep, sed */
 require('../global');
 
 echo('Appending docs to README.md');
@@ -16,7 +16,11 @@ docs = docs.replace(/\/\/\@include (.+)/g, function(match, path) {
 
 // Remove '//@'
 docs = docs.replace(/\/\/\@ ?/g, '');
-// Append docs to README
-sed('-i', /## Command reference(.|\n)*/, '## Command reference\n\n' + docs, 'README.md');
+
+// Wipe out the old docs
+cat('README.md').replace(/## Command reference(.|\n)*/, '## Command reference').to('README.md');
+
+// Append new docs to README
+sed('-i', /## Command reference/, '## Command reference\n\n' + docs, 'README.md');
 
 echo('All done.');


### PR DESCRIPTION
This fixes an issue (#309) where the gen-docs script's sed() command would improperly
update the docs.

As a bonus, Travis now checks that docs are generated properly (or, more specifically, that no files have been changed by running the tests and re-generating docs, which is exactly what we want). This prevents breaking changes in `sed()` from going unnoticed. This will also prevent people from modifying doc-comments in the source files without generating docs, or by modifying the README manually without changing comments.