### PR TITLE
Update cp documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ cp('-Rf', ['/tmp/*', '/usr/local/*'], '/home/tmp'); // same as above
 
 Copies files. The wildcard `*` is accepted.
 
+Unlike POSIX `cp`, files will not be overwritten by default. Use `-f` to overwrite files.
+
 
 ### rm([options,] file [, file ...])
 ### rm([options,] file_array)

--- a/src/cp.js
+++ b/src/cp.js
@@ -104,6 +104,8 @@ function cpdirSyncRecursive(sourceDir, destDir, opts) {
 //@ ```
 //@
 //@ Copies files. The wildcard `*` is accepted.
+//@
+//@ Unlike POSIX `cp`, files will not be overwritten by default. Use `-f` to overwrite files.
 function _cp(options, sources, dest) {
   options = common.parseOptions(options, {
     'f': 'force',


### PR DESCRIPTION
Updates cp documentation to mention that files are not overwritten by default (#210).