### PR TITLE
feat(set): add new set() command

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,21 @@ A FILE argument that does not exist is created empty, unless -c is supplied.
 This is a partial implementation of *[touch(1)](http://linux.die.net/man/1/touch)*.
 
 
+### set(options)
+Available options:
+
++ `+/-e`: exit upon error (`config.fatal`)
++ `+/-v`: verbose: show all commands (`config.verbose`)
+
+Examples:
+
+```javascript
+set('-e'); // exit upon first error
+set('+e'); // this undoes a "set('-e')"
+```
+
+Sets global configuration variables
+
 
 ## Non-Unix commands
 
@@ -606,10 +621,26 @@ Example:
 
 ```javascript
 require('shelljs/global');
-config.fatal = true;
+config.fatal = true; // or set('-e');
 cp('this_file_does_not_exist', '/dev/null'); // dies here
 /* more commands... */
 ```
 
 If `true` the script will die on errors. Default is `false`. This is
 analogous to Bash's `set -e`
+
+### config.verbose
+Example:
+
+```javascript
+config.verbose = true; // or set('-v');
+cd('dir/');
+ls('subdir/');
+```
+
+Will print each command as follows:
+
+```
+cd dir/
+ls subdir/
+```

--- a/shell.js
+++ b/shell.js
@@ -111,6 +111,10 @@ exports.chmod = common.wrap('chmod', _chmod);
 var _touch = require('./src/touch');
 exports.touch = common.wrap('touch', _touch);
 
+//@include ./src/set
+var _set = require('./src/set');
+exports.set = common.wrap('set', _set);
+
 
 //@
 //@ ## Non-Unix commands
@@ -154,10 +158,27 @@ exports.config = common.config;
 //@
 //@ ```javascript
 //@ require('shelljs/global');
-//@ config.fatal = true;
+//@ config.fatal = true; // or set('-e');
 //@ cp('this_file_does_not_exist', '/dev/null'); // dies here
 //@ /* more commands... */
 //@ ```
 //@
 //@ If `true` the script will die on errors. Default is `false`. This is
 //@ analogous to Bash's `set -e`
+
+//@
+//@ ### config.verbose
+//@ Example:
+//@
+//@ ```javascript
+//@ config.verbose = true; // or set('-v');
+//@ cd('dir/');
+//@ ls('subdir/');
+//@ ```
+//@
+//@ Will print each command as follows:
+//@
+//@ ```
+//@ cd dir/
+//@ ls subdir/
+//@ ```

--- a/src/common.js
+++ b/src/common.js
@@ -5,7 +5,8 @@ var _ls = require('./ls');
 // Module globals
 var config = {
   silent: false,
-  fatal: false
+  fatal: false,
+  verbose: false,
 };
 exports.config = config;
 
@@ -194,6 +195,12 @@ function wrap(cmd, fn, options) {
 
     try {
       var args = [].slice.call(arguments, 0);
+
+      if (config.verbose) {
+        args.unshift(cmd);
+        console.log.apply(console, args);
+        args.shift();
+      }
 
       if (options && options.notUnix) {
         retValue = fn.apply(this, args);

--- a/src/set.js
+++ b/src/set.js
@@ -1,0 +1,49 @@
+var common = require('./common');
+
+//@
+//@ ### set(options)
+//@ Available options:
+//@
+//@ + `+/-e`: exit upon error (`config.fatal`)
+//@ + `+/-v`: verbose: show all commands (`config.verbose`)
+//@
+//@ Examples:
+//@
+//@ ```javascript
+//@ set('-e'); // exit upon first error
+//@ set('+e'); // this undoes a "set('-e')"
+//@ ```
+//@
+//@ Sets global configuration variables
+function _set(options) {
+  if (!options) {
+    var args = [].slice.call(arguments, 0);
+    if (args.length < 2)
+      common.error('must provide an argument');
+    options = args[1];
+  }
+  var negate = (options[0] === '+');
+  if (negate) {
+    options = '-' + options.slice(1); // parseOptions needs a '-' prefix
+  }
+  options = common.parseOptions(options, {
+    'e': 'fatal',
+    'v': 'verbose'
+  });
+
+  var key;
+  if (negate) {
+    for (key in options)
+      options[key] = !options[key];
+  }
+
+  for (key in options) {
+    // Only change the global config if `negate` is false and the option is true
+    // or if `negate` is true and the option is false (aka negate !== option)
+    if (negate !== options[key]) {
+      common.config[key] = options[key];
+    }
+  }
+  return;
+}
+module.exports = _set;

--- a/src/touch.js
+++ b/src/touch.js
@@ -22,8 +22,6 @@ var fs = require('fs');
 //@ Update the access and modification times of each FILE to the current time.
 //@ A FILE argument that does not exist is created empty, unless -c is supplied.
 //@ This is a partial implementation of *[touch(1)](http://linux.die.net/man/1/touch)*.
-//@
-//
 function _touch(opts, files) {
   opts = common.parseOptions(opts, {
     'a': 'atime_only',

--- a/test/set.js
+++ b/test/set.js
@@ -1,0 +1,52 @@
+var shell = require('..');
+
+var assert = require('assert');
+
+var oldConfigSilent = shell.config.silent;
+shell.config.silent = true;
+
+shell.rm('-rf', 'tmp');
+shell.mkdir('tmp');
+
+//
+// Valids
+//
+
+// initial values
+assert.strictEqual(oldConfigSilent, false);
+assert.strictEqual(shell.config.verbose, false);
+assert.strictEqual(shell.config.fatal, false);
+
+// default behavior
+var result = shell.exec('node -e \"require(\'../global\'); ls(\'file_doesnt_exist\'); echo(1234);\"');
+assert.equal(result.code, 0);
+assert.equal(result.stdout, '1234\n');
+assert.equal(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');
+
+// set -e
+var result = shell.exec('node -e \"require(\'../global\'); set(\'-e\'); ls(\'file_doesnt_exist\'); echo(1234);\"');
+assert.equal(result.code, 1);
+assert.equal(result.stdout, '');
+assert.equal(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');
+
+// set -v
+var result = shell.exec('node -e \"require(\'../global\'); set(\'-v\'); ls(\'file_doesnt_exist\'); echo(1234);\"');
+assert.equal(result.code, 0);
+assert.equal(result.stdout, 'ls file_doesnt_exist\n1234\n');
+assert.equal(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');
+
+// set -ev
+var result = shell.exec('node -e \"require(\'../global\'); set(\'-ev\'); ls(\'file_doesnt_exist\'); echo(1234);\"');
+assert.equal(result.code, 1);
+assert.equal(result.stdout, 'ls file_doesnt_exist\n');
+assert.equal(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');
+
+// set -e, set +e
+var result = shell.exec('node -e \"require(\'../global\'); set(\'-e\'); set(\'+e\'); ls(\'file_doesnt_exist\'); echo(1234);\"');
+assert.equal(result.code, 0);
+assert.equal(result.stdout, '1234\n');
+assert.equal(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');
+
+shell.exit(123);
+
+


### PR DESCRIPTION
Add new set() command as a wrapper for `config` variables. This takes the `-e`, `-v`, `+e`, and `+v` flags.

This is based off (and replaces) #149, which introduced the `logCmd` option. This also adds `set()` as a nice wrapper for interfacing with the variables.

`config.verbose` will log each command in a unix-y kind of format. For example, `ls('dir/')` logs as `ls dir/` (strips parens, strips surrounding quotes). This is mostly just because it was easier to implement this way.

I left the docs for `config.fatal` (and added docs for `config.verbose`), although we might also consider deprecating those and encouraging the use of the equivalent `set()` commands instead (to trim down on documentation). One issue is that `config.silent` does not have an analogous [`set` option](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html).

This also fixes a formatting error in `touch.js`'s comment block.