### PR TITLE
feat(exec): allow all exec options to pass through

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,8 @@ Available options (all `false` by default):
 + `async`: Asynchronous execution. If a callback is provided, it will be set to
   `true`, regardless of the passed value.
 + `silent`: Do not echo program output to console.
++ and any option available to NodeJS's
+  [child_process.exec()](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
 
 Examples:
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -21,7 +21,10 @@ function execSync(cmd, opts) {
       sleepFile = path.resolve(tempDir+'/'+common.randomFileName());
 
   opts = common.extend({
-    silent: common.config.silent
+    silent: common.config.silent,
+    cwd: _pwd(),
+    env: process.env,
+    maxBuffer: DEFAULT_MAXBUFFER_SIZE
   }, opts);
 
   var previousStdoutContent = '',
@@ -60,9 +63,6 @@ function execSync(cmd, opts) {
   if (fs.existsSync(codeFile)) common.unlinkSync(codeFile);
 
   var execCommand = '"'+process.execPath+'" '+scriptFile;
-  opts.cwd = opts.cwd || _pwd();
-  opts.env = opts.env || process.env;
-  opts.maxBuffer = opts.maxBuffer || DEFAULT_MAXBUFFER_SIZE;
   var script;
 
   if (typeof child.execSync === 'function') {
@@ -155,13 +155,12 @@ function execAsync(cmd, opts, callback) {
   var stdout = '';
   var stderr = '';
 
-  var options = common.extend({
-    silent: common.config.silent
+  opts = common.extend({
+    silent: common.config.silent,
+    cwd: _pwd(),
+    env: process.env,
+    maxBuffer: DEFAULT_MAXBUFFER_SIZE
   }, opts);
-
-  opts.env = opts.env || process.env;
-  opts.cwd = opts.cwd || _pwd();
-  opts.maxBuffer = opts.maxBuffer || DEFAULT_MAXBUFFER_SIZE;
 
   var c = child.exec(cmd, opts, function(err) {
     if (callback)
@@ -170,13 +169,13 @@ function execAsync(cmd, opts, callback) {
 
   c.stdout.on('data', function(data) {
     stdout += data;
-    if (!options.silent)
+    if (!opts.silent)
       process.stdout.write(data);
   });
 
   c.stderr.on('data', function(data) {
     stderr += data;
-    if (!options.silent)
+    if (!opts.silent)
       process.stderr.write(data);
   });
 

--- a/test/resources/exec/slow.js
+++ b/test/resources/exec/slow.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// sleep for 5 seconds
+setTimeout(function() {
+    console.log('slow');
+}, 100);


### PR DESCRIPTION
This allows any option from https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback to be passed through our `shell.exec()` function to the native `exec()`/`execSync()`.

This fixes #250, #132 and replaces #270 #284 #333 #163 

This specifically tests the `cwd`, `maxBuffer`, and `timeout` options, since those were requested.