### PR TITLE
fix(cp): add -n option, make -f default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ include the base directories, e.g. `lib/resources/file1` instead of just `file1`
 ### cp([options,] source_array, dest)
 Available options:
 
-+ `-f`: force
++ `-f`: force (default behavior)
++ `-n`: no-clobber
 + `-r, -R`: recursive
 
 Examples:

--- a/src/cp.js
+++ b/src/cp.js
@@ -76,7 +76,7 @@ function cpdirSyncRecursive(sourceDir, destDir, opts) {
       fs.symlinkSync(symlinkFull, destFile, os.platform() === "win32" ? "junction" : null);
     } else {
       /* At this point, we've hit a file actually worth copying... so copy it on over. */
-      if (fs.existsSync(destFile) && !opts.force) {
+      if (fs.existsSync(destFile) && opts.no_force) {
         common.log('skipping existing file: ' + files[i]);
       } else {
         copyFileSync(srcFile, destFile);
@@ -92,7 +92,8 @@ function cpdirSyncRecursive(sourceDir, destDir, opts) {
 //@ ### cp([options,] source_array, dest)
 //@ Available options:
 //@
-//@ + `-f`: force
+//@ + `-f`: force (default behavior)
+//@ + `-n`: no-clobber
 //@ + `-r, -R`: recursive
 //@
 //@ Examples:
@@ -106,7 +107,8 @@ function cpdirSyncRecursive(sourceDir, destDir, opts) {
 //@ Copies files. The wildcard `*` is accepted.
 function _cp(options, sources, dest) {
   options = common.parseOptions(options, {
-    'f': 'force',
+    'f': '!no_force',
+    'n': 'no_force',
     'R': 'recursive',
     'r': 'recursive'
   });
@@ -133,7 +135,7 @@ function _cp(options, sources, dest) {
     common.error('dest is not a directory (too many sources)');
 
   // Dest is an existing file, but no -f given
-  if (exists && stats.isFile() && !options.force)
+  if (exists && stats.isFile() && options.no_force)
     common.error('dest file already exists: ' + dest);
 
   if (options.recursive) {
@@ -184,7 +186,7 @@ function _cp(options, sources, dest) {
           }
         }
 
-        cpdirSyncRecursive(src, newDest, {force: options.force});
+        cpdirSyncRecursive(src, newDest, {no_force: options.no_force});
       }
       return; // done with dir
     }
@@ -197,7 +199,7 @@ function _cp(options, sources, dest) {
     if (fs.existsSync(dest) && fs.statSync(dest).isDirectory())
       thisDest = path.normalize(dest + '/' + path.basename(src));
 
-    if (fs.existsSync(thisDest) && !options.force) {
+    if (fs.existsSync(thisDest) && options.no_force) {
       common.error('dest file already exists: ' + thisDest, true);
       return; // skip file
     }

--- a/test/cp.js
+++ b/test/cp.js
@@ -46,7 +46,7 @@ assert.equal(fs.existsSync('tmp/asdfasdf2'), false);
 shell.cp('asdfasdf1', 'asdfasdf2', 'resources/file1'); // too many sources (dest is file)
 assert.ok(shell.error());
 
-shell.cp('resources/file1', 'resources/file2'); // dest already exists
+shell.cp('-n', 'resources/file1', 'resources/file2'); // dest already exists
 assert.ok(shell.error());
 
 shell.cp('resources/file1', 'resources/file2', 'tmp/a_file'); // too many sources
@@ -56,6 +56,22 @@ assert.equal(fs.existsSync('tmp/a_file'), false);
 //
 // Valids
 //
+
+// -f by default
+shell.cp('resources/file2', 'resources/copyfile2');
+shell.cp('resources/file1', 'resources/file2'); // dest already exists
+assert.ok(!shell.error());
+assert.equal(shell.cat('resources/file1'), shell.cat('resources/file2')); // after cp
+shell.mv('resources/copyfile2', 'resources/file2'); // restore
+assert.ok(!shell.error());
+
+// -f (explicitly)
+shell.cp('resources/file2', 'resources/copyfile2');
+shell.cp('-f', 'resources/file1', 'resources/file2'); // dest already exists
+assert.ok(!shell.error());
+assert.equal(shell.cat('resources/file1'), shell.cat('resources/file2')); // after cp
+shell.mv('resources/copyfile2', 'resources/file2'); // restore
+assert.ok(!shell.error());
 
 // simple - to dir
 shell.cp('resources/file1', 'tmp');


### PR DESCRIPTION
Fix default behavior for `cp()` for bash compatibility. This replaces #325, and is done in a similar style to #328 