### PR TITLE
fix(touch): enhance parseOptions and fix touch's -r flag

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -35,7 +35,6 @@ function _touch(opts, files) {
     common.error('no paths given');
   }
 
-
   if (Array.isArray(files)) {
     files.forEach(function(f) {
       touchFile(opts, f);

--- a/test/common.js
+++ b/test/common.js
@@ -76,6 +76,16 @@ assert.ok(result.recursive === false);
 assert.ok(result.no_force === true);
 assert.ok(result.force === undefined); // this key shouldn't exist
 
+// common.parseOptions using an object to hold options
+var result = common.parseOptions({'-v': 'some text here'}, {
+  'v': 'value',
+  'f': 'force',
+  'r': 'reverse'
+});
+assert.ok(result.value === 'some text here');
+assert.ok(result.force === false);
+assert.ok(result.reverse === false);
+
 shell.exit(123);
 
 

--- a/test/exec.js
+++ b/test/exec.js
@@ -99,11 +99,11 @@ if (process.version >= 'v0.11') { // this option doesn't work on v0.10
 }
 
 // set timeout option
-result = shell.exec('node resources/exec/slow.js'); // default timeout is ok
+result = shell.exec('node resources/exec/slow.js 100'); // default timeout is ok
 assert.ok(!shell.error());
 assert.equal(result.code, 0);
 if (process.version >= 'v0.11') { // this option doesn't work on v0.10
-  result = shell.exec('node resources/exec/slow.js', {timeout: 10}); // times out
+  result = shell.exec('node resources/exec/slow.js 100', {timeout: 10}); // times out
   assert.ok(shell.error());
 }
 

--- a/test/resources/exec/slow.js
+++ b/test/resources/exec/slow.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-// sleep for 5 seconds
 setTimeout(function() {
     console.log('slow');
-}, 100);
+}, parseInt(process.argv[2], 10));

--- a/test/touch.js
+++ b/test/touch.js
@@ -1,4 +1,4 @@
-var shell = require('../shell.js');
+var shell = require('..');
 var assert = require('assert');
 var fs = require('fs');
 var crypto = require('crypto');
@@ -39,11 +39,16 @@ assert.ok(shell.error());
 // uses a reference file for mtime
 var testFile = tmpFile(false);
 var testFile2 = tmpFile();
-var testFile2Stat = resetUtimes(testFile2);
-
+shell.touch(testFile2);
+shell.exec('node resources/exec/slow.js 3000');
+shell.touch(testFile);
+assert.ok(!shell.error());
+assert.notEqual(fs.statSync(testFile).mtime.getTime(), fs.statSync(testFile2).mtime.getTime());
+assert.notEqual(fs.statSync(testFile).atime.getTime(), fs.statSync(testFile2).atime.getTime());
 shell.touch({'-r': testFile2}, testFile);
-var testFileStat = resetUtimes(testFile);
-assert.strictEqual(testFileStat.mtime.getTime(), testFile2Stat.mtime.getTime());
+assert.ok(!shell.error());
+assert.equal(fs.statSync(testFile).mtime.getTime(), fs.statSync(testFile2).mtime.getTime());
+assert.equal(fs.statSync(testFile).atime.getTime(), fs.statSync(testFile2).atime.getTime());
 
 // sets mtime
 var testFile = tmpFile();


### PR DESCRIPTION
This improves `parseOptions` to allow options of the form:

```
touch({'-r', 'path/to/file'}, 'other-file.txt');
```

to supply a value to an option. In this example, `-r` has the string value `'path/to/file'`.