### PR TITLE
feat(touch): supports multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,8 @@ Notable exceptions:
 + There is no "quiet" option since default behavior is to run silent.
 
 
-### touch([options,] file)
+### touch([options,] file [, file ...])
+### touch([options,] file_array)
 Available options:
 
 + `-a`: Change only the access time

--- a/src/touch.js
+++ b/src/touch.js
@@ -2,7 +2,8 @@ var common = require('./common');
 var fs = require('fs');
 
 //@
-//@ ### touch([options,] file)
+//@ ### touch([options,] file [, file ...])
+//@ ### touch([options,] file_array)
 //@ Available options:
 //@
 //@ + `-a`: Change only the access time
@@ -31,20 +32,16 @@ function _touch(opts, files) {
     'r': 'reference',
   });
 
-  if (!files) {
-    common.error('no paths given');
-  }
-
-  if (Array.isArray(files)) {
-    files.forEach(function(f) {
-      touchFile(opts, f);
-    });
-  } else if (typeof files === 'string') {
-    touchFile(opts, files);
-  } else {
+  if (!files)
+    common.error('no files given');
+  else if (typeof files === 'string')
+    files = [].slice.call(arguments, 1);
+  else
     common.error('file arg should be a string file path or an Array of string file paths');
-  }
 
+  files.forEach(function(f) {
+    touchFile(opts, f);
+  });
 }
 
 function touchFile(opts, file) {

--- a/test/touch.js
+++ b/test/touch.js
@@ -79,6 +79,22 @@ var oldStat = resetUtimes(testFile);
 shell.touch('-m', testFile);
 assert.equal(oldStat.atime.getTime(), fs.statSync(testFile).atime.getTime());
 
+// multiple files
+testFile = tmpFile(true);
+testFile2 = tmpFile(true);
+shell.rm('-f', testFile, testFile2);
+shell.touch(testFile, testFile2);
+assert(fs.existsSync(testFile));
+assert(fs.existsSync(testFile2));
+
+// file array
+testFile = tmpFile(true);
+testFile2 = tmpFile(true);
+shell.rm('-f', testFile, testFile2);
+shell.touch([testFile, testFile2]);
+assert(fs.existsSync(testFile));
+assert(fs.existsSync(testFile2));
+
 function resetUtimes(f) {
   var d = new Date();
   d.setYear(2000);


### PR DESCRIPTION
Does what it says. From the (updated) docs:

> touch([options,] file [, file ...])
> touch([options,] file_array)

This is consistent with the API for `ls()`, `cp()`, `mv()`, `rm()`, etc.