### PR TITLE
fix(exec): now actually supports shell option

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -65,11 +65,14 @@ function execSync(cmd, opts) {
   var execCommand = '"'+process.execPath+'" '+scriptFile;
   var script;
 
+  opts.cwd = path.resolve(opts.cwd);
+  var optString = JSON.stringify(opts);
+
   if (typeof child.execSync === 'function') {
     script = [
       "var child = require('child_process')",
       "  , fs = require('fs');",
-      "var childProcess = child.exec('"+escape(cmd)+"', {env: process.env, maxBuffer: "+opts.maxBuffer+"}, function(err) {",
+      "var childProcess = child.exec('"+escape(cmd)+"', "+optString+", function(err) {",
       "  fs.writeFileSync('"+escape(codeFile)+"', err ? err.code.toString() : '0');",
       "});",
       "var stdoutStream = fs.createWriteStream('"+escape(stdoutFile)+"');",
@@ -101,7 +104,7 @@ function execSync(cmd, opts) {
     script = [
       "var child = require('child_process')",
       "  , fs = require('fs');",
-      "var childProcess = child.exec('"+escape(cmd)+"', {env: process.env, maxBuffer: "+opts.maxBuffer+"}, function(err) {",
+      "var childProcess = child.exec('"+escape(cmd)+"', "+optString+", function(err) {",
       "  fs.writeFileSync('"+escape(codeFile)+"', err ? err.code.toString() : '0');",
       "});"
     ].join('\n');

--- a/test/exec.js
+++ b/test/exec.js
@@ -107,6 +107,31 @@ if (process.version >= 'v0.11') { // this option doesn't work on v0.10
   assert.ok(shell.error());
 }
 
+// check process.env works
+assert.ok(!shell.env.FOO);
+shell.env.FOO = 'Hello world';
+result = shell.exec(process.platform !== 'win32' ? 'echo $FOO' : 'echo %FOO%');
+assert.ok(!shell.error());
+assert.equal(result.code, 0);
+assert.equal(result.stdout, 'Hello world' + os.EOL);
+assert.equal(result.stderr, '');
+
+// set shell option (TODO: add tests for Windows)
+if (process.platform !== 'win32') {
+  result = shell.exec('echo $0');
+  assert.ok(!shell.error());
+  assert.equal(result.code, 0);
+  assert.equal(result.stdout, '/bin/sh\n'); // sh by default
+  var bashPath = shell.which('bash').trim();
+  // this option doesn't work on v0.10
+  if (bashPath && process.version >= 'v0.11') {
+    result = shell.exec('echo $0', {shell: '/bin/bash'});
+    assert.ok(!shell.error());
+    assert.equal(result.code, 0);
+    assert.equal(result.stdout, '/bin/bash\n');
+  }
+}
+
 //
 // async
 //


### PR DESCRIPTION
Looks like #335 doesn't work perfectly with all options. This is because `execSync` does 2 calls to `exec()`, and some options need to be passed to both calls.

This should clean things up a bit, and fix the issue for the `shell` option, which would actually fix #138 and #208.