### PR TITLE
feat(grep): add -l option

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ using the given search regex and replacement string or function. Returns the new
 Available options:
 
 + `-v`: Inverse the sense of the regex and print the lines not matching the criteria.
++ `-l`: Print only filenames of matching files
 
 Examples:
 

--- a/test/grep.js
+++ b/test/grep.js
@@ -83,4 +83,12 @@ var result = shell.grep('l*\\.js', 'resources/grep/file');
 assert.equal(shell.error(), null);
 assert.equal(result, 'this line ends in.js\nlllllllllllllllll.js\n');
 
+// -l option
+result = shell.grep('-l', 'test1', 'resources/file1', 'resources/file2', 'resources/file1.txt');
+assert.equal(shell.error(), null);
+assert.ok(result.match(/file1(\n|$)/));
+assert.ok(result.match(/file1.txt/));
+assert.ok(!result.match(/file2.txt/));
+assert.equal(result.split('\n').length - 1, 2);
+
 shell.exit(123);


### PR DESCRIPTION
`grep -l` will only print filenames of matching files.

Sort-of replaces #116. I can add `-s` support if we want to completely close that PR.