### PR TITLE
Consistently use LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Fixes cat, ls, and sed tests on Windows when Git line ending configuration is set to auto.