### PR TITLE
config.fatal now throws an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,12 +635,13 @@ Example:
 ```javascript
 require('shelljs/global');
 config.fatal = true; // or set('-e');
-cp('this_file_does_not_exist', '/dev/null'); // dies here
+cp('this_file_does_not_exist', '/dev/null'); // throws Error here
 /* more commands... */
 ```
 
-If `true` the script will die on errors. Default is `false`. This is
-analogous to Bash's `set -e`
+If `true` the script will throw a Javascript error when any shell.js
+command encounters an error. Default is `false`. This is analogous to
+Bash's `set -e`
 
 ### config.verbose
 Example:

--- a/shell.js
+++ b/shell.js
@@ -159,12 +159,13 @@ exports.config = common.config;
 //@ ```javascript
 //@ require('shelljs/global');
 //@ config.fatal = true; // or set('-e');
-//@ cp('this_file_does_not_exist', '/dev/null'); // dies here
+//@ cp('this_file_does_not_exist', '/dev/null'); // throws Error here
 //@ /* more commands... */
 //@ ```
 //@
-//@ If `true` the script will die on errors. Default is `false`. This is
-//@ analogous to Bash's `set -e`
+//@ If `true` the script will throw a Javascript error when any shell.js
+//@ command encounters an error. Default is `false`. This is analogous to
+//@ Bash's `set -e`
 
 //@
 //@ ### config.verbose

--- a/src/common.js
+++ b/src/common.js
@@ -37,14 +37,11 @@ function error(msg, _continue) {
   else
     state.error += '\n' + log_entry;
 
+  if(!_continue || config.fatal)
+    throw new Error(log_entry);
+
   if (msg.length > 0)
     log(log_entry);
-
-  if (config.fatal)
-    process.exit(1);
-
-  if (!_continue)
-    throw '';
 }
 exports.error = error;
 

--- a/test/exec.js
+++ b/test/exec.js
@@ -19,20 +19,14 @@ assert.ok(result.code > 0);
 
 // Test 'fatal' mode for exec, temporarily overriding process.exit
 var old_fatal = shell.config.fatal;
-var old_exit = process.exit;
-
-var exitcode = 9999;
-process.exit = function (_exitcode) {
-    exitcode = _exitcode;
-};
 
 shell.config.fatal = true;
 
-var result = shell.exec('asdfasdf'); // could not find command
-assert.equal(exitcode, 1);
+assert.throws(function() {
+  shell.exec('asdfasdf'); // could not find command
+}, /exec: internal error/);
 
 shell.config.fatal = old_fatal;
-process.exit = old_exit;
 
 //
 // Valids

--- a/test/set.js
+++ b/test/set.js
@@ -25,9 +25,11 @@ assert.equal(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n'
 
 // set -e
 var result = shell.exec('node -e \"require(\'../global\'); set(\'-e\'); ls(\'file_doesnt_exist\'); echo(1234);\"');
-assert.equal(result.code, 1);
+var nodeVersion = process.versions.node.split('.').map(function(str) { return parseInt(str, 10); });
+var uncaughtErrorExitCode = (nodeVersion[0] === 0 && nodeVersion[1] < 11) ? 8 : 1;
+assert.equal(result.code, uncaughtErrorExitCode);
 assert.equal(result.stdout, '');
-assert.equal(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');
+assert(result.stderr.indexOf('Error: ls: no such file or directory: file_doesnt_exist') >= 0);
 
 // set -v
 var result = shell.exec('node -e \"require(\'../global\'); set(\'-v\'); ls(\'file_doesnt_exist\'); echo(1234);\"');
@@ -37,9 +39,9 @@ assert.equal(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n'
 
 // set -ev
 var result = shell.exec('node -e \"require(\'../global\'); set(\'-ev\'); ls(\'file_doesnt_exist\'); echo(1234);\"');
-assert.equal(result.code, 1);
+assert.equal(result.code, uncaughtErrorExitCode);
 assert.equal(result.stdout, 'ls file_doesnt_exist\n');
-assert.equal(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');
+assert(result.stderr.indexOf('Error: ls: no such file or directory: file_doesnt_exist') >= 0);
 
 // set -e, set +e
 var result = shell.exec('node -e \"require(\'../global\'); set(\'-e\'); set(\'+e\'); ls(\'file_doesnt_exist\'); echo(1234);\"');


### PR DESCRIPTION
Hi everyone!

This PR adds a 'config.throw' option to throw errors from shell commands. Config.fatal is useful, but it doesn't log stack traces, which makes deep errors hard to find. This 'throw' option is useful in synchronous scripts where you have try / catch handling, or you want the default behavior of printing a full stack trace and exiting.

Thanks!!