### PR TITLE
feat(set): add -f option to disable globbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ Available options:
 
 + `+/-e`: exit upon error (`config.fatal`)
 + `+/-v`: verbose: show all commands (`config.verbose`)
++ `+/-f`: disable filename expansion (globbing)
 
 Examples:
 

--- a/src/common.js
+++ b/src/common.js
@@ -7,6 +7,7 @@ var config = {
   silent: false,
   fatal: false,
   verbose: false,
+  noglob: false
 };
 exports.config = config;
 
@@ -258,7 +259,7 @@ function wrap(cmd, fn, options) {
           else
             return arg;
         });
-        if (options && typeof options.idx === 'number')
+        if (!config.noglob && options && typeof options.idx === 'number')
           args = args.slice(0, options.idx).concat(expand(args.slice(options.idx)));
         retValue = fn.apply(this, args);
       }

--- a/src/set.js
+++ b/src/set.js
@@ -6,6 +6,7 @@ var common = require('./common');
 //@
 //@ + `+/-e`: exit upon error (`config.fatal`)
 //@ + `+/-v`: verbose: show all commands (`config.verbose`)
+//@ + `+/-f`: disable filename expansion (globbing)
 //@
 //@ Examples:
 //@
@@ -28,7 +29,8 @@ function _set(options) {
   }
   options = common.parseOptions(options, {
     'e': 'fatal',
-    'v': 'verbose'
+    'v': 'verbose',
+    'f': 'noglob'
   });
 
   var key;

--- a/test/set.js
+++ b/test/set.js
@@ -16,6 +16,9 @@ shell.mkdir('tmp');
 assert.strictEqual(oldConfigSilent, false);
 assert.strictEqual(shell.config.verbose, false);
 assert.strictEqual(shell.config.fatal, false);
+assert.strictEqual(shell.config.noglob, false);
+
+shell.cp('-R', 'resources/', 'tmp');
 
 // default behavior
 var result = shell.exec('node -e \"require(\'../global\'); ls(\'file_doesnt_exist\'); echo(1234);\"');
@@ -46,6 +49,14 @@ var result = shell.exec('node -e \"require(\'../global\'); set(\'-e\'); set(\'+e
 assert.equal(result.code, 0);
 assert.equal(result.stdout, '1234\n');
 assert.equal(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');
+
+// set -f
+shell.set('-f'); // disable globbing
+shell.rm('tmp/*.txt');
+assert.ok(shell.error()); // file '*.txt' doesn't exist, so rm() fails
+shell.set('+f');
+shell.rm('tmp/*.txt');
+assert.ok(!shell.error()); // globbing works, so rm succeeds
 
 shell.exit(123);
 


### PR DESCRIPTION
See the docs for `set('-f')`. This is analogous to Bash's functionality.

It's a nice option to have safer code for the bulk of the utilities (this doesn't affect `exec()` *yet* but this will disable globbing for that too once that's an option)

Fixes #344 