### PR TITLE
feat(glob): use glob module for globbing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   "bin": {
     "shjs": "./bin/shjs"
   },
-  "dependencies": {},
+  "dependencies": {
+    "glob": "^7.0.0"
+  },
   "devDependencies": {
     "coffee-script": "^1.10.0",
     "jshint": "~2.1.11"

--- a/src/cp.js
+++ b/src/cp.js
@@ -159,7 +159,7 @@ function _cp(options, sources, dest) {
     }
   }
 
-  sources = common.expand(sources);
+  sources = common.expand(sources, {dot: true});
 
   sources.forEach(function(src) {
     if (!fs.existsSync(src)) {

--- a/src/grep.js
+++ b/src/grep.js
@@ -29,9 +29,6 @@ function _grep(options, regex, files) {
 
   if (typeof files === 'string')
     files = [].slice.call(arguments, 2);
-  // if it's array leave it as it is
-
-  files = common.expand(files);
 
   var grep = [];
   files.forEach(function(file) {

--- a/test/cp.js
+++ b/test/cp.js
@@ -166,4 +166,10 @@ if (common.platform !== 'win') {
     assert.equal(fs.statSync('resources/cp-mode-bits/executable').mode, fs.statSync('tmp/executable').mode);
 }
 
+// Make sure hidden files are copied recursively
+shell.rm('-rf', 'tmp/');
+shell.cp('-r', 'resources/ls/', 'tmp/');
+assert.ok(!shell.error());
+assert.ok(fs.existsSync('tmp/.hidden_file'));
+
 shell.exit(123);


### PR DESCRIPTION
Switch to the glob module to do shell globbing. Fixes a bug in `cp()` where
hidden files were not copied recursively.

Replaces #275, fixes #225. This is a less-aggressive version of #275 (doesn't modify `ls()` nearly as much). We should probably add some more glob-related tests though, like `file?.txt` and things of that sort.

I wrote this up because this will fix one of the bugs I found when writing the `ShellString` refactor for free.

For what it's worth, this does hurt performance slightly (it takes 16 seconds on average to run `npm test` instead of 15 seconds), but not by very much. We might be able to get that performance back some other way.

Closes #275, #225.