### PR TITLE
Refactor shellstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,8 +331,9 @@ Examples:
 cat('input.txt').to('output.txt');
 ```
 
-Analogous to the redirection operator `>` in Unix, but works with JavaScript strings (such as
-those returned by `cat`, `grep`, etc). _Like Unix redirections, `to()` will overwrite any existing file!_
+Analogous to the redirection operator `>` in Unix, but works with
+ShellStrings (such as those returned by `cat`, `grep`, etc). _Like Unix
+redirections, `to()` will overwrite any existing file!_
 
 
 ### 'string'.toEnd(file)
@@ -343,8 +344,8 @@ Examples:
 cat('input.txt').toEnd('output.txt');
 ```
 
-Analogous to the redirect-and-append operator `>>` in Unix, but works with JavaScript strings (such as
-those returned by `cat`, `grep`, etc).
+Analogous to the redirect-and-append operator `>>` in Unix, but works with
+ShellStrings (such as those returned by `cat`, `grep`, etc).
 
 
 ### sed([options,] search_regex, replacement, file [, file ...])
@@ -612,6 +613,18 @@ Follows Python's [tempfile algorithm](http://docs.python.org/library/tempfile.ht
 ### error()
 Tests if error occurred in the last command. Returns `null` if no error occurred,
 otherwise returns string explaining the error
+
+
+### ShellString(str)
+
+Examples:
+
+```
+var foo = ShellString('hello world');
+```
+
+Turns a regular string into a string-like object similar to what each
+command returns. This has special methods, like `.to()` and `.toEnd()`
 
 
 ## Configuration

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/* globals cat, cd, echo, grep, sed */
+/* globals cat, cd, echo, grep, sed, ShellString */
 require('../global');
 
 echo('Appending docs to README.md');
@@ -18,7 +18,7 @@ docs = docs.replace(/\/\/\@include (.+)/g, function(match, path) {
 docs = docs.replace(/\/\/\@ ?/g, '');
 
 // Wipe out the old docs
-cat('README.md').replace(/## Command reference(.|\n)*/, '## Command reference').to('README.md');
+ShellString(cat('README.md').replace(/## Command reference(.|\n)*/, '## Command reference')).to('README.md');
 
 // Append new docs to README
 sed('-i', /## Command reference/, '## Command reference\n\n' + docs, 'README.md');

--- a/shell.js
+++ b/shell.js
@@ -53,13 +53,10 @@ exports.test = common.wrap('test', _test);
 var _cat = require('./src/cat');
 exports.cat = common.wrap('cat', _cat, {idx: 1});
 
+// The below commands have been moved to common.ShellString(), and are only here
+// for generating the docs
 //@include ./src/to
-var _to = require('./src/to');
-String.prototype.to = common.wrap('to', _to, {idx: 1});
-
 //@include ./src/toEnd
-var _toEnd = require('./src/toEnd');
-String.prototype.toEnd = common.wrap('toEnd', _toEnd, {idx: 1});
 
 //@include ./src/sed
 var _sed = require('./src/sed');
@@ -124,11 +121,12 @@ exports.set = common.wrap('set', _set);
 var _tempDir = require('./src/tempdir');
 exports.tempdir = common.wrap('tempdir', _tempDir);
 
-
 //@include ./src/error
 var _error = require('./src/error');
 exports.error = _error;
 
+//@include ./src/common
+exports.ShellString = common.ShellString;
 
 
 //@

--- a/src/cat.js
+++ b/src/cat.js
@@ -33,6 +33,6 @@ function _cat(options, files) {
     cat += fs.readFileSync(file, 'utf8');
   });
 
-  return common.ShellString(cat);
+  return new common.ShellString(cat, common.state.error);
 }
 module.exports = _cat;

--- a/src/echo.js
+++ b/src/echo.js
@@ -16,6 +16,6 @@ function _echo(opts, messages) {
   // allow strings starting with '-', see issue #20
   messages = [].slice.call(arguments, opts ? 0 : 1);
   console.log.apply(console, messages);
-  return common.ShellString(messages.join(' '));
+  return new common.ShellString(messages.join(' '));
 }
 module.exports = _echo;

--- a/src/exec.js
+++ b/src/exec.js
@@ -22,7 +22,7 @@ function execSync(cmd, opts) {
 
   opts = common.extend({
     silent: common.config.silent,
-    cwd: _pwd(),
+    cwd: _pwd().toString(),
     env: process.env,
     maxBuffer: DEFAULT_MAXBUFFER_SIZE
   }, opts);
@@ -151,13 +151,10 @@ function execSync(cmd, opts) {
   if (code !== 0)  {
     common.error('', true);
   }
-  // True if successful, false if not
-  var obj = {
-    code: code,
-    output: stdout, // deprecated
-    stdout: stdout,
-    stderr: stderr
-  };
+  var obj = common.ShellString(stdout, stderr);
+  // obj.stdout = stdout;
+  // obj.stderr = stderr;
+  obj.code = code;
   return obj;
 } // execSync()
 
@@ -168,7 +165,7 @@ function execAsync(cmd, opts, callback) {
 
   opts = common.extend({
     silent: common.config.silent,
-    cwd: _pwd(),
+    cwd: _pwd().toString(),
     env: process.env,
     maxBuffer: DEFAULT_MAXBUFFER_SIZE
   }, opts);

--- a/src/grep.js
+++ b/src/grep.js
@@ -51,6 +51,6 @@ function _grep(options, regex, files) {
     }
   });
 
-  return common.ShellString(grep.join('\n')+'\n');
+  return new common.ShellString(grep.join('\n')+'\n', common.state.error);
 }
 module.exports = _grep;

--- a/src/ls.js
+++ b/src/ls.js
@@ -3,6 +3,8 @@ var fs = require('fs');
 var common = require('./common');
 var _cd = require('./cd');
 var _pwd = require('./pwd');
+var _to = require('./to');
+var _toEnd = require('./toEnd');
 
 //@
 //@ ### ls([options,] [path, ...])
@@ -151,6 +153,15 @@ function _ls(options, paths) {
     common.error('no such file or directory: ' + p, true);
   });
 
+  // Add methods, to make this more compatible with ShellStrings
+  list.stdout = list.join('\n') + '\n';
+  list.stderr = common.state.error;
+  list.to = function (file) {
+    common.wrap('to', _to, {idx: 1}).call(this.stdout, file);
+  };
+  list.toEnd = function(file) {
+    common.wrap('toEnd', _toEnd, {idx: 1}).call(this.stdout, file);
+  };
   return list;
 }
 module.exports = _ls;

--- a/src/ls.js
+++ b/src/ls.js
@@ -104,7 +104,7 @@ function _ls(options, paths) {
 
           // Recursive?
           if (options.recursive) {
-            var oldDir = _pwd();
+            var oldDir = _pwd().toString();
             _cd('', p);
             if (fs.statSync(orig_file).isDirectory())
               list = list.concat(_ls('-R'+(options.all?'A':''), orig_file+'/*'));

--- a/src/pwd.js
+++ b/src/pwd.js
@@ -6,6 +6,6 @@ var common = require('./common');
 //@ Returns the current directory.
 function _pwd() {
   var pwd = path.resolve(process.cwd());
-  return common.ShellString(pwd);
+  return new common.ShellString(pwd);
 }
 module.exports = _pwd;

--- a/src/sed.js
+++ b/src/sed.js
@@ -57,6 +57,6 @@ function _sed(options, regex, replacement, files) {
       fs.writeFileSync(file, result, 'utf8');
   });
 
-  return common.ShellString(sed.join('\n'));
+  return new common.ShellString(sed.join('\n'), common.state.error);
 }
 module.exports = _sed;

--- a/src/to.js
+++ b/src/to.js
@@ -11,8 +11,9 @@ var path = require('path');
 //@ cat('input.txt').to('output.txt');
 //@ ```
 //@
-//@ Analogous to the redirection operator `>` in Unix, but works with JavaScript strings (such as
-//@ those returned by `cat`, `grep`, etc). _Like Unix redirections, `to()` will overwrite any existing file!_
+//@ Analogous to the redirection operator `>` in Unix, but works with
+//@ ShellStrings (such as those returned by `cat`, `grep`, etc). _Like Unix
+//@ redirections, `to()` will overwrite any existing file!_
 function _to(options, file) {
   if (!file)
     common.error('wrong arguments');

--- a/src/toEnd.js
+++ b/src/toEnd.js
@@ -11,8 +11,8 @@ var path = require('path');
 //@ cat('input.txt').toEnd('output.txt');
 //@ ```
 //@
-//@ Analogous to the redirect-and-append operator `>>` in Unix, but works with JavaScript strings (such as
-//@ those returned by `cat`, `grep`, etc).
+//@ Analogous to the redirect-and-append operator `>>` in Unix, but works with
+//@ ShellStrings (such as those returned by `cat`, `grep`, etc).
 function _toEnd(options, file) {
   if (!file)
     common.error('wrong arguments');

--- a/src/which.js
+++ b/src/which.js
@@ -93,6 +93,6 @@ function _which(options, cmd) {
 
   where = where || path.resolve(cmd);
 
-  return common.ShellString(where);
+  return new common.ShellString(where);
 }
 module.exports = _which;

--- a/test/cd.js
+++ b/test/cd.js
@@ -46,7 +46,7 @@ shell.cd(cur);
 shell.cd('/');
 shell.cd('-');
 assert.equal(shell.error(), null);
-assert.equal(process.cwd(), path.resolve(cur));
+assert.equal(process.cwd(), path.resolve(cur.toString()));
 
 // cd + other commands
 

--- a/test/common.js
+++ b/test/common.js
@@ -86,6 +86,14 @@ assert.ok(result.value === 'some text here');
 assert.ok(result.force === false);
 assert.ok(result.reverse === false);
 
+// Some basic tests on the ShellString type
+result = shell.ShellString('foo');
+assert.strictEqual(result.toString(), 'foo');
+assert.equal(result.stdout, 'foo');
+assert.ok(typeof result.stderr === 'undefined');
+assert.ok(result.to);
+assert.ok(result.toEnd);
+
 shell.exit(123);
 
 

--- a/test/config.js
+++ b/test/config.js
@@ -27,7 +27,7 @@ assert.equal(shell.config.fatal, false); // default
 shell.mkdir('-p', 'tmp');
 var file = 'tmp/tempscript'+Math.random()+'.js',
     script = 'require(\'../../global.js\'); config.silent=true; config.fatal=false; cp("this_file_doesnt_exist", "."); echo("got here");';
-script.to(file);
+shell.ShellString(script).to(file);
 child.exec('node '+file, function(err, stdout) {
   assert.ok(stdout.match('got here'));
 
@@ -37,7 +37,7 @@ child.exec('node '+file, function(err, stdout) {
   shell.mkdir('-p', 'tmp');
   var file = 'tmp/tempscript'+Math.random()+'.js',
       script = 'require(\'../../global.js\'); config.silent=true; config.fatal=true; cp("this_file_doesnt_exist", "."); echo("got here");';
-  script.to(file);
+  shell.ShellString(script).to(file);
   child.exec('node '+file, function(err, stdout) {
     assert.ok(!stdout.match('got here'));
 

--- a/test/cp.js
+++ b/test/cp.js
@@ -61,7 +61,7 @@ assert.equal(fs.existsSync('tmp/a_file'), false);
 shell.cp('resources/file2', 'resources/copyfile2');
 shell.cp('resources/file1', 'resources/file2'); // dest already exists
 assert.ok(!shell.error());
-assert.equal(shell.cat('resources/file1'), shell.cat('resources/file2')); // after cp
+assert.equal(shell.cat('resources/file1') + '', shell.cat('resources/file2') + ''); // after cp
 shell.mv('resources/copyfile2', 'resources/file2'); // restore
 assert.ok(!shell.error());
 
@@ -69,7 +69,7 @@ assert.ok(!shell.error());
 shell.cp('resources/file2', 'resources/copyfile2');
 shell.cp('-f', 'resources/file1', 'resources/file2'); // dest already exists
 assert.ok(!shell.error());
-assert.equal(shell.cat('resources/file1'), shell.cat('resources/file2')); // after cp
+assert.equal(shell.cat('resources/file1') + '', shell.cat('resources/file2') + ''); // after cp
 shell.mv('resources/copyfile2', 'resources/file2'); // restore
 assert.ok(!shell.error());
 
@@ -131,18 +131,18 @@ assert.equal(shell.error(), null); // crash test only
 //recursive, everything exists, with force flag
 shell.rm('-rf', 'tmp/*');
 shell.cp('-R', 'resources/cp', 'tmp');
-'changing things around'.to('tmp/cp/dir_a/z');
-assert.notEqual(shell.cat('resources/cp/dir_a/z'), shell.cat('tmp/cp/dir_a/z')); // before cp
+shell.ShellString('changing things around').to('tmp/cp/dir_a/z');
+assert.notEqual(shell.cat('resources/cp/dir_a/z') + '', shell.cat('tmp/cp/dir_a/z') + ''); // before cp
 shell.cp('-Rf', 'resources/cp', 'tmp');
 assert.equal(shell.error(), null);
-assert.equal(shell.cat('resources/cp/dir_a/z'), shell.cat('tmp/cp/dir_a/z')); // after cp
+assert.equal(shell.cat('resources/cp/dir_a/z') + '', shell.cat('tmp/cp/dir_a/z') + ''); // after cp
 
 //recursive, creates dest dir since it's only one level deep (see Github issue #44)
 shell.rm('-rf', 'tmp/*');
 shell.cp('-r', 'resources/issue44', 'tmp/dir2');
 assert.equal(shell.error(), null);
 assert.equal(shell.ls('-R', 'resources/issue44') + '', shell.ls('-R', 'tmp/dir2') + '');
-assert.equal(shell.cat('resources/issue44/main.js'), shell.cat('tmp/dir2/main.js'));
+assert.equal(shell.cat('resources/issue44/main.js') + '', shell.cat('tmp/dir2/main.js') + '');
 
 //recursive, does *not* create dest dir since it's too deep (see Github issue #44)
 shell.rm('-rf', 'tmp/*');

--- a/test/echo.js
+++ b/test/echo.js
@@ -20,7 +20,7 @@ shell.mkdir('tmp');
 shell.mkdir('-p', 'tmp');
 var file = 'tmp/tempscript'+Math.random()+'.js',
     script = 'require(\'../../global.js\'); echo("-asdf", "111");'; // test '-' bug (see issue #20)
-script.to(file);
+shell.ShellString(script).to(file);
 child.exec('node '+file, function(err, stdout) {
   assert.ok(stdout === '-asdf 111\n' || stdout === '-asdf 111\nundefined\n'); // 'undefined' for v0.4
 
@@ -28,7 +28,7 @@ child.exec('node '+file, function(err, stdout) {
   shell.mkdir('-p', 'tmp');
   var file = 'tmp/tempscript'+Math.random()+'.js',
       script = 'require(\'../../global.js\'); config.silent=true; echo(555);';
-  script.to(file);
+  shell.ShellString(script).to(file);
   child.exec('node '+file, function(err, stdout) {
     assert.ok(stdout === '555\n' || stdout === '555\nundefined\n'); // 'undefined' for v0.4
 

--- a/test/exec.js
+++ b/test/exec.js
@@ -126,6 +126,13 @@ if (process.platform !== 'win32') {
   }
 }
 
+// exec returns a ShellString
+result = shell.exec('echo foo');
+assert.ok(typeof result === 'object');
+assert.ok(result instanceof String);
+assert.ok(typeof result.stdout === 'string');
+assert.strictEqual(result.toString(), result.stdout);
+
 //
 // async
 //

--- a/test/grep.js
+++ b/test/grep.js
@@ -22,6 +22,14 @@ assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
 shell.grep(/asdf/g, '/asdfasdf'); // no such file
 assert.ok(shell.error());
 
+// if at least one file is missing, this should be an error
+shell.cp('-f', 'resources/file1', 'tmp/file1');
+assert.equal(fs.existsSync('asdfasdf'), false); // sanity check
+assert.equal(fs.existsSync('tmp/file1'), true); // sanity check
+var result = shell.grep(/asdf/g, 'tmp/file1', 'asdfasdf');
+assert.ok(shell.error());
+assert.equal(result.stderr, 'grep: no such file or directory: asdfasdf');
+
 //
 // Valids
 //

--- a/test/ls.js
+++ b/test/ls.js
@@ -320,4 +320,26 @@ assert.ok(result.atime); // check that these keys exist
 assert.ok(result.ctime); // check that these keys exist
 assert.ok(result.toString().match(/^(\d+ +){5}.*$/));
 
+// Test new ShellString-like attributes
+result = shell.ls('resources/ls');
+assert.equal(shell.error(), null);
+assert.equal(result.stdout.indexOf('file1') > -1, true);
+assert.equal(result.stdout.indexOf('file2') > -1, true);
+assert.equal(result.stdout.indexOf('file1.js') > -1, true);
+assert.equal(result.stdout.indexOf('file2.js') > -1, true);
+assert.equal(result.stdout.indexOf('filename(with)[chars$]^that.must+be-escaped') > -1, true);
+assert.equal(result.stdout.indexOf('a_dir') > -1, true);
+assert.strictEqual(typeof result.stdout, 'string');
+assert.ok(result.to);
+assert.ok(result.toEnd);
+result.to('tmp/testingToOutput.txt');
+assert.equal(shell.cat('tmp/testingToOutput.txt'), result.stdout);
+shell.rm('tmp/testingToOutput.txt');
+
+// Check stderr field
+assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+result = shell.ls('resources/ls/file1', '/asdfasdf');
+assert.ok(shell.error());
+assert.equal(shell.error(), result.stderr);
+
 shell.exit(123);

--- a/test/make.js
+++ b/test/make.js
@@ -11,7 +11,7 @@ var file = 'tmp/tempscript'+Math.random()+'.js',
              '  echo("second");' +
              '}';
 
-script.to(file);
+shell.ShellString(script).to(file);
 child.exec('node '+file, function(err, stdout) {
   assert.ok(stdout.match('first'));
   assert.ok(!stdout.match('second')); // Make should die on errors, so this should never get echoed

--- a/test/rm.js
+++ b/test/rm.js
@@ -121,7 +121,7 @@ assert.equal(contents.length, 0);
 
 // removal of a read-only file (unforced)
 shell.mkdir('-p', 'tmp/readonly');
-'asdf'.to('tmp/readonly/file1');
+shell.ShellString('asdf').to('tmp/readonly/file1');
 fs.chmodSync('tmp/readonly/file1', '0444'); // -r--r--r--
 shell.rm('tmp/readonly/file1');
 assert.equal(fs.existsSync('tmp/readonly/file1'), true); // bash's rm always asks before removing read-only files
@@ -129,15 +129,15 @@ assert.equal(fs.existsSync('tmp/readonly/file1'), true); // bash's rm always ask
 
 // removal of a read-only file (forced)
 shell.mkdir('-p', 'tmp/readonly');
-'asdf'.to('tmp/readonly/file2');
+shell.ShellString('asdf').to('tmp/readonly/file2');
 fs.chmodSync('tmp/readonly/file2', '0444'); // -r--r--r--
 shell.rm('-f', 'tmp/readonly/file2');
 assert.equal(fs.existsSync('tmp/readonly/file2'), false);
 
 // removal of a tree containing read-only files (unforced)
 shell.mkdir('-p', 'tmp/tree2');
-'asdf'.to('tmp/tree2/file1');
-'asdf'.to('tmp/tree2/file2');
+shell.ShellString('asdf').to('tmp/tree2/file1');
+shell.ShellString('asdf').to('tmp/tree2/file2');
 fs.chmodSync('tmp/tree2/file1', '0444'); // -r--r--r--
 shell.rm('-r', 'tmp/tree2');
 assert.equal(fs.existsSync('tmp/tree2/file1'), true);
@@ -145,8 +145,8 @@ assert.equal(fs.existsSync('tmp/tree2/file2'), false);
 
 // removal of a tree containing read-only files (forced)
 shell.mkdir('-p', 'tmp/tree');
-'asdf'.to('tmp/tree/file1');
-'asdf'.to('tmp/tree/file2');
+shell.ShellString('asdf').to('tmp/tree/file1');
+shell.ShellString('asdf').to('tmp/tree/file2');
 fs.chmodSync('tmp/tree/file1', '0444'); // -r--r--r--
 shell.rm('-rf', 'tmp/tree');
 assert.equal(fs.existsSync('tmp/tree'), false);
@@ -155,9 +155,9 @@ assert.equal(fs.existsSync('tmp/tree'), false);
 shell.mkdir('-p', 'tmp/tree3');
 shell.mkdir('-p', 'tmp/tree3/subtree');
 shell.mkdir('-p', 'tmp/tree3/.hidden');
-'asdf'.to('tmp/tree3/subtree/file');
-'asdf'.to('tmp/tree3/.hidden/file');
-'asdf'.to('tmp/tree3/file');
+shell.ShellString('asdf').to('tmp/tree3/subtree/file');
+shell.ShellString('asdf').to('tmp/tree3/.hidden/file');
+shell.ShellString('asdf').to('tmp/tree3/file');
 fs.chmodSync('tmp/tree3/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree3/subtree/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree3/.hidden/file', '0444'); // -r--r--r--
@@ -168,9 +168,9 @@ assert.equal(shell.ls('tmp/tree3').length, 0);
 shell.mkdir('-p', 'tmp/tree4');
 shell.mkdir('-p', 'tmp/tree4/subtree');
 shell.mkdir('-p', 'tmp/tree4/.hidden');
-'asdf'.to('tmp/tree4/subtree/file');
-'asdf'.to('tmp/tree4/.hidden/file');
-'asdf'.to('tmp/tree4/file');
+shell.ShellString('asdf').to('tmp/tree4/subtree/file');
+shell.ShellString('asdf').to('tmp/tree4/.hidden/file');
+shell.ShellString('asdf').to('tmp/tree4/file');
 fs.chmodSync('tmp/tree4/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree4/subtree/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree4/.hidden/file', '0444'); // -r--r--r--

--- a/test/sed.js
+++ b/test/sed.js
@@ -29,8 +29,9 @@ assert.ok(shell.error());
 shell.cp('-f', 'resources/file1', 'tmp/file1');
 assert.equal(fs.existsSync('asdfasdf'), false); // sanity check
 assert.equal(fs.existsSync('tmp/file1'), true); // sanity check
-shell.sed(/asdf/g, 'nada', 'tmp/file1', 'asdfasdf');
+var result = shell.sed(/asdf/g, 'nada', 'tmp/file1', 'asdfasdf');
 assert.ok(shell.error());
+assert.equal(result.stderr, 'sed: no such file or directory: asdfasdf');
 
 //
 // Valids
@@ -39,47 +40,47 @@ assert.ok(shell.error());
 shell.cp('-f', 'resources/file1', 'tmp/file1');
 var result = shell.sed('test1', 'hello', 'tmp/file1'); // search string
 assert.equal(shell.error(), null);
-assert.equal(result, 'hello');
+assert.equal(result.toString(), 'hello');
 
 var result = shell.sed(/test1/, 'hello', 'tmp/file1'); // search regex
 assert.equal(shell.error(), null);
-assert.equal(result, 'hello');
+assert.equal(result.toString(), 'hello');
 
 var result = shell.sed(/test1/, 1234, 'tmp/file1'); // numeric replacement
 assert.equal(shell.error(), null);
-assert.equal(result, '1234');
+assert.equal(result.toString(), '1234');
 
 var replaceFun = function (match) {
   return match.toUpperCase() + match;
 };
 var result = shell.sed(/test1/, replaceFun, 'tmp/file1'); // replacement function
 assert.equal(shell.error(), null);
-assert.equal(result, 'TEST1test1');
+assert.equal(result.toString(), 'TEST1test1');
 
 var result = shell.sed('-i', /test1/, 'hello', 'tmp/file1');
 assert.equal(shell.error(), null);
-assert.equal(result, 'hello');
-assert.equal(shell.cat('tmp/file1'), 'hello');
+assert.equal(result.toString(), 'hello');
+assert.equal(shell.cat('tmp/file1').toString(), 'hello');
 
 // make sure * in regex is not globbed
 var result = shell.sed(/alpha*beta/, 'hello', 'resources/grep/file');
 assert.equal(shell.error(), null);
-assert.equal(result, 'hello\nhowareyou\nhello\nthis line ends in.js\nlllllllllllllllll.js\n');
+assert.equal(result.toString(), 'hello\nhowareyou\nhello\nthis line ends in.js\nlllllllllllllllll.js\n');
 
 // make sure * in string-regex is not globbed
 var result = shell.sed('alpha*beta', 'hello', 'resources/grep/file');
 assert.ok(!shell.error());
-assert.equal(result, 'hello\nhowareyou\nhello\nthis line ends in.js\nlllllllllllllllll.js\n');
+assert.equal(result.toString(), 'hello\nhowareyou\nhello\nthis line ends in.js\nlllllllllllllllll.js\n');
 
 // make sure * in regex is not globbed
 var result = shell.sed(/l*\.js/, '', 'resources/grep/file');
 assert.ok(!shell.error());
-assert.equal(result, 'alphaaaaaaabeta\nhowareyou\nalphbeta\nthis line ends in\n\n');
+assert.equal(result.toString(), 'alphaaaaaaabeta\nhowareyou\nalphbeta\nthis line ends in\n\n');
 
 // make sure * in string-regex is not globbed
 var result = shell.sed('l*\\.js', '', 'resources/grep/file');
 assert.ok(!shell.error());
-assert.equal(result, 'alphaaaaaaabeta\nhowareyou\nalphbeta\nthis line ends in\n\n');
+assert.equal(result.toString(), 'alphaaaaaaabeta\nhowareyou\nalphbeta\nthis line ends in\n\n');
 
 shell.cp('-f', 'resources/file1', 'tmp/file1');
 shell.cp('-f', 'resources/file2', 'tmp/file2');
@@ -87,28 +88,28 @@ shell.cp('-f', 'resources/file2', 'tmp/file2');
 // multiple file names
 var result = shell.sed('test', 'hello', 'tmp/file1', 'tmp/file2');
 assert.equal(shell.error(), null);
-assert.equal(result, 'hello1\nhello2');
+assert.equal(result.toString(), 'hello1\nhello2');
 
 // array of file names (and try it out with a simple regex)
 var result = shell.sed(/t.*st/, 'hello', ['tmp/file1', 'tmp/file2']);
 assert.equal(shell.error(), null);
-assert.equal(result, 'hello1\nhello2');
+assert.equal(result.toString(), 'hello1\nhello2');
 
 // multiple file names, with in-place-replacement
 var result = shell.sed('-i', 'test', 'hello', ['tmp/file1', 'tmp/file2']);
 assert.equal(shell.error(), null);
-assert.equal(result, 'hello1\nhello2');
-assert.equal(shell.cat('tmp/file1'), 'hello1');
-assert.equal(shell.cat('tmp/file2'), 'hello2');
+assert.equal(result.toString(), 'hello1\nhello2');
+assert.equal(shell.cat('tmp/file1').toString(), 'hello1');
+assert.equal(shell.cat('tmp/file2').toString(), 'hello2');
 
 // glob file names, with in-place-replacement
 shell.cp('resources/file*.txt', 'tmp/');
-assert.equal(shell.cat('tmp/file1.txt'), 'test1\n');
-assert.equal(shell.cat('tmp/file2.txt'), 'test2\n');
+assert.equal(shell.cat('tmp/file1.txt').toString(), 'test1\n');
+assert.equal(shell.cat('tmp/file2.txt').toString(), 'test2\n');
 var result = shell.sed('-i', 'test', 'hello', 'tmp/file*.txt');
 assert.equal(shell.error(), null);
-assert.equal(result, 'hello1\n\nhello2\n'); // TODO: fix sed's behavior
-assert.equal(shell.cat('tmp/file1.txt'), 'hello1\n');
-assert.equal(shell.cat('tmp/file2.txt'), 'hello2\n');
+assert.equal(result.toString(), 'hello1\n\nhello2\n'); // TODO: fix sed's behavior
+assert.equal(shell.cat('tmp/file1.txt').toString(), 'hello1\n');
+assert.equal(shell.cat('tmp/file2.txt').toString(), 'hello2\n');
 
 shell.exit(123);

--- a/test/to.js
+++ b/test/to.js
@@ -12,18 +12,22 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-'hello world'.to();
+// Normal strings don't have '.to()' anymore
+var str = 'hello world';
+assert.ok(typeof str.to === 'undefined');
+
+shell.ShellString('hello world').to();
 assert.ok(shell.error());
 
 assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
-'hello world'.to('/asdfasdf/file');
+shell.ShellString('hello world').to('/asdfasdf/file');
 assert.ok(shell.error());
 
 //
 // Valids
 //
 
-'hello world'.to('tmp/to1').to('tmp/to2');
+shell.ShellString('hello world').to('tmp/to1').to('tmp/to2');
 var result = shell.cat('tmp/to1');
 assert.equal(shell.error(), null);
 assert.equal(result, 'hello world');
@@ -32,7 +36,7 @@ assert.equal(shell.error(), null);
 assert.equal(result, 'hello world');
 
 // With a glob
-'goodbye'.to('tmp/t*1');
+shell.ShellString('goodbye').to('tmp/t*1');
 var result = shell.cat('tmp/to1');
 assert.equal(shell.error(), null);
 assert.equal(result, 'goodbye');

--- a/test/toEnd.js
+++ b/test/toEnd.js
@@ -12,7 +12,11 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-'hello world'.toEnd();
+// Normal strings don't have '.toEnd()' anymore
+var str = 'hello world';
+assert.ok(typeof str.toEnd === 'undefined');
+
+shell.ShellString('hello world').toEnd();
 assert.ok(shell.error());
 
 assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
@@ -23,9 +27,9 @@ assert.ok(shell.error());
 
 assert.equal(fs.existsSync('tmp/toEnd1'), false); //Check file toEnd() creates does not already exist
 assert.equal(fs.existsSync('tmp/toEnd2'), false);
-'hello '.toEnd('tmp/toEnd1');
+shell.ShellString('hello ').toEnd('tmp/toEnd1');
 assert.equal(fs.existsSync('tmp/toEnd1'), true); //Check that file was created
-'world'.toEnd('tmp/toEnd1').toEnd('tmp/toEnd2'); //Write some more to the file
+shell.ShellString('world').toEnd('tmp/toEnd1').toEnd('tmp/toEnd2'); //Write some more to the file
 var result = shell.cat('tmp/toEnd1');
 assert.equal(shell.error(), null);
 assert.equal(result, 'hello world'); //Check that the result is what we expect
@@ -34,8 +38,8 @@ assert.equal(shell.error(), null);
 assert.equal(result, 'world'); //Check that the result is what we expect
 
 // With a glob
-'good'.to('tmp/toE*1');
-'bye'.toEnd('tmp/toE*1');
+shell.ShellString('good').to('tmp/toE*1');
+shell.ShellString('bye').toEnd('tmp/toE*1');
 var result = shell.cat('tmp/toEnd1');
 assert.equal(shell.error(), null);
 assert.equal(result, 'goodbye');

--- a/test/which.js
+++ b/test/which.js
@@ -25,7 +25,7 @@ assert.ok(!result);
 
 var node = shell.which('node');
 assert.ok(!shell.error());
-assert.ok(fs.existsSync(node));
+assert.ok(fs.existsSync(node + ''));
 
 if (process.platform === 'win32') {
     // This should be equivalent on Windows
@@ -33,7 +33,7 @@ if (process.platform === 'win32') {
     assert.ok(!shell.error());
     // If the paths are equal, then this file *should* exist, since that's
     // already been checked.
-    assert.equal(node, nodeExe);
+    assert.equal(node + '', nodeExe + '');
 }
 
 shell.exit(123);


### PR DESCRIPTION
This is a PR to refactor commands to return `ShellString` objects instead of regular strings. This still has some broken tests, so it's far from ready, but I think in principle this approach will work.

Feel free to fix any tests and/or post the diffs.

Fixes #356, #154.