### PR TITLE
Ignore gitattributes from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,5 +5,6 @@ tmp/
 .jshintrc
 .lgtm
 .travis.yml
+.gitattributes
 appveyor.yml
 RELEASE.md


### PR DESCRIPTION
This ignores the `.gitattributes` file