### PR TITLE
fix(verbose): verbose-style logging is consistent

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -75,15 +75,15 @@ exports.which = common.wrap('which', _which);
 
 //@include ./src/echo
 var _echo = require('./src/echo');
-exports.echo = _echo; // don't common.wrap() as it could parse '-options'
+exports.echo = common.wrap('echo', _echo);
 
 //@include ./src/dirs
 var _dirs = require('./src/dirs').dirs;
-exports.dirs = common.wrap("dirs", _dirs, {idx: 1});
+exports.dirs = common.wrap('dirs', _dirs, {idx: 1});
 var _pushd = require('./src/dirs').pushd;
 exports.pushd = common.wrap('pushd', _pushd, {idx: 1});
 var _popd = require('./src/dirs').popd;
-exports.popd = common.wrap("popd", _popd, {idx: 1});
+exports.popd = common.wrap('popd', _popd, {idx: 1});
 
 //@include ./src/ln
 var _ln = require('./src/ln');

--- a/src/common.js
+++ b/src/common.js
@@ -204,7 +204,7 @@ function wrap(cmd, fn, options) {
 
       if (config.verbose) {
         args.unshift(cmd);
-        console.log.apply(console, args);
+        console.error.apply(console, args);
         args.shift();
       }
 
@@ -240,8 +240,8 @@ function wrap(cmd, fn, options) {
     } catch (e) {
       if (!state.error) {
         // If state.error hasn't been set it's an error thrown by Node, not us - probably a bug...
-        console.log('shell.js: internal error');
-        console.log(e.stack || e);
+        console.error('shell.js: internal error');
+        console.error(e.stack || e);
         process.exit(1);
       }
       if (config.fatal)

--- a/src/echo.js
+++ b/src/echo.js
@@ -12,8 +12,9 @@ var common = require('./common');
 //@
 //@ Prints string to stdout, and returns string with additional utility methods
 //@ like `.to()`.
-function _echo() {
-  var messages = [].slice.call(arguments, 0);
+function _echo(opts, messages) {
+  // allow strings starting with '-', see issue #20
+  messages = [].slice.call(arguments, opts ? 0 : 1);
   console.log.apply(console, messages);
   return common.ShellString(messages.join(' '));
 }

--- a/test/set.js
+++ b/test/set.js
@@ -37,14 +37,16 @@ assert(result.stderr.indexOf('Error: ls: no such file or directory: file_doesnt_
 // set -v
 var result = shell.exec('node -e \"require(\'../global\'); set(\'-v\'); ls(\'file_doesnt_exist\'); echo(1234);\"');
 assert.equal(result.code, 0);
-assert.equal(result.stdout, 'ls file_doesnt_exist\n1234\n');
-assert.equal(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');
+assert.equal(result.stdout, '1234\n');
+assert.equal(result.stderr, 'ls file_doesnt_exist\nls: no such file or directory: file_doesnt_exist\necho 1234\n');
 
 // set -ev
 var result = shell.exec('node -e \"require(\'../global\'); set(\'-ev\'); ls(\'file_doesnt_exist\'); echo(1234);\"');
 assert.equal(result.code, uncaughtErrorExitCode);
-assert.equal(result.stdout, 'ls file_doesnt_exist\n');
+assert.equal(result.stdout, '');
 assert(result.stderr.indexOf('Error: ls: no such file or directory: file_doesnt_exist') >= 0);
+assert(result.stderr.indexOf('ls file_doesnt_exist\n') >= 0);
+assert.equal(result.stderr.indexOf('echo 1234\n'), -1);
 
 // set -e, set +e
 var result = shell.exec('node -e \"require(\'../global\'); set(\'-e\'); set(\'+e\'); ls(\'file_doesnt_exist\'); echo(1234);\"');


### PR DESCRIPTION
This fixes a couple issues with `config.verbose` logging, and some related things.

 - `set('-v')` previously didn't log `echo()` commands because those weren't `common.wrap`'ed
 - `echo()` is now wrapped, but is designed to still allow echoing strings that start with "-" (ex. "-1*3+5") (see issue #20)
 - `echo()` still does not glob. This is because 1. globbing isn't that useful for `echo()` in my opinion, and 2. echo is frequently used enough that it should have good performance by default
 - internal errors are now outputted to stderr instead of stdout
 - `set('-v')`-style logging goes to stderr, not stdout. This resembles Bash's behavior with `set -v`

The way this is implemented, `echo()` still doesn't support any options, but we may want to consider allowing for that in the future (`-n` comes to mind). It'd be pretty easy to add support for that option once this is merged.

Also, it simplifies things if `echo()` is wrapped, since it ensures that commands like `echo(pwd())` still work the same, even if #360 lands.