### PR TITLE
fix(exec): properly handles paths with spaces and quotes

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -62,7 +62,11 @@ function execSync(cmd, opts) {
   if (fs.existsSync(stderrFile)) common.unlinkSync(stderrFile);
   if (fs.existsSync(codeFile)) common.unlinkSync(codeFile);
 
-  var execCommand = '"'+process.execPath+'" '+scriptFile;
+  var execCommand = '"' +
+      process.execPath.replace(/"/g, '\\"') +
+      '" "' +
+      scriptFile.replace(/"/g, '\\"') +
+      '"';
   var script;
 
   opts.cwd = path.resolve(opts.cwd);


### PR DESCRIPTION
This fixes #17. This is based off #263, but it also escapes quotes in the path.

The issue comes from the fact that `exec()` executes a script created in the temporary directory. On unix systems, this is usually `/tmp/`, which has no unusual characters in the name. Windows users usually have a temporary directory that is a subdirectory of their home folder (which has their username as part of the path). Therefore, Windows users with usernames containing either a space or a `"` couldn't use `exec()` properly.

This now properly surrounds the strings with quotes, and escapes any quote characters inside for security, preventing scenarios, such as creating a directory named `/tmp"; echo hijacked; echo "` (perhaps `$TMP` is modified to point there, and this is chosen as the temporary directory). `echo hijacked` represents an arbitrary command. As it's currently implemented, #263 is still susceptible.