### PR TITLE
docs(exec): exec options only work for v0.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ Available options (all `false` by default):
 + `silent`: Do not echo program output to console.
 + and any option available to NodeJS's
   [child_process.exec()](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
+  (only available on Node v0.11+)
 
 Examples:
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -206,6 +206,7 @@ function execAsync(cmd, opts, pipe, callback) {
 //@ + `silent`: Do not echo program output to console.
 //@ + and any option available to NodeJS's
 //@   [child_process.exec()](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
+//@   (only available on Node v0.11+)
 //@
 //@ Examples:
 //@


### PR DESCRIPTION
Resolves #350 

As far as I can tell, node `v0.10` doesn't support many options to `child_process.exec()`. This doesn't really fix it, but it does document that these options don't work for that platform.

Whether or not we officially support `v0.10` (currently we test against it for unit tests), there are still users out there using `v0.10`, and I'm sure some of them will still try to mix ShellJS with it. I think, since this is a known issue, it's worth documenting (since there's no good workaround). Most users won't be affected by it, and the few that are affected will be aware (and maybe switch to a newer version of node because of it).