### PR TITLE
feat(pipe): add support for pipes between commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ otherwise returns string explaining the error
 
 Examples:
 
-```
+```javascript
 var foo = ShellString('hello world');
 ```
 
@@ -627,10 +627,25 @@ Turns a regular string into a string-like object similar to what each
 command returns. This has special methods, like `.to()` and `.toEnd()`
 
 
+### Pipes
+
+Examples:
+
+```javascript
+grep('foo', 'file1.txt', 'file2.txt').sed(/o/g, 'a').to('output.txt');
+echo('files with o\'s in the name:\n' + ls().grep('o'));
+cat('test.js').exec('node'); // pipe to exec() call
+```
+
+Commands can send their output to another command in a pipe-like fashion.
+`sed`, `grep`, `cat`, `exec`, `to`, and `toEnd` can appear on the right-hand
+side of a pipe. Pipes can be chained.
+
 ## Configuration
 
 
 ### config.silent
+
 Example:
 
 ```javascript
@@ -645,6 +660,7 @@ Suppresses all command output if `true`, except for `echo()` calls.
 Default is `false`.
 
 ### config.fatal
+
 Example:
 
 ```javascript
@@ -659,6 +675,7 @@ command encounters an error. Default is `false`. This is analogous to
 Bash's `set -e`
 
 ### config.verbose
+
 Example:
 
 ```javascript

--- a/shell.js
+++ b/shell.js
@@ -128,6 +128,20 @@ exports.error = _error;
 //@include ./src/common
 exports.ShellString = common.ShellString;
 
+//@
+//@ ### Pipes
+//@
+//@ Examples:
+//@
+//@ ```javascript
+//@ grep('foo', 'file1.txt', 'file2.txt').sed(/o/g, 'a').to('output.txt');
+//@ echo('files with o\'s in the name:\n' + ls().grep('o'));
+//@ cat('test.js').exec('node'); // pipe to exec() call
+//@ ```
+//@
+//@ Commands can send their output to another command in a pipe-like fashion.
+//@ `sed`, `grep`, `cat`, `exec`, `to`, and `toEnd` can appear on the right-hand
+//@ side of a pipe. Pipes can be chained.
 
 //@
 //@ ## Configuration
@@ -137,6 +151,7 @@ exports.config = common.config;
 
 //@
 //@ ### config.silent
+//@
 //@ Example:
 //@
 //@ ```javascript
@@ -152,6 +167,7 @@ exports.config = common.config;
 
 //@
 //@ ### config.fatal
+//@
 //@ Example:
 //@
 //@ ```javascript
@@ -167,6 +183,7 @@ exports.config = common.config;
 
 //@
 //@ ### config.verbose
+//@
 //@ Example:
 //@
 //@ ```javascript

--- a/src/cat.js
+++ b/src/cat.js
@@ -17,14 +17,12 @@ var fs = require('fs');
 //@ containing the files if more than one file is given (a new line character is
 //@ introduced between each file). Wildcard `*` accepted.
 function _cat(options, files) {
-  var cat = '';
+  var cat = common.readFromPipe(this);
 
-  if (!files)
+  if (!files && !cat)
     common.error('no paths given');
 
-  if (typeof files === 'string')
-    files = [].slice.call(arguments, 1);
-  // if it's array leave it as it is
+  files = [].slice.call(arguments, 1);
 
   files.forEach(function(file) {
     if (!fs.existsSync(file))

--- a/src/grep.js
+++ b/src/grep.js
@@ -24,21 +24,26 @@ function _grep(options, regex, files) {
     'l': 'nameOnly'
   });
 
-  if (!files)
+  // Check if this is coming from a pipe
+  var pipe = common.readFromPipe(this);
+
+  if (!files && !pipe)
     common.error('no paths given');
 
-  if (typeof files === 'string')
-    files = [].slice.call(arguments, 2);
+  files = [].slice.call(arguments, 2);
+
+  if (pipe)
+    files.unshift('-');
 
   var grep = [];
   files.forEach(function(file) {
-    if (!fs.existsSync(file)) {
+    if (!fs.existsSync(file) && file !== '-') {
       common.error('no such file or directory: ' + file, true);
       return;
     }
 
-    var contents = fs.readFileSync(file, 'utf8'),
-        lines = contents.split(/\r*\n/);
+    var contents = file === '-' ? pipe : fs.readFileSync(file, 'utf8');
+    var lines = contents.split(/\r*\n/);
     if (options.nameOnly) {
       if (contents.match(regex))
         grep.push(file);

--- a/src/ls.js
+++ b/src/ls.js
@@ -3,8 +3,6 @@ var fs = require('fs');
 var common = require('./common');
 var _cd = require('./cd');
 var _pwd = require('./pwd');
-var _to = require('./to');
-var _toEnd = require('./toEnd');
 
 //@
 //@ ### ls([options,] [path, ...])
@@ -154,15 +152,7 @@ function _ls(options, paths) {
   });
 
   // Add methods, to make this more compatible with ShellStrings
-  list.stdout = list.join('\n') + '\n';
-  list.stderr = common.state.error;
-  list.to = function (file) {
-    common.wrap('to', _to, {idx: 1}).call(this.stdout, file);
-  };
-  list.toEnd = function(file) {
-    common.wrap('toEnd', _toEnd, {idx: 1}).call(this.stdout, file);
-  };
-  return list;
+  return new common.ShellString(list, common.state.error);
 }
 module.exports = _ls;
 

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,0 +1,85 @@
+var shell = require('..');
+
+var assert = require('assert');
+
+shell.config.silent = true;
+
+shell.rm('-rf', 'tmp');
+shell.mkdir('tmp');
+
+//
+// Invalids
+//
+
+// no piped methods for commands that don't return anything
+assert.throws(function() {
+  shell.cp('resources/file1', 'tmp/');
+  assert.ok(!shell.error());
+  shell.cp('resources/file1', 'tmp/').cat();
+});
+
+// commands like `rm` can't be on the right side of pipes
+assert.equal(typeof shell.ls('.').rm, 'undefined');
+assert.equal(typeof shell.cat('resources/file1.txt').rm, 'undefined');
+
+//
+// Valids
+//
+
+// piping to cat() should return roughly the same thing
+assert.strictEqual(shell.cat('resources/file1.txt').cat().toString(),
+    shell.cat('resources/file1.txt').toString());
+
+// piping ls() into cat() converts to a string
+assert.strictEqual(shell.ls('resources/').cat().toString(),
+    shell.ls('resources/').stdout);
+
+var result;
+result = shell.ls('resources/').grep('file1');
+assert.equal(result + '', 'file1\nfile1.js\nfile1.txt\n');
+
+result = shell.ls('resources/').cat().grep('file1');
+assert.equal(result + '', 'file1\nfile1.js\nfile1.txt\n');
+
+// Equivalent to a simple grep() test case
+result = shell.cat('resources/grep/file').grep(/alpha*beta/);
+assert.equal(shell.error(), null);
+assert.equal(result.toString(), 'alphaaaaaaabeta\nalphbeta\n');
+
+// Equivalent to a simple sed() test case
+var result = shell.cat('resources/grep/file').sed(/l*\.js/, '');
+assert.ok(!shell.error());
+assert.equal(result.toString(), 'alphaaaaaaabeta\nhowareyou\nalphbeta\nthis line ends in\n\n');
+
+// Synchronous exec
+// TODO: add windows tests
+if (process.platform !== 'win32') {
+  // unix-specific
+  if (shell.which('grep').stdout) {
+    result = shell.cat('resources/grep/file').exec("grep 'alpha*beta'");
+    assert.equal(shell.error(), null);
+    assert.equal(result, 'alphaaaaaaabeta\nalphbeta\n');
+  } else {
+    console.error('Warning: Cannot verify piped exec');
+  }
+} else {
+  console.error('Warning: Cannot verify piped exec');
+}
+
+// Async exec
+// TODO: add windows tests
+if (process.platform !== 'win32') {
+  // unix-specific
+  if (shell.which('grep').stdout) {
+    shell.cat('resources/grep/file').exec("grep 'alpha*beta'", function(code, stdout) {
+      assert.equal(code, 0);
+      assert.equal(stdout, 'alphaaaaaaabeta\nalphbeta\n');
+      shell.exit(123);
+    });
+  } else {
+    console.error('Warning: Cannot verify piped exec');
+  }
+} else {
+  console.error('Warning: Cannot verify piped exec');
+  shell.exit(123);
+}


### PR DESCRIPTION
Fixes #148

Commands can now be piped, of the form:

```javascript
grep('foo', 'file1.txt', 'file2.txt').sed(/o/g, 'a').to('output.txt');
echo('files with o\'s in the name:\n' + ls().grep('o'));
cat('test.js').exec('node'); // pipe to exec() call
```

Commands can send their output to another command in a pipe-like fashion. `sed`, `grep`, `cat`, `exec`, `to`, and `toEnd` can appear on the right-hand side of a pipe. Pipes can be chained. You can even pipe into async `exec()`.

This also improves performance slightly. I got rid of the slow, home-grown `escape()` function inside of `src/exec.js` and replaced it with `JSON.stringify()`, which I measured to be slightly faster, and much more reliable (it properly escapes newlines, tabs, etc. as well).

I couldn't think of any tests to add for piping to `exec()` on Windows (can't think of any native commands that can be on the right-hand side of a pipe). I'm fairly certain this code does work on Windows, I just couldn't think of a use-case. Worst case, we can go back and have someone more Windows-savvy make a PR adding the tests.