### PR TITLE
Check if Windows paths end in \ for recursive cp()

### DIFF
--- a/src/cp.js
+++ b/src/cp.js
@@ -143,7 +143,7 @@ function _cp(options, sources, dest) {
     // Recursive allows the shortcut syntax "sourcedir/" for "sourcedir/*"
     // (see Github issue #15)
     sources.forEach(function(src, i) {
-      if (src[src.length - 1] === '/') {
+      if (src[src.length - 1] === '/' || os.platform() === 'win32' && src[src.length - 1] === '\\') {
         sources[i] += '*';
       // If src is a directory and dest doesn't exist, 'cp -r src dest' should copy src/* into dest
       } else if (fs.statSync(src).isDirectory() && !exists) {


### PR DESCRIPTION
Paths which needed to be manipulated using the `path` module prior to calling `cp()` will contain `\` when running on Windows.

Found this while investigating the cause of ryanflorence/react-project#14. react-project needs to manipulate paths first because the stuff it uses `cp()` to copy is relative to its own location in `node_modules` rather than the cwd.