### PR TITLE
refactor(cp): clean up code and fix #376

### DIFF
--- a/test/set.js
+++ b/test/set.js
@@ -6,7 +6,6 @@ var oldConfigSilent = shell.config.silent;
 shell.config.silent = true;
 
 shell.rm('-rf', 'tmp');
-shell.mkdir('tmp');
 
 //
 // Valids


### PR DESCRIPTION
Fixes issue in #376. Simplifies the code, and slight perf win.

This fixes the semantics of `cp()`, which had deviated from unix `cp` a bit. If anyone is available to review, that would be good.

Goals of this PR:

 - improve performance
 - improve correctness