### PR TITLE
refactor(cd): use process.env.OLDPWD to store previous dir

### DIFF
--- a/src/cd.js
+++ b/src/cd.js
@@ -10,16 +10,16 @@ function _cd(options, dir) {
     dir = common.getUserHome();
 
   if (dir === '-') {
-    if (!common.state.previousDir)
+    if (!process.env.OLDPWD)
       common.error('could not find previous directory');
     else
-      dir = common.state.previousDir;
+      dir = process.env.OLDPWD;
   }
 
   try {
     var curDir = process.cwd();
     process.chdir(dir);
-    common.state.previousDir = curDir;
+    process.env.OLDPWD = curDir;
   } catch (e) {
     // something went wrong, let's figure out the error
     var err;

--- a/src/common.js
+++ b/src/common.js
@@ -21,10 +21,11 @@ exports.config = config;
 var state = {
   error: null,
   currentCmd: 'shell.js',
-  previousDir: null,
   tempDir: null
 };
 exports.state = state;
+
+process.env.OLDPWD = null; // initially, there's no previous directory
 
 var platform = os.type().match(/^Win/) ? 'win' : 'unix';
 exports.platform = platform;


### PR DESCRIPTION
This should be a simple refactor. This uses `process.env.OLDPWD` to store the previous directory (used by `cd -`), instead of a separate variable as we had it. It's a little closer to bash's semantics if we use `process.env`, since now people can run `echo(env.OLDPWD)` and see a useful result.