### PR TITLE
feat: adding error codes to ShellJS

### DIFF
--- a/src/cat.js
+++ b/src/cat.js
@@ -31,6 +31,6 @@ function _cat(options, files) {
     cat += fs.readFileSync(file, 'utf8');
   });
 
-  return new common.ShellString(cat, common.state.error);
+  return new common.ShellString(cat, common.state.error, common.state.errorCode);
 }
 module.exports = _cat;

--- a/src/cd.js
+++ b/src/cd.js
@@ -31,5 +31,6 @@ function _cd(options, dir) {
     }
     if (err) common.error(err);
   }
+  return new common.ShellString('', common.state.error, common.state.errorCode);
 }
 module.exports = _cd;

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -208,5 +208,6 @@ function _chmod(options, mode, filePattern) {
       fs.chmodSync(file, newPerms);
     }
   });
+  return new common.ShellString('', common.state.error, common.state.errorCode);
 }
 module.exports = _chmod;

--- a/src/common.js
+++ b/src/common.js
@@ -9,6 +9,8 @@ var shell = require('..');
 var _to = require('./to');
 var _toEnd = require('./toEnd');
 
+var DEFAULT_ERROR_CODE = 1;
+
 // Module globals
 var config = {
   silent: false,
@@ -20,6 +22,7 @@ exports.config = config;
 
 var state = {
   error: null,
+  errorCode: 0,
   currentCmd: 'shell.js',
   tempDir: null
 };
@@ -36,8 +39,18 @@ function log() {
 }
 exports.log = log;
 
-// Shows error message. Throws unless _continue or config.fatal are true
-function error(msg, _continue) {
+// Shows error message. Throws if config.fatal is true
+function error(msg, _code, _continue) {
+  if (typeof _code === 'boolean') {
+    _continue = _code;
+    _code = DEFAULT_ERROR_CODE;
+  }
+  if (typeof _code !== 'number')
+    _code = DEFAULT_ERROR_CODE;
+
+  if (state.errorCode === 0)
+    state.errorCode = _code;
+
   if (state.error === null)
     state.error = '';
   var log_entry = state.currentCmd + ': ' + msg;
@@ -46,8 +59,16 @@ function error(msg, _continue) {
   else
     state.error += '\n' + log_entry;
 
-  if(!_continue || config.fatal)
+  if(config.fatal)
     throw new Error(log_entry);
+
+  if(!_continue) {
+    // throw new Error(log_entry);
+    throw {
+      msg: 'earlyExit',
+      retValue: (new ShellString('', state.error, state.errorCode))
+    };
+  }
 
   if (msg.length > 0)
     log(log_entry);
@@ -65,7 +86,7 @@ exports.error = error;
 //@
 //@ Turns a regular string into a string-like object similar to what each
 //@ command returns. This has special methods, like `.to()` and `.toEnd()`
-var ShellString = function (stdout, stderr) {
+var ShellString = function (stdout, stderr, code) {
   var that;
   if (stdout instanceof Array) {
     that = stdout;
@@ -75,6 +96,7 @@ var ShellString = function (stdout, stderr) {
     that.stdout = stdout;
   }
   that.stderr = stderr;
+  that.code = code;
   that.to    = function() {wrap('to', _to, {idx: 1}).apply(that.stdout, arguments); return that;};
   that.toEnd = function() {wrap('toEnd', _toEnd, {idx: 1}).apply(that.stdout, arguments); return that;};
   ['cat', 'sed', 'grep', 'exec'].forEach(function (cmd) {
@@ -230,6 +252,7 @@ function wrap(cmd, fn, options) {
 
     state.currentCmd = cmd;
     state.error = null;
+    state.errorCode = 0;
 
     try {
       var args = [].slice.call(arguments, 0);
@@ -274,7 +297,13 @@ function wrap(cmd, fn, options) {
         });
         if (!config.noglob && options && typeof options.idx === 'number')
           args = args.slice(0, options.idx).concat(expand(args.slice(options.idx)));
-        retValue = fn.apply(this, args);
+        try {
+          retValue = fn.apply(this, args);
+        } catch (e) {
+          if (e.msg === 'earlyExit')
+            retValue = e.retValue;
+          else throw e;
+        }
       }
     } catch (e) {
       if (!state.error) {

--- a/src/common.js
+++ b/src/common.js
@@ -28,7 +28,7 @@ var state = {
 };
 exports.state = state;
 
-process.env.OLDPWD = null; // initially, there's no previous directory
+delete process.env.OLDPWD; // initially, there's no previous directory
 
 var platform = os.type().match(/^Win/) ? 'win' : 'unix';
 exports.platform = platform;

--- a/src/cp.js
+++ b/src/cp.js
@@ -131,7 +131,7 @@ function _cp(options, sources, dest) {
 
   // Dest is an existing file, but -n is given
   if (destExists && destStat.isFile() && options.no_force)
-    common.error('dest file already destExists: ' + dest);
+    common.error('dest file already exists: ' + dest);
 
   sources.forEach(function(src) {
     if (!fs.existsSync(src)) {
@@ -168,12 +168,13 @@ function _cp(options, sources, dest) {
         thisDest = path.normalize(dest + '/' + path.basename(src));
 
       if (fs.existsSync(thisDest) && options.no_force) {
-        common.error('dest file already destExists: ' + thisDest, true);
+        common.error('dest file already exists: ' + thisDest, true);
         return; // skip file
       }
 
       copyFileSync(src, thisDest);
     }
   }); // forEach(src)
+  return new common.ShellString('', common.state.error, common.state.errorCode);
 }
 module.exports = _cp;

--- a/src/echo.js
+++ b/src/echo.js
@@ -16,6 +16,6 @@ function _echo(opts, messages) {
   // allow strings starting with '-', see issue #20
   messages = [].slice.call(arguments, opts ? 0 : 1);
   console.log.apply(console, messages);
-  return new common.ShellString(messages.join(' '));
+  return new common.ShellString(messages.join(' '), '', 0);
 }
 module.exports = _echo;

--- a/src/exec.js
+++ b/src/exec.js
@@ -151,10 +151,7 @@ function execSync(cmd, opts, pipe) {
   if (code !== 0)  {
     common.error('', true);
   }
-  var obj = common.ShellString(stdout, stderr);
-  // obj.stdout = stdout;
-  // obj.stderr = stderr;
-  obj.code = code;
+  var obj = common.ShellString(stdout, stderr, code);
   return obj;
 } // execSync()
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -149,7 +149,7 @@ function execSync(cmd, opts, pipe) {
   try { common.unlinkSync(codeFile); } catch(e) {}
 
   if (code !== 0)  {
-    common.error('', true);
+    common.error('', code, true);
   }
   var obj = common.ShellString(stdout, stderr, code);
   return obj;

--- a/src/find.js
+++ b/src/find.js
@@ -46,6 +46,6 @@ function _find(options, paths) {
     }
   });
 
-  return list;
+  return new common.ShellString(list, common.state.error, common.state.errorCode);
 }
 module.exports = _find;

--- a/src/grep.js
+++ b/src/grep.js
@@ -56,6 +56,6 @@ function _grep(options, regex, files) {
     }
   });
 
-  return new common.ShellString(grep.join('\n')+'\n', common.state.error);
+  return new common.ShellString(grep.join('\n')+'\n', common.state.error, common.state.errorCode);
 }
 module.exports = _grep;

--- a/src/grep.js
+++ b/src/grep.js
@@ -28,7 +28,7 @@ function _grep(options, regex, files) {
   var pipe = common.readFromPipe(this);
 
   if (!files && !pipe)
-    common.error('no paths given');
+    common.error('no paths given', 2);
 
   files = [].slice.call(arguments, 2);
 
@@ -38,7 +38,7 @@ function _grep(options, regex, files) {
   var grep = [];
   files.forEach(function(file) {
     if (!fs.existsSync(file) && file !== '-') {
-      common.error('no such file or directory: ' + file, true);
+      common.error('no such file or directory: ' + file, 2, true);
       return;
     }
 

--- a/src/ln.js
+++ b/src/ln.js
@@ -65,5 +65,6 @@ function _ln(options, source, dest) {
       common.error(err.message);
     }
   }
+  return new common.ShellString('', common.state.error, common.state.errorCode);
 }
 module.exports = _ln;

--- a/src/ls.js
+++ b/src/ls.js
@@ -100,7 +100,7 @@ function _ls(options, paths) {
   });
 
   // Add methods, to make this more compatible with ShellStrings
-  return new common.ShellString(list, common.state.error);
+  return new common.ShellString(list, common.state.error, common.state.errorCode);
 }
 
 function addLsAttributes(path, stats) {

--- a/src/ls.js
+++ b/src/ls.js
@@ -70,7 +70,7 @@ function _ls(options, paths) {
     try {
       stat = fs.lstatSync(p);
     } catch (e) {
-      common.error('no such file or directory: ' + p, true);
+      common.error('no such file or directory: ' + p, 2, true);
       return;
     }
 

--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -64,5 +64,6 @@ function _mkdir(options, dirs) {
     else
       fs.mkdirSync(dir, parseInt('0777', 8));
   });
+  return new common.ShellString('', common.state.error, common.state.errorCode);
 } // mkdir
 module.exports = _mkdir;

--- a/src/mv.js
+++ b/src/mv.js
@@ -74,5 +74,6 @@ function _mv(options, sources, dest) {
 
     fs.renameSync(src, thisDest);
   }); // forEach(src)
+  return new common.ShellString('', common.state.error, common.state.errorCode);
 } // mv
 module.exports = _mv;

--- a/src/pwd.js
+++ b/src/pwd.js
@@ -6,6 +6,6 @@ var common = require('./common');
 //@ Returns the current directory.
 function _pwd() {
   var pwd = path.resolve(process.cwd());
-  return new common.ShellString(pwd);
+  return new common.ShellString(pwd, '', common.state.errorCode);
 }
 module.exports = _pwd;

--- a/src/rm.js
+++ b/src/rm.js
@@ -156,5 +156,6 @@ function _rm(options, files) {
       rmdirSyncRecursive(file, options.force);
     }
   }); // forEach(file)
+  return new common.ShellString('', common.state.error, common.state.errorCode);
 } // rm
 module.exports = _rm;

--- a/src/sed.js
+++ b/src/sed.js
@@ -47,7 +47,7 @@ function _sed(options, regex, replacement, files) {
   var sed = [];
   files.forEach(function(file) {
     if (!fs.existsSync(file) && file !== '-') {
-      common.error('no such file or directory: ' + file, true);
+      common.error('no such file or directory: ' + file, 2, true);
       return;
     }
 

--- a/src/sed.js
+++ b/src/sed.js
@@ -63,6 +63,6 @@ function _sed(options, regex, replacement, files) {
       fs.writeFileSync(file, result, 'utf8');
   });
 
-  return new common.ShellString(sed.join('\n'), common.state.error);
+  return new common.ShellString(sed.join('\n'), common.state.error, common.state.errorCode);
 }
 module.exports = _sed;

--- a/src/touch.js
+++ b/src/touch.js
@@ -42,6 +42,7 @@ function _touch(opts, files) {
   files.forEach(function(f) {
     touchFile(opts, f);
   });
+  return new common.ShellString('', common.state.error, common.state.errorCode);
 }
 
 function touchFile(opts, file) {

--- a/src/which.js
+++ b/src/which.js
@@ -93,6 +93,6 @@ function _which(options, cmd) {
 
   where = where || path.resolve(cmd);
 
-  return new common.ShellString(where);
+  return new common.ShellString(where, '', common.state.errorCode);
 }
 module.exports = _which;

--- a/test/cat.js
+++ b/test/cat.js
@@ -12,34 +12,42 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-shell.cat();
+var result = shell.cat();
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'cat: no paths given');
 
 assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
-shell.cat('/adsfasdf'); // file does not exist
+result = shell.cat('/asdfasdf'); // file does not exist
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'cat: no such file or directory: /asdfasdf');
 
 //
 // Valids
 //
 
 // simple
-var result = shell.cat('resources/cat/file1');
+result = shell.cat('resources/cat/file1');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result, 'test1\n');
 
 // multiple files
-var result = shell.cat('resources/cat/file2', 'resources/cat/file1');
+result = shell.cat('resources/cat/file2', 'resources/cat/file1');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result, 'test2\ntest1\n');
 
 // multiple files, array syntax
-var result = shell.cat(['resources/cat/file2', 'resources/cat/file1']);
+result = shell.cat(['resources/cat/file2', 'resources/cat/file1']);
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result, 'test2\ntest1\n');
 
-var result = shell.cat('resources/file*.txt');
+result = shell.cat('resources/file*.txt');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.ok(result.search('test1') > -1); // file order might be random
 assert.ok(result.search('test2') > -1);
 

--- a/test/cd.js
+++ b/test/cd.js
@@ -18,61 +18,75 @@ shell.mkdir('tmp');
 //
 
 assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
-shell.cd('/adsfasdf'); // dir does not exist
+var result = shell.cd('/asdfasdf'); // dir does not exist
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'cd: no such file or directory: /asdfasdf');
 
 assert.equal(fs.existsSync('resources/file1'), true); // sanity check
-shell.cd('resources/file1'); // file, not dir
+result = shell.cd('resources/file1'); // file, not dir
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'cd: not a directory: resources/file1');
 
-shell.cd('-'); // Haven't changed yet, so there is no previous directory
+result = shell.cd('-'); // Haven't changed yet, so there is no previous directory
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'cd: could not find previous directory');
 
 //
 // Valids
 //
 
-shell.cd(cur);
-shell.cd('tmp');
+result = shell.cd(cur);
+result = shell.cd('tmp');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(path.basename(process.cwd()), 'tmp');
 
-shell.cd(cur);
-shell.cd('/');
+result = shell.cd(cur);
+result = shell.cd('/');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(process.cwd(), path.resolve('/'));
 
-shell.cd(cur);
-shell.cd('/');
-shell.cd('-');
+result = shell.cd(cur);
+result = shell.cd('/');
+result = shell.cd('-');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(process.cwd(), path.resolve(cur.toString()));
 
 // cd + other commands
 
-shell.cd(cur);
-shell.rm('-f', 'tmp/*');
+result = shell.cd(cur);
+result = shell.rm('-f', 'tmp/*');
 assert.equal(fs.existsSync('tmp/file1'), false);
-shell.cd('resources');
+result = shell.cd('resources');
 assert.equal(shell.error(), null);
-shell.cp('file1', '../tmp');
+assert.equal(result.code, 0);
+result = shell.cp('file1', '../tmp');
 assert.equal(shell.error(), null);
-shell.cd('../tmp');
+assert.equal(result.code, 0);
+result = shell.cd('../tmp');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('file1'), true);
 
 // Test tilde expansion
 
-shell.cd('~');
+result = shell.cd('~');
 assert.equal(process.cwd(), common.getUserHome());
-shell.cd('..');
-shell.cd('~'); // Change back to home
+result = shell.cd('..');
+assert.notEqual(process.cwd(), common.getUserHome());
+result = shell.cd('~'); // Change back to home
 assert.equal(process.cwd(), common.getUserHome());
 
 // Goes to home directory if no arguments are passed
-shell.cd(cur);
-shell.cd();
+result = shell.cd(cur);
+result = shell.cd();
 assert.ok(!shell.error());
+assert.equal(result.code, 0);
 assert.equal(process.cwd(), common.getUserHome());
 
 shell.exit(123);

--- a/test/chmod.js
+++ b/test/chmod.js
@@ -10,10 +10,12 @@ shell.config.silent = true;
 // Invalids
 //
 
-shell.chmod('blah');  // missing args
+var result = shell.chmod('blah');  // missing args
 assert.ok(shell.error());
-shell.chmod('893', 'resources/chmod');  // invalid permissions - mode must be in octal
+assert.equal(result.code, 1);
+result = shell.chmod('893', 'resources/chmod');  // invalid permissions - mode must be in octal
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
 //
 // Valids
@@ -24,119 +26,171 @@ if (common.platform === 'win')
     shell.exit(123);
 
 // Test files - the bitmasking is to ignore the upper bits.
-shell.chmod('755', 'resources/chmod/file1');
+result = shell.chmod('755', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('777', 8), parseInt('755', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('777', 8), parseInt('644', 8));
 
-shell.chmod('o+x', 'resources/chmod/file1');
+result = shell.chmod('o+x', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('007', 8), parseInt('005', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
-shell.chmod('+x', 'resources/chmod/file1');
+result = shell.chmod('+x', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('777', 8), parseInt('755', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
 // Test setuid
-shell.chmod('u+s', 'resources/chmod/file1');
+result = shell.chmod('u+s', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('4000', 8), parseInt('4000', 8));
-shell.chmod('u-s', 'resources/chmod/file1');
+result = shell.chmod('u-s', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('777', 8), parseInt('644', 8));
 
 // according to POSIX standards at http://linux.die.net/man/1/chmod,
 // setuid is never cleared from a directory unless explicitly asked for.
-shell.chmod('u+s', 'resources/chmod/c');
-shell.chmod('755', 'resources/chmod/c');
+result = shell.chmod('u+s', 'resources/chmod/c');
+assert.equal(result.code, 0);
+result = shell.chmod('755', 'resources/chmod/c');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/c').mode & parseInt('4000', 8), parseInt('4000', 8));
-shell.chmod('u-s', 'resources/chmod/c');
+result = shell.chmod('u-s', 'resources/chmod/c');
+assert.equal(result.code, 0);
 
 // Test setgid
-shell.chmod('g+s', 'resources/chmod/file1');
+result = shell.chmod('g+s', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('2000', 8), parseInt('2000', 8));
-shell.chmod('g-s', 'resources/chmod/file1');
+result = shell.chmod('g-s', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('777', 8), parseInt('644', 8));
 
 // Test sticky bit
-shell.chmod('+t', 'resources/chmod/file1');
+result = shell.chmod('+t', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('1000', 8), parseInt('1000', 8));
-shell.chmod('-t', 'resources/chmod/file1');
+result = shell.chmod('-t', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('777', 8), parseInt('644', 8));
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('1000', 8), 0);
 
 // Test directories
-shell.chmod('a-w', 'resources/chmod/b/a/b');
+result = shell.chmod('a-w', 'resources/chmod/b/a/b');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/b/a/b').mode & parseInt('777', 8), parseInt('555', 8));
-shell.chmod('755', 'resources/chmod/b/a/b');
+result = shell.chmod('755', 'resources/chmod/b/a/b');
+assert.equal(result.code, 0);
 
 // Test recursion
-shell.chmod('-R', 'a+w', 'resources/chmod/b');
+result = shell.chmod('-R', 'a+w', 'resources/chmod/b');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/b/a/b').mode & parseInt('777', 8), parseInt('777', 8));
-shell.chmod('-R', '755', 'resources/chmod/b');
+result = shell.chmod('-R', '755', 'resources/chmod/b');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/b/a/b').mode & parseInt('777', 8), parseInt('755', 8));
 
 // Test symbolic links w/ recursion  - WARNING: *nix only
 fs.symlinkSync('resources/chmod/b/a', 'resources/chmod/a/b/c/link', 'dir');
-shell.chmod('-R', 'u-w', 'resources/chmod/a/b');
+result = shell.chmod('-R', 'u-w', 'resources/chmod/a/b');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/a/b/c').mode & parseInt('700', 8), parseInt('500', 8));
 assert.equal(fs.statSync('resources/chmod/b/a').mode & parseInt('700', 8), parseInt('700', 8));
-shell.chmod('-R', 'u+w', 'resources/chmod/a/b');
+result = shell.chmod('-R', 'u+w', 'resources/chmod/a/b');
+assert.equal(result.code, 0);
 fs.unlinkSync('resources/chmod/a/b/c/link');
 
 // Test combinations
-shell.chmod('a-rwx', 'resources/chmod/file1');
+result = shell.chmod('a-rwx', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('000', 8), parseInt('000', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
-shell.chmod('a-rwx,u+r', 'resources/chmod/file1');
+result = shell.chmod('a-rwx,u+r', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('400', 8), parseInt('400', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
-shell.chmod('a-rwx,u+rw', 'resources/chmod/file1');
+result = shell.chmod('a-rwx,u+rw', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('600', 8), parseInt('600', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
-shell.chmod('a-rwx,u+rwx', 'resources/chmod/file1');
+result = shell.chmod('a-rwx,u+rwx', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('700', 8), parseInt('700', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
-shell.chmod('000', 'resources/chmod/file1');
-shell.chmod('u+rw', 'resources/chmod/file1');
+result = shell.chmod('000', 'resources/chmod/file1');
+assert.equal(result.code, 0);
+result = shell.chmod('u+rw', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('600', 8), parseInt('600', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
-shell.chmod('000', 'resources/chmod/file1');
-shell.chmod('u+wx', 'resources/chmod/file1');
+result = shell.chmod('000', 'resources/chmod/file1');
+assert.equal(result.code, 0);
+result = shell.chmod('u+wx', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('300', 8), parseInt('300', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
-shell.chmod('000', 'resources/chmod/file1');
-shell.chmod('u+r,g+w,o+x', 'resources/chmod/file1');
+result = shell.chmod('000', 'resources/chmod/file1');
+assert.equal(result.code, 0);
+result = shell.chmod('u+r,g+w,o+x', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('421', 8), parseInt('421', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
-shell.chmod('000', 'resources/chmod/file1');
-shell.chmod('u+rw,g+wx', 'resources/chmod/file1');
+result = shell.chmod('000', 'resources/chmod/file1');
+assert.equal(result.code, 0);
+result = shell.chmod('u+rw,g+wx', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('630', 8), parseInt('630', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
-shell.chmod('700', 'resources/chmod/file1');
-shell.chmod('u-x,g+rw', 'resources/chmod/file1');
+result = shell.chmod('700', 'resources/chmod/file1');
+assert.equal(result.code, 0);
+result = shell.chmod('u-x,g+rw', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('660', 8), parseInt('660', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
-shell.chmod('a-rwx,u+rw', 'resources/chmod/file1');
+result = shell.chmod('a-rwx,u+rw', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('600', 8), parseInt('600', 8));
-shell.chmod('a-rwx,u+rw', 'resources/chmod/file1');
+result = shell.chmod('a-rwx,u+rw', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('600', 8), parseInt('600', 8));
-shell.chmod('644', 'resources/chmod/file1');
+result = shell.chmod('644', 'resources/chmod/file1');
+assert.equal(result.code, 0);
 
 // Support capital X ("entry" permission aka directory-only execute)
 
-shell.chmod('744', 'resources/chmod/xdir');
-shell.chmod('644', 'resources/chmod/xdir/file');
-shell.chmod('744', 'resources/chmod/xdir/deep');
-shell.chmod('644', 'resources/chmod/xdir/deep/file');
-shell.chmod('-R', 'a+X', 'resources/chmod/xdir');
+result = shell.chmod('744', 'resources/chmod/xdir');
+assert.equal(result.code, 0);
+result = shell.chmod('644', 'resources/chmod/xdir/file');
+assert.equal(result.code, 0);
+result = shell.chmod('744', 'resources/chmod/xdir/deep');
+assert.equal(result.code, 0);
+result = shell.chmod('644', 'resources/chmod/xdir/deep/file');
+assert.equal(result.code, 0);
+result = shell.chmod('-R', 'a+X', 'resources/chmod/xdir');
+assert.equal(result.code, 0);
 
 assert.equal(fs.statSync('resources/chmod/xdir').mode & parseInt('755', 8), parseInt('755', 8));
 assert.equal(fs.statSync('resources/chmod/xdir/file').mode & parseInt('644', 8), parseInt('644', 8));

--- a/test/cp.js
+++ b/test/cp.js
@@ -14,99 +14,136 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-shell.cp();
+var result = shell.cp();
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'cp: missing <source> and/or <dest>');
 
-shell.cp('file1');
+result = shell.cp('file1');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'cp: missing <source> and/or <dest>');
 
-shell.cp('-f');
+result = shell.cp('-f');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'cp: missing <source> and/or <dest>');
 
 shell.rm('-rf', 'tmp/*');
-shell.cp('-@', 'resources/file1', 'tmp/file1'); // option not supported, files OK
+result = shell.cp('-@', 'resources/file1', 'tmp/file1'); // option not supported, files OK
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 assert.equal(fs.existsSync('tmp/file1'), false);
+assert.equal(result.stderr, 'cp: option not recognized: @');
 
-shell.cp('-Z', 'asdfasdf', 'tmp/file2'); // option not supported, files NOT OK
+result = shell.cp('-Z', 'asdfasdf', 'tmp/file2'); // option not supported, files NOT OK
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 assert.equal(fs.existsSync('tmp/file2'), false);
+assert.equal(result.stderr, 'cp: option not recognized: Z');
 
-shell.cp('asdfasdf', 'tmp'); // source does not exist
+result = shell.cp('asdfasdf', 'tmp'); // source does not exist
 assert.ok(shell.error());
-assert.equal(numLines(shell.error()), 1);
+assert.equal(result.code, 1);
+assert.equal(numLines(result.stderr), 1);
 assert.equal(fs.existsSync('tmp/asdfasdf'), false);
+assert.equal(result.stderr, 'cp: no such file or directory: asdfasdf');
 
-shell.cp('asdfasdf1', 'asdfasdf2', 'tmp'); // sources do not exist
+result = shell.cp('asdfasdf1', 'asdfasdf2', 'tmp'); // sources do not exist
 assert.ok(shell.error());
-assert.equal(numLines(shell.error()), 2);
+assert.equal(result.code, 1);
+assert.equal(numLines(result.stderr), 2);
 assert.equal(fs.existsSync('tmp/asdfasdf1'), false);
 assert.equal(fs.existsSync('tmp/asdfasdf2'), false);
+assert.equal(result.stderr, 'cp: no such file or directory: asdfasdf1\ncp: no such file or directory: asdfasdf2');
 
-shell.cp('asdfasdf1', 'asdfasdf2', 'resources/file1'); // too many sources (dest is file)
+result = shell.cp('asdfasdf1', 'asdfasdf2', 'resources/file1'); // too many sources (dest is file)
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'cp: dest is not a directory (too many sources)');
 
-shell.cp('-n', 'resources/file1', 'resources/file2'); // dest already exists
+result = shell.cp('-n', 'resources/file1', 'resources/file2'); // dest already exists
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'cp: dest file already exists: resources/file2');
 
-shell.cp('resources/file1', 'resources/file2', 'tmp/a_file'); // too many sources
+result = shell.cp('resources/file1', 'resources/file2', 'tmp/a_file'); // too many sources
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 assert.equal(fs.existsSync('tmp/a_file'), false);
+assert.equal(result.stderr, 'cp: dest is not a directory (too many sources)');
 
 //
 // Valids
 //
 
 // -f by default
-shell.cp('resources/file2', 'resources/copyfile2');
-shell.cp('resources/file1', 'resources/file2'); // dest already exists
+result = shell.cp('resources/file2', 'resources/copyfile2');
+result = shell.cp('resources/file1', 'resources/file2'); // dest already exists
 assert.ok(!shell.error());
+assert.equal(result.code, 0);
+assert.ok(!result.stderr);
 assert.equal(shell.cat('resources/file1') + '', shell.cat('resources/file2') + ''); // after cp
 shell.mv('resources/copyfile2', 'resources/file2'); // restore
 assert.ok(!shell.error());
 
 // -f (explicitly)
-shell.cp('resources/file2', 'resources/copyfile2');
-shell.cp('-f', 'resources/file1', 'resources/file2'); // dest already exists
+result = shell.cp('resources/file2', 'resources/copyfile2');
+result = shell.cp('-f', 'resources/file1', 'resources/file2'); // dest already exists
 assert.ok(!shell.error());
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.equal(shell.cat('resources/file1') + '', shell.cat('resources/file2') + ''); // after cp
 shell.mv('resources/copyfile2', 'resources/file2'); // restore
 assert.ok(!shell.error());
+assert.equal(result.code, 0);
 
 // simple - to dir
-shell.cp('resources/file1', 'tmp');
+result = shell.cp('resources/file1', 'tmp');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/file1'), true);
 
 // simple - to file
-shell.cp('resources/file2', 'tmp/file2');
+result = shell.cp('resources/file2', 'tmp/file2');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/file2'), true);
 
 // simple - file list
 shell.rm('-rf', 'tmp/*');
-shell.cp('resources/file1', 'resources/file2', 'tmp');
+result = shell.cp('resources/file1', 'resources/file2', 'tmp');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/file1'), true);
 assert.equal(fs.existsSync('tmp/file2'), true);
 
 // simple - file list, array syntax
 shell.rm('-rf', 'tmp/*');
-shell.cp(['resources/file1', 'resources/file2'], 'tmp');
+result = shell.cp(['resources/file1', 'resources/file2'], 'tmp');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/file1'), true);
 assert.equal(fs.existsSync('tmp/file2'), true);
 
-shell.cp('resources/file2', 'tmp/file3');
+result = shell.cp('resources/file2', 'tmp/file3');
 assert.equal(fs.existsSync('tmp/file3'), true);
-shell.cp('-f', 'resources/file2', 'tmp/file3'); // file exists, but -f specified
+result = shell.cp('-f', 'resources/file2', 'tmp/file3'); // file exists, but -f specified
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/file3'), true);
 
 // glob
 shell.rm('-rf', 'tmp/*');
-shell.cp('resources/file?', 'tmp');
+result = shell.cp('resources/file?', 'tmp');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.ok(fs.existsSync('tmp/file1'));
 assert.ok(fs.existsSync('tmp/file2'));
 assert.ok(!fs.existsSync('tmp/file1.js'));
@@ -116,8 +153,10 @@ assert.ok(!fs.existsSync('tmp/file2.txt'));
 
 // wildcard
 shell.rm('tmp/file1', 'tmp/file2');
-shell.cp('resources/file*', 'tmp');
+result = shell.cp('resources/file*', 'tmp');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.ok(fs.existsSync('tmp/file1'));
 assert.ok(fs.existsSync('tmp/file2'));
 assert.ok(fs.existsSync('tmp/file1.js'));
@@ -127,74 +166,94 @@ assert.ok(fs.existsSync('tmp/file2.txt'));
 
 // recursive, with regular files
 shell.rm('-rf', 'tmp/*');
-shell.cp('-R', 'resources/file1', 'resources/file2', 'tmp');
+result = shell.cp('-R', 'resources/file1', 'resources/file2', 'tmp');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.ok(fs.existsSync('tmp/file1'));
 assert.ok(fs.existsSync('tmp/file2'));
 
 // recursive, nothing exists
 shell.rm('-rf', 'tmp/*');
-shell.cp('-R', 'resources/cp', 'tmp');
+result = shell.cp('-R', 'resources/cp', 'tmp');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.equal(shell.ls('-R', 'resources/cp') + '', shell.ls('-R', 'tmp/cp') + '');
 
 //recursive, nothing exists, source ends in '/' (see Github issue #15)
 shell.rm('-rf', 'tmp/*');
-shell.cp('-R', 'resources/cp/', 'tmp/');
+result = shell.cp('-R', 'resources/cp/', 'tmp/');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.equal(shell.ls('-R', 'resources/cp') + '', shell.ls('-R', 'tmp/cp') + '');
 
 // recursive, globbing regular files with extension (see Github issue #376)
 shell.rm('-rf', 'tmp/*');
-shell.cp('-R', 'resources/file*.txt', 'tmp');
+result = shell.cp('-R', 'resources/file*.txt', 'tmp');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.ok(fs.existsSync('tmp/file1.txt'));
 assert.ok(fs.existsSync('tmp/file2.txt'));
 
 // recursive, copying one regular file (also related to Github issue #376)
 shell.rm('-rf', 'tmp/*');
-shell.cp('-R', 'resources/file1.txt', 'tmp');
+result = shell.cp('-R', 'resources/file1.txt', 'tmp');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.ok(fs.existsSync('tmp/file1.txt'));
 assert.ok(!fs.statSync('tmp/file1.txt').isDirectory()); // don't let it be a dir
 
 //recursive, everything exists, no force flag
 shell.rm('-rf', 'tmp/*');
-shell.cp('-R', 'resources/cp', 'tmp');
-shell.cp('-R', 'resources/cp', 'tmp');
+result = shell.cp('-R', 'resources/cp', 'tmp');
+result = shell.cp('-R', 'resources/cp', 'tmp');
 assert.equal(shell.error(), null); // crash test only
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 
 //recursive, everything exists, with force flag
 shell.rm('-rf', 'tmp/*');
-shell.cp('-R', 'resources/cp', 'tmp');
+result = shell.cp('-R', 'resources/cp', 'tmp');
 shell.ShellString('changing things around').to('tmp/cp/dir_a/z');
 assert.notEqual(shell.cat('resources/cp/dir_a/z') + '', shell.cat('tmp/cp/dir_a/z') + ''); // before cp
-shell.cp('-Rf', 'resources/cp', 'tmp');
+result = shell.cp('-Rf', 'resources/cp', 'tmp');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.equal(shell.cat('resources/cp/dir_a/z') + '', shell.cat('tmp/cp/dir_a/z') + ''); // after cp
 
 //recursive, creates dest dir since it's only one level deep (see Github issue #44)
 shell.rm('-rf', 'tmp/*');
-shell.cp('-r', 'resources/issue44', 'tmp/dir2');
+result = shell.cp('-r', 'resources/issue44', 'tmp/dir2');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.equal(shell.ls('-R', 'resources/issue44') + '', shell.ls('-R', 'tmp/dir2') + '');
 assert.equal(shell.cat('resources/issue44/main.js') + '', shell.cat('tmp/dir2/main.js') + '');
 
 //recursive, does *not* create dest dir since it's too deep (see Github issue #44)
 shell.rm('-rf', 'tmp/*');
-shell.cp('-r', 'resources/issue44', 'tmp/dir2/dir3');
+result = shell.cp('-r', 'resources/issue44', 'tmp/dir2/dir3');
 assert.ok(shell.error());
+assert.equal(result.stderr, 'cp: cannot create directory \'tmp/dir2/dir3\': No such file or directory');
+assert.equal(result.code, 1);
 assert.equal(fs.existsSync('tmp/dir2'), false);
 
 //recursive, copies entire directory
 shell.rm('-rf', 'tmp/*');
-shell.cp('-r', 'resources/cp/dir_a', 'tmp/dest');
+result = shell.cp('-r', 'resources/cp/dir_a', 'tmp/dest');
 assert.equal(shell.error(), null);
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/dest/z'), true);
 
 //recursive, with trailing slash, does the exact same
 shell.rm('-rf', 'tmp/*');
-shell.cp('-r', 'resources/cp/dir_a/', 'tmp/dest');
+result = shell.cp('-r', 'resources/cp/dir_a/', 'tmp/dest');
 assert.equal(shell.error(), null);
 assert.equal(fs.existsSync('tmp/dest/z'), true);
 
@@ -210,14 +269,16 @@ if (common.platform !== 'win') {
 
 // Make sure hidden files are copied recursively
 shell.rm('-rf', 'tmp/');
-shell.cp('-r', 'resources/ls/', 'tmp/');
+result = shell.cp('-r', 'resources/ls/', 'tmp/');
 assert.ok(!shell.error());
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 assert.ok(fs.existsSync('tmp/.hidden_file'));
 
 // no-recursive will copy regular files only
 shell.rm('-rf', 'tmp/');
 shell.mkdir('tmp/');
-shell.cp('resources/file1.txt', 'resources/ls/', 'tmp/');
+result = shell.cp('resources/file1.txt', 'resources/ls/', 'tmp/');
 assert.ok(shell.error());
 assert.ok(!fs.existsSync('tmp/.hidden_file')); // doesn't copy dir contents
 assert.ok(!fs.existsSync('tmp/ls')); // doesn't copy dir itself
@@ -226,7 +287,7 @@ assert.ok(fs.existsSync('tmp/file1.txt'));
 // no-recursive will copy regular files only
 shell.rm('-rf', 'tmp/');
 shell.mkdir('tmp/');
-shell.cp('resources/file1.txt', 'resources/file2.txt', 'resources/cp',
+result = shell.cp('resources/file1.txt', 'resources/file2.txt', 'resources/cp',
     'resources/ls/', 'tmp/');
 assert.ok(shell.error());
 assert.ok(!fs.existsSync('tmp/.hidden_file')); // doesn't copy dir contents

--- a/test/find.js
+++ b/test/find.js
@@ -12,6 +12,7 @@ shell.mkdir('tmp');
 //
 
 var result = shell.find(); // no paths given
+assert.equal(result.code, 1);
 assert.ok(shell.error());
 
 //
@@ -20,30 +21,34 @@ assert.ok(shell.error());
 
 // current path
 shell.cd('resources/find');
-var result = shell.find('.');
+result = shell.find('.');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('.hidden') > -1, true);
 assert.equal(result.indexOf('dir1/dir11/a_dir11') > -1, true);
 assert.equal(result.length, 11);
 shell.cd('../..');
 
 // simple path
-var result = shell.find('resources/find');
+result = shell.find('resources/find');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('resources/find/.hidden') > -1, true);
 assert.equal(result.indexOf('resources/find/dir1/dir11/a_dir11') > -1, true);
 assert.equal(result.length, 11);
 
 // multiple paths - comma
-var result = shell.find('resources/find/dir1', 'resources/find/dir2');
+result = shell.find('resources/find/dir1', 'resources/find/dir2');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('resources/find/dir1/dir11/a_dir11') > -1, true);
 assert.equal(result.indexOf('resources/find/dir2/a_dir1') > -1, true);
 assert.equal(result.length, 6);
 
 // multiple paths - array
-var result = shell.find(['resources/find/dir1', 'resources/find/dir2']);
+result = shell.find(['resources/find/dir1', 'resources/find/dir2']);
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('resources/find/dir1/dir11/a_dir11') > -1, true);
 assert.equal(result.indexOf('resources/find/dir2/a_dir1') > -1, true);
 assert.equal(result.length, 6);

--- a/test/grep.js
+++ b/test/grep.js
@@ -12,23 +12,28 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-shell.grep();
+var result = shell.grep();
 assert.ok(shell.error());
+assert.equal(result.code, 2);
 
-shell.grep(/asdf/g); // too few args
+result = shell.grep(/asdf/g); // too few args
 assert.ok(shell.error());
+assert.equal(result.code, 2);
 
 assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
-shell.grep(/asdf/g, '/asdfasdf'); // no such file
+result = shell.grep(/asdf/g, '/asdfasdf'); // no such file
 assert.ok(shell.error());
+assert.equal(result.stderr, 'grep: no such file or directory: /asdfasdf');
+assert.equal(result.code, 2);
 
 // if at least one file is missing, this should be an error
 shell.cp('-f', 'resources/file1', 'tmp/file1');
 assert.equal(fs.existsSync('asdfasdf'), false); // sanity check
 assert.equal(fs.existsSync('tmp/file1'), true); // sanity check
-var result = shell.grep(/asdf/g, 'tmp/file1', 'asdfasdf');
+result = shell.grep(/asdf/g, 'tmp/file1', 'asdfasdf');
 assert.ok(shell.error());
 assert.equal(result.stderr, 'grep: no such file or directory: asdfasdf');
+assert.equal(result.code, 2);
 
 //
 // Valids

--- a/test/ln.js
+++ b/test/ln.js
@@ -31,35 +31,43 @@ shell.cp('resources/*', 'tmp');
 // Invalids
 //
 
-shell.ln();
+var result = shell.ln();
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
-shell.ln('file');
+result = shell.ln('file');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
-shell.ln('-f');
+result = shell.ln('-f');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
-shell.ln('tmp/file1', 'tmp/file2');
+result = shell.ln('tmp/file1', 'tmp/file2');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
-shell.ln('tmp/noexist', 'tmp/linkfile1');
+result = shell.ln('tmp/noexist', 'tmp/linkfile1');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
-shell.ln('-sf', 'no/exist', 'tmp/badlink');
+result = shell.ln('-sf', 'no/exist', 'tmp/badlink');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
-shell.ln('-sf', 'noexist', 'tmp/badlink');
+result = shell.ln('-sf', 'noexist', 'tmp/badlink');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
-shell.ln('-f', 'noexist', 'tmp/badlink');
+result = shell.ln('-f', 'noexist', 'tmp/badlink');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
 //
 // Valids
 //
 
-shell.ln('tmp/file1', 'tmp/linkfile1');
+result = shell.ln('tmp/file1', 'tmp/linkfile1');
 assert(fs.existsSync('tmp/linkfile1'));
 assert.equal(
   fs.readFileSync('tmp/file1').toString(),
@@ -70,10 +78,11 @@ assert.equal(
   fs.readFileSync('tmp/linkfile1').toString(),
   'new content 1'
 );
+assert.equal(result.code, 0);
 
 // With glob
 shell.rm('tmp/linkfile1');
-shell.ln('tmp/fi*1', 'tmp/linkfile1');
+result = shell.ln('tmp/fi*1', 'tmp/linkfile1');
 assert(fs.existsSync('tmp/linkfile1'));
 assert.equal(
   fs.readFileSync('tmp/file1').toString(),
@@ -84,6 +93,7 @@ assert.equal(
   fs.readFileSync('tmp/linkfile1').toString(),
   'new content 1'
 );
+assert.equal(result.code, 0);
 
 skipOnWinForEPERM(shell.ln.bind(shell, '-s', 'file2', 'tmp/linkfile2'), function () {
     assert(fs.existsSync('tmp/linkfile2'));
@@ -101,20 +111,23 @@ skipOnWinForEPERM(shell.ln.bind(shell, '-s', 'file2', 'tmp/linkfile2'), function
 // Symbolic link directory test
 shell.mkdir('tmp/ln');
 shell.touch('tmp/ln/hello');
-shell.ln('-s', 'ln', 'tmp/dir1');
+result = shell.ln('-s', 'ln', 'tmp/dir1');
 assert(fs.existsSync('tmp/ln/hello'));
 assert(fs.existsSync('tmp/dir1/hello'));
+assert.equal(result.code, 0);
 
 // To current directory
 shell.cd('tmp');
-shell.ln('-s', './', 'dest');
+result = shell.ln('-s', './', 'dest');
+assert.equal(result.code, 0);
 shell.touch('testfile.txt');
 assert(fs.existsSync('testfile.txt'));
 assert(fs.existsSync('dest/testfile.txt'));
 shell.rm('-f', 'dest');
 shell.mkdir('dir1');
 shell.cd('dir1');
-shell.ln('-s', './', '../dest');
+result = shell.ln('-s', './', '../dest');
+assert.equal(result.code, 0);
 shell.touch('insideDir.txt');
 shell.cd('..');
 assert(fs.existsSync('testfile.txt'));
@@ -123,7 +136,8 @@ assert(fs.existsSync('dir1/insideDir.txt'));
 assert(!fs.existsSync('dest/insideDir.txt'));
 shell.cd('..');
 
-shell.ln('-f', 'tmp/file1.js', 'tmp/file2.js');
+result = shell.ln('-f', 'tmp/file1.js', 'tmp/file2.js');
+assert.equal(result.code, 0);
 assert(fs.existsSync('tmp/file2.js'));
 assert.equal(
   fs.readFileSync('tmp/file1.js').toString(),

--- a/test/ls.js
+++ b/test/ls.js
@@ -9,15 +9,15 @@ shell.rm('-rf', 'tmp');
 shell.mkdir('tmp');
 
 var idx;
-var result;
 
 //
 // Invalids
 //
 
 assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
-result = shell.ls('/asdfasdf'); // no such file or dir
+var result = shell.ls('/asdfasdf'); // no such file or dir
 assert.ok(shell.error());
+assert.equal(result.code, 2);
 assert.equal(result.length, 0);
 
 //
@@ -26,14 +26,17 @@ assert.equal(result.length, 0);
 
 result = shell.ls();
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 
 result = shell.ls('/');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 
 // no args
 shell.cd('resources/ls');
 result = shell.ls();
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('file1') > -1, true);
 assert.equal(result.indexOf('file2') > -1, true);
 assert.equal(result.indexOf('file1.js') > -1, true);
@@ -46,6 +49,7 @@ shell.cd('../..');
 // simple arg
 result = shell.ls('resources/ls');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('file1') > -1, true);
 assert.equal(result.indexOf('file2') > -1, true);
 assert.equal(result.indexOf('file1.js') > -1, true);
@@ -58,6 +62,7 @@ assert.equal(result.length, 6);
 shell.cd('resources/ls');
 result = shell.ls('-A');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('file1') > -1, true);
 assert.equal(result.indexOf('file2') > -1, true);
 assert.equal(result.indexOf('file1.js') > -1, true);
@@ -73,6 +78,7 @@ shell.cd('../..');
 shell.cd('resources/ls');
 result = shell.ls('-a'); // (deprecated) backwards compatibility test
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('file1') > -1, true);
 assert.equal(result.indexOf('file2') > -1, true);
 assert.equal(result.indexOf('file1.js') > -1, true);
@@ -87,6 +93,7 @@ shell.cd('../..');
 // wildcard, very simple
 result = shell.ls('resources/cat/*');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('resources/cat/file1') > -1, true);
 assert.equal(result.indexOf('resources/cat/file2') > -1, true);
 assert.equal(result.length, 2);
@@ -94,6 +101,7 @@ assert.equal(result.length, 2);
 // wildcard, simple
 result = shell.ls('resources/ls/*');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('resources/ls/file1') > -1, true);
 assert.equal(result.indexOf('resources/ls/file2') > -1, true);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
@@ -107,6 +115,7 @@ assert.equal(result.length, 7);
 // wildcard, simple, with -d
 result = shell.ls('-d', 'resources/ls/*');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('resources/ls/file1') > -1, true);
 assert.equal(result.indexOf('resources/ls/file2') > -1, true);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
@@ -118,6 +127,7 @@ assert.equal(result.length, 6);
 // wildcard, hidden only
 result = shell.ls('-d', 'resources/ls/.*');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('resources/ls/.hidden_file') > -1, true);
 assert.equal(result.indexOf('resources/ls/.hidden_dir') > -1, true);
 assert.equal(result.length, 2);
@@ -125,6 +135,7 @@ assert.equal(result.length, 2);
 // wildcard, mid-file
 result = shell.ls('resources/ls/f*le*');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.length, 5);
 assert.equal(result.indexOf('resources/ls/file1') > -1, true);
 assert.equal(result.indexOf('resources/ls/file2') > -1, true);
@@ -135,6 +146,7 @@ assert.equal(result.indexOf('resources/ls/filename(with)[chars$]^that.must+be-es
 // wildcard, mid-file with dot (should escape dot for regex)
 result = shell.ls('resources/ls/f*le*.js');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.length, 2);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
 assert.equal(result.indexOf('resources/ls/file2.js') > -1, true);
@@ -142,17 +154,27 @@ assert.equal(result.indexOf('resources/ls/file2.js') > -1, true);
 // one file that exists, one that doesn't
 result = shell.ls('resources/ls/file1.js', 'resources/ls/thisdoesntexist');
 assert.ok(shell.error());
+assert.equal(result.code, 2);
+assert.equal(result.length, 1);
+assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
+
+// one file that exists, one that doesn't (other order)
+result = shell.ls('resources/ls/thisdoesntexist', 'resources/ls/file1.js');
+assert.ok(shell.error());
+assert.equal(result.code, 2);
 assert.equal(result.length, 1);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
 
 // wildcard, should not do partial matches
 result = shell.ls('resources/ls/*.j'); // shouldn't get .js
 assert.ok(shell.error());
+assert.equal(result.code, 2);
 assert.equal(result.length, 0);
 
 // wildcard, all files with extension
 result = shell.ls('resources/ls/*.*');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.length, 3);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
 assert.equal(result.indexOf('resources/ls/file2.js') > -1, true);
@@ -161,6 +183,7 @@ assert.equal(result.indexOf('resources/ls/filename(with)[chars$]^that.must+be-es
 // wildcard, with additional path
 result = shell.ls('resources/ls/f*le*.js', 'resources/ls/a_dir');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.length, 4);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
 assert.equal(result.indexOf('resources/ls/file2.js') > -1, true);
@@ -170,6 +193,7 @@ assert.equal(result.indexOf('nada') > -1, true); // no wildcard == no path prefi
 // wildcard for both paths
 result = shell.ls('resources/ls/f*le*.js', 'resources/ls/a_dir/*');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.length, 4);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
 assert.equal(result.indexOf('resources/ls/file2.js') > -1, true);
@@ -179,6 +203,7 @@ assert.equal(result.indexOf('resources/ls/a_dir/nada') > -1, true);
 // wildcard for both paths, array
 result = shell.ls(['resources/ls/f*le*.js', 'resources/ls/a_dir/*']);
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.length, 4);
 assert.equal(result.indexOf('resources/ls/file1.js') > -1, true);
 assert.equal(result.indexOf('resources/ls/file2.js') > -1, true);
@@ -189,6 +214,7 @@ assert.equal(result.indexOf('resources/ls/a_dir/nada') > -1, true);
 shell.cd('resources/ls');
 result = shell.ls('-R');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('a_dir') > -1, true);
 assert.equal(result.indexOf('a_dir/b_dir') > -1, true);
 assert.equal(result.indexOf('a_dir/b_dir/z') > -1, true);
@@ -198,6 +224,7 @@ shell.cd('../..');
 // recusive, path given
 result = shell.ls('-R', 'resources/ls');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('a_dir') > -1, true);
 assert.equal(result.indexOf('a_dir/b_dir') > -1, true);
 assert.equal(result.indexOf('a_dir/b_dir/z') > -1, true);
@@ -206,6 +233,7 @@ assert.equal(result.length, 9);
 // recusive, path given - 'all' flag
 result = shell.ls('-RA', 'resources/ls');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('a_dir') > -1, true);
 assert.equal(result.indexOf('a_dir/b_dir') > -1, true);
 assert.equal(result.indexOf('a_dir/b_dir/z') > -1, true);
@@ -215,6 +243,7 @@ assert.equal(result.length, 14);
 // recursive, wildcard
 result = shell.ls('-R', 'resources/ls');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.indexOf('a_dir') > -1, true);
 assert.equal(result.indexOf('a_dir/b_dir') > -1, true);
 assert.equal(result.indexOf('a_dir/b_dir/z') > -1, true);
@@ -228,16 +257,19 @@ assert.equal(result.length, 1);
 // directory option, single arg
 result = shell.ls('-d', 'resources/ls');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.length, 1);
 
 // directory option, single arg with trailing '/'
 result = shell.ls('-d', 'resources/ls/');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.length, 1);
 
 // directory option, multiple args
 result = shell.ls('-d', 'resources/ls/a_dir', 'resources/ls/file1');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.ok(result.indexOf('resources/ls/a_dir') > -1);
 assert.ok(result.indexOf('resources/ls/file1') > -1);
 assert.equal(result.length, 2);
@@ -245,6 +277,7 @@ assert.equal(result.length, 2);
 // directory option, globbed arg
 result = shell.ls('-d', 'resources/ls/*');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.ok(result.indexOf('resources/ls/a_dir') > -1);
 assert.ok(result.indexOf('resources/ls/file1') > -1);
 assert.ok(result.indexOf('resources/ls/file1.js') > -1);
@@ -289,6 +322,7 @@ assert.ok(result.toString().match(/^(\d+ +){5}.*$/));
 // long option, directory
 result = shell.ls('-l', 'resources/ls');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 idx = -1;
 for (var k=0; k < result.length; k++) {
   if (result[k].name === 'file1') {
@@ -313,6 +347,7 @@ assert.ok(result.toString().match(/^(\d+ +){5}.*$/));
 // long option, directory, recursive (and windows converts slashes)
 result = shell.ls('-lR', 'resources/ls/');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 idx = -1;
 for (var k=0; k < result.length; k++) {
   if (result[k].name === 'a_dir/b_dir') {
@@ -338,6 +373,7 @@ assert.ok(result.toString().match(/^(\d+ +){5}.*$/));
 // Test new ShellString-like attributes
 result = shell.ls('resources/ls');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.stdout.indexOf('file1') > -1, true);
 assert.equal(result.stdout.indexOf('file2') > -1, true);
 assert.equal(result.stdout.indexOf('file1.js') > -1, true);
@@ -355,6 +391,6 @@ shell.rm('tmp/testingToOutput.txt');
 assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
 result = shell.ls('resources/ls/file1', '/asdfasdf');
 assert.ok(shell.error());
-assert.equal(shell.error(), result.stderr);
+assert.equal('ls: no such file or directory: /asdfasdf', result.stderr);
 
 shell.exit(123);

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -13,68 +13,82 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-shell.mkdir();
+var result = shell.mkdir();
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mkdir: no paths given');
 
 var mtime = fs.statSync('tmp').mtime.toString();
-shell.mkdir('tmp'); // dir already exists
+result = shell.mkdir('tmp'); // dir already exists
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mkdir: path already exists: tmp');
 assert.equal(fs.statSync('tmp').mtime.toString(), mtime); // didn't mess with dir
 
 assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
-shell.mkdir('/asdfasdf/asdfasdf'); // root path does not exist
+result = shell.mkdir('/asdfasdf/foobar'); // root path does not exist
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mkdir: no such file or directory: /asdfasdf');
 assert.equal(fs.existsSync('/asdfasdf'), false);
+assert.equal(fs.existsSync('/asdfasdf/foobar'), false);
 
 //
 // Valids
 //
 
 assert.equal(fs.existsSync('tmp/t1'), false);
-shell.mkdir('tmp/t1'); // simple dir
+result = shell.mkdir('tmp/t1'); // simple dir
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/t1'), true);
 
 assert.equal(fs.existsSync('tmp/t2'), false);
 assert.equal(fs.existsSync('tmp/t3'), false);
-shell.mkdir('tmp/t2', 'tmp/t3'); // multiple dirs
+result = shell.mkdir('tmp/t2', 'tmp/t3'); // multiple dirs
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/t2'), true);
 assert.equal(fs.existsSync('tmp/t3'), true);
 
 assert.equal(fs.existsSync('tmp/t1'), true);
 assert.equal(fs.existsSync('tmp/t4'), false);
-shell.mkdir('tmp/t1', 'tmp/t4'); // one dir exists, one doesn't
+result = shell.mkdir('tmp/t1', 'tmp/t4'); // one dir exists, one doesn't
 assert.equal(numLines(shell.error()), 1);
 assert.equal(fs.existsSync('tmp/t1'), true);
 assert.equal(fs.existsSync('tmp/t4'), true);
 
 assert.equal(fs.existsSync('tmp/a'), false);
-shell.mkdir('-p', 'tmp/a/b/c');
+result = shell.mkdir('-p', 'tmp/a/b/c');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/a/b/c'), true);
 shell.rm('-Rf', 'tmp/a'); // revert
 
 // multiple dirs
-shell.mkdir('-p', 'tmp/zzza', 'tmp/zzzb', 'tmp/zzzc');
+result = shell.mkdir('-p', 'tmp/zzza', 'tmp/zzzb', 'tmp/zzzc');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/zzza'), true);
 assert.equal(fs.existsSync('tmp/zzzb'), true);
 assert.equal(fs.existsSync('tmp/zzzc'), true);
 
 // multiple dirs, array syntax
-shell.mkdir('-p', ['tmp/yyya', 'tmp/yyyb', 'tmp/yyyc']);
+result = shell.mkdir('-p', ['tmp/yyya', 'tmp/yyyb', 'tmp/yyyc']);
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/yyya'), true);
 assert.equal(fs.existsSync('tmp/yyyb'), true);
 assert.equal(fs.existsSync('tmp/yyyc'), true);
 
 // globbed dir
-shell.mkdir('-p', 'tmp/mydir');
+result = shell.mkdir('-p', 'tmp/mydir');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/mydir'), true);
-shell.mkdir('-p', 'tmp/m*ir');
+result = shell.mkdir('-p', 'tmp/m*ir');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/mydir'), true);
 assert.equal(fs.existsSync('tmp/m*ir'), false); // doesn't create literal name
 

--- a/test/mv.js
+++ b/test/mv.js
@@ -16,56 +16,80 @@ shell.cp('resources/*', 'tmp');
 // Invalids
 //
 
-shell.mv();
+var result = shell.mv();
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mv: missing <source> and/or <dest>');
 
-shell.mv('file1');
+result = shell.mv('file1');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mv: missing <source> and/or <dest>');
 
-shell.mv('-f');
+result = shell.mv('-f');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mv: missing <source> and/or <dest>');
 
-shell.mv('-Z', 'tmp/file1', 'tmp/file1'); // option not supported
+result = shell.mv('-Z', 'tmp/file1', 'tmp/file1'); // option not supported
 assert.ok(shell.error());
 assert.equal(fs.existsSync('tmp/file1'), true);
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mv: option not recognized: Z');
 
-shell.mv('asdfasdf', 'tmp'); // source does not exist
+result = shell.mv('asdfasdf', 'tmp'); // source does not exist
 assert.ok(shell.error());
 assert.equal(numLines(shell.error()), 1);
 assert.equal(fs.existsSync('tmp/asdfasdf'), false);
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mv: no such file or directory: asdfasdf');
 
-shell.mv('asdfasdf1', 'asdfasdf2', 'tmp'); // sources do not exist
+result = shell.mv('asdfasdf1', 'asdfasdf2', 'tmp'); // sources do not exist
 assert.ok(shell.error());
 assert.equal(numLines(shell.error()), 2);
 assert.equal(fs.existsSync('tmp/asdfasdf1'), false);
 assert.equal(fs.existsSync('tmp/asdfasdf2'), false);
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mv: no such file or directory: asdfasdf1\nmv: no such file or directory: asdfasdf2');
 
-shell.mv('asdfasdf1', 'asdfasdf2', 'tmp/file1'); // too many sources (dest is file)
+result = shell.mv('asdfasdf1', 'asdfasdf2', 'tmp/file1'); // too many sources (dest is file)
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mv: dest is not a directory (too many sources)');
 
 // -n is no-force/no-clobber
-shell.mv('-n', 'tmp/file1', 'tmp/file2'); // dest already exists
+result = shell.mv('-n', 'tmp/file1', 'tmp/file2'); // dest already exists
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mv: dest file already exists: tmp/file2');
 
 // -f is the default behavior
 shell.cp('tmp/file1', 'tmp/tmp_file');
-shell.mv('tmp/tmp_file', 'tmp/file2'); // dest already exists (but that's ok)
+result = shell.mv('tmp/tmp_file', 'tmp/file2'); // dest already exists (but that's ok)
 assert.ok(!shell.error());
+assert.ok(!result.stderr);
+assert.equal(result.code, 0);
 
 // -fn is the same as -n
-shell.mv('-fn', 'tmp/file1', 'tmp/file2');
+result = shell.mv('-fn', 'tmp/file1', 'tmp/file2');
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mv: dest file already exists: tmp/file2');
 
-shell.mv('tmp/file1', 'tmp/file2', 'tmp/a_file'); // too many sources (exist, but dest is file)
+result = shell.mv('tmp/file1', 'tmp/file2', 'tmp/a_file'); // too many sources (exist, but dest is file)
 assert.ok(shell.error());
 assert.equal(fs.existsSync('tmp/a_file'), false);
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mv: dest is not a directory (too many sources)');
 
-shell.mv('tmp/file*', 'tmp/file1'); // can't use wildcard when dest is file
+result = shell.mv('tmp/file*', 'tmp/file1'); // can't use wildcard when dest is file
 assert.ok(shell.error());
 assert.equal(fs.existsSync('tmp/file1'), true);
 assert.equal(fs.existsSync('tmp/file2'), true);
 assert.equal(fs.existsSync('tmp/file1.js'), true);
 assert.equal(fs.existsSync('tmp/file2.js'), true);
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'mv: dest is not a directory (too many sources)');
 
 //
 // Valids
@@ -75,58 +99,67 @@ shell.cd('tmp');
 
 // handles self OK
 shell.mkdir('tmp2');
-shell.mv('*', 'tmp2'); // has to handle self (tmp2 --> tmp2) without throwing error
+result = shell.mv('*', 'tmp2'); // has to handle self (tmp2 --> tmp2) without throwing error
 assert.ok(shell.error()); // there's an error, but not fatal
 assert.equal(fs.existsSync('tmp2/file1'), true); // moved OK
-shell.mv('tmp2/*', '.'); // revert
+assert.equal(result.code, 1);
+result = shell.mv('tmp2/*', '.'); // revert
 assert.equal(fs.existsSync('file1'), true); // moved OK
+assert.equal(result.code, 0);
 
-shell.mv('file1', 'file3'); // one source
+result = shell.mv('file1', 'file3'); // one source
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('file1'), false);
 assert.equal(fs.existsSync('file3'), true);
-shell.mv('file3', 'file1'); // revert
+result = shell.mv('file3', 'file1'); // revert
 assert.equal(shell.error(), null);
 assert.equal(fs.existsSync('file1'), true);
+assert.equal(result.code, 0);
 
 // two sources
 shell.rm('-rf', 't');
 shell.mkdir('-p', 't');
-shell.mv('file1', 'file2', 't');
+result = shell.mv('file1', 'file2', 't');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('file1'), false);
 assert.equal(fs.existsSync('file2'), false);
 assert.equal(fs.existsSync('t/file1'), true);
 assert.equal(fs.existsSync('t/file2'), true);
-shell.mv('t/*', '.'); // revert
+result = shell.mv('t/*', '.'); // revert
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('file1'), true);
 assert.equal(fs.existsSync('file2'), true);
 
 // two sources, array style
 shell.rm('-rf', 't');
 shell.mkdir('-p', 't');
-shell.mv(['file1', 'file2'], 't'); // two sources
+result = shell.mv(['file1', 'file2'], 't'); // two sources
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('file1'), false);
 assert.equal(fs.existsSync('file2'), false);
 assert.equal(fs.existsSync('t/file1'), true);
 assert.equal(fs.existsSync('t/file2'), true);
-shell.mv('t/*', '.'); // revert
+result = shell.mv('t/*', '.'); // revert
 assert.equal(fs.existsSync('file1'), true);
 assert.equal(fs.existsSync('file2'), true);
 
-shell.mv('file*.js', 't'); // wildcard
+result = shell.mv('file*.js', 't'); // wildcard
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('file1.js'), false);
 assert.equal(fs.existsSync('file2.js'), false);
 assert.equal(fs.existsSync('t/file1.js'), true);
 assert.equal(fs.existsSync('t/file2.js'), true);
-shell.mv('t/*', '.'); // revert
+result = shell.mv('t/*', '.'); // revert
 assert.equal(fs.existsSync('file1.js'), true);
 assert.equal(fs.existsSync('file2.js'), true);
 
-shell.mv('-f', 'file1', 'file2'); // dest exists, but -f given
+result = shell.mv('-f', 'file1', 'file2'); // dest exists, but -f given
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('file1'), false);
 assert.equal(fs.existsSync('file2'), true);
 

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -11,13 +11,6 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-// no piped methods for commands that don't return anything
-assert.throws(function() {
-  shell.cp('resources/file1', 'tmp/');
-  assert.ok(!shell.error());
-  shell.cp('resources/file1', 'tmp/').cat();
-});
-
 // commands like `rm` can't be on the right side of pipes
 assert.equal(typeof shell.ls('.').rm, 'undefined');
 assert.equal(typeof shell.cat('resources/file1.txt').rm, 'undefined');

--- a/test/pwd.js
+++ b/test/pwd.js
@@ -14,10 +14,14 @@ shell.mkdir('tmp');
 
 var _pwd = shell.pwd();
 assert.equal(shell.error(), null);
+assert.equal(_pwd.code, 0);
+assert.ok(!_pwd.stderr);
 assert.equal(_pwd, path.resolve('.'));
 
 shell.cd('tmp');
 var _pwd = shell.pwd();
+assert.equal(_pwd.code, 0);
+assert.ok(!_pwd.stderr);
 assert.equal(shell.error(), null);
 assert.equal(path.basename(_pwd), 'tmp');
 

--- a/test/rm.js
+++ b/test/rm.js
@@ -13,64 +13,79 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-shell.rm();
+var result = shell.rm();
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'rm: no paths given');
 
-shell.rm('asdfasdf'); // file does not exist
+result = shell.rm('asdfasdf'); // file does not exist
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'rm: no such file or directory: asdfasdf');
 
-shell.rm('-f'); // no file
+result = shell.rm('-f'); // no file
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.equal(result.stderr, 'rm: no paths given');
 
-shell.rm('-@', 'resources/file1'); // invalid option
+result = shell.rm('-@', 'resources/file1'); // invalid option
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 assert.equal(fs.existsSync('resources/file1'), true);
+assert.equal(result.stderr, 'rm: option not recognized: @');
 
 //
 // Valids
 //
 
 // file does not exist, but -f specified
-shell.rm('-f', 'asdfasdf');
+result = shell.rm('-f', 'asdfasdf');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 
 // simple rm
 shell.cp('-f', 'resources/file1', 'tmp/file1');
 assert.equal(fs.existsSync('tmp/file1'), true);
-shell.rm('tmp/file1');
+result = shell.rm('tmp/file1');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/file1'), false);
 
 // recursive dir removal - small-caps '-r'
 shell.mkdir('-p', 'tmp/a/b/c');
 assert.equal(fs.existsSync('tmp/a/b/c'), true);
-shell.rm('-rf', 'tmp/a');
+result = shell.rm('-rf', 'tmp/a');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/a'), false);
 
 // recursive dir removal - capital '-R'
 shell.mkdir('-p', 'tmp/a/b/c');
 assert.equal(fs.existsSync('tmp/a/b/c'), true);
-shell.rm('-Rf', 'tmp/a');
+result = shell.rm('-Rf', 'tmp/a');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/a'), false);
 
 // recursive dir removal - absolute path
 shell.mkdir('-p', 'tmp/a/b/c');
 assert.equal(fs.existsSync('tmp/a/b/c'), true);
-shell.rm('-Rf', path.resolve('./tmp/a'));
+result = shell.rm('-Rf', path.resolve('./tmp/a'));
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/a'), false);
 
 // wildcard
 shell.cp('-f', 'resources/file*', 'tmp');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/file1'), true);
 assert.equal(fs.existsSync('tmp/file2'), true);
 assert.equal(fs.existsSync('tmp/file1.js'), true);
 assert.equal(fs.existsSync('tmp/file2.js'), true);
-shell.rm('tmp/file*');
+result = shell.rm('tmp/file*');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/file1'), false);
 assert.equal(fs.existsSync('tmp/file2'), false);
 assert.equal(fs.existsSync('tmp/file1.js'), false);
@@ -85,8 +100,9 @@ assert.equal(fs.existsSync('tmp/a/b/c'), true);
 assert.equal(fs.existsSync('tmp/b'), true);
 assert.equal(fs.existsSync('tmp/c'), true);
 assert.equal(fs.existsSync('tmp/.hidden'), true);
-shell.rm('-rf', 'tmp/*');
+result = shell.rm('-rf', 'tmp/*');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 var contents = fs.readdirSync('tmp');
 assert.equal(contents.length, 1);
 assert.equal(contents[0], '.hidden'); // shouldn't remove hiddden if no .* given
@@ -100,8 +116,9 @@ assert.equal(fs.existsSync('tmp/a/b/c'), true);
 assert.equal(fs.existsSync('tmp/b'), true);
 assert.equal(fs.existsSync('tmp/c'), true);
 assert.equal(fs.existsSync('tmp/.hidden'), true);
-shell.rm('-rf', 'tmp/*', 'tmp/.*');
+result = shell.rm('-rf', 'tmp/*', 'tmp/.*');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 var contents = fs.readdirSync('tmp');
 assert.equal(contents.length, 0);
 
@@ -114,8 +131,9 @@ assert.equal(fs.existsSync('tmp/a/b/c'), true);
 assert.equal(fs.existsSync('tmp/b'), true);
 assert.equal(fs.existsSync('tmp/c'), true);
 assert.equal(fs.existsSync('tmp/.hidden'), true);
-shell.rm('-rf', ['tmp/*', 'tmp/.*']);
+result = shell.rm('-rf', ['tmp/*', 'tmp/.*']);
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 var contents = fs.readdirSync('tmp');
 assert.equal(contents.length, 0);
 
@@ -123,7 +141,7 @@ assert.equal(contents.length, 0);
 shell.mkdir('-p', 'tmp/readonly');
 shell.ShellString('asdf').to('tmp/readonly/file1');
 fs.chmodSync('tmp/readonly/file1', '0444'); // -r--r--r--
-shell.rm('tmp/readonly/file1');
+result = shell.rm('tmp/readonly/file1');
 assert.equal(fs.existsSync('tmp/readonly/file1'), true); // bash's rm always asks before removing read-only files
                                                          // here we just assume "no"
 
@@ -131,7 +149,7 @@ assert.equal(fs.existsSync('tmp/readonly/file1'), true); // bash's rm always ask
 shell.mkdir('-p', 'tmp/readonly');
 shell.ShellString('asdf').to('tmp/readonly/file2');
 fs.chmodSync('tmp/readonly/file2', '0444'); // -r--r--r--
-shell.rm('-f', 'tmp/readonly/file2');
+result = shell.rm('-f', 'tmp/readonly/file2');
 assert.equal(fs.existsSync('tmp/readonly/file2'), false);
 
 // removal of a tree containing read-only files (unforced)
@@ -139,7 +157,7 @@ shell.mkdir('-p', 'tmp/tree2');
 shell.ShellString('asdf').to('tmp/tree2/file1');
 shell.ShellString('asdf').to('tmp/tree2/file2');
 fs.chmodSync('tmp/tree2/file1', '0444'); // -r--r--r--
-shell.rm('-r', 'tmp/tree2');
+result = shell.rm('-r', 'tmp/tree2');
 assert.equal(fs.existsSync('tmp/tree2/file1'), true);
 assert.equal(fs.existsSync('tmp/tree2/file2'), false);
 
@@ -148,7 +166,7 @@ shell.mkdir('-p', 'tmp/tree');
 shell.ShellString('asdf').to('tmp/tree/file1');
 shell.ShellString('asdf').to('tmp/tree/file2');
 fs.chmodSync('tmp/tree/file1', '0444'); // -r--r--r--
-shell.rm('-rf', 'tmp/tree');
+result = shell.rm('-rf', 'tmp/tree');
 assert.equal(fs.existsSync('tmp/tree'), false);
 
 // removal of a sub-tree containing read-only and hidden files - rm('dir/*')
@@ -161,7 +179,7 @@ shell.ShellString('asdf').to('tmp/tree3/file');
 fs.chmodSync('tmp/tree3/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree3/subtree/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree3/.hidden/file', '0444'); // -r--r--r--
-shell.rm('-rf', 'tmp/tree3/*', 'tmp/tree3/.*'); // erase dir contents
+result = shell.rm('-rf', 'tmp/tree3/*', 'tmp/tree3/.*'); // erase dir contents
 assert.equal(shell.ls('tmp/tree3').length, 0);
 
 // removal of a sub-tree containing read-only and hidden files - rm('dir')
@@ -174,15 +192,16 @@ shell.ShellString('asdf').to('tmp/tree4/file');
 fs.chmodSync('tmp/tree4/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree4/subtree/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree4/.hidden/file', '0444'); // -r--r--r--
-shell.rm('-rf', 'tmp/tree4'); // erase dir contents
+result = shell.rm('-rf', 'tmp/tree4'); // erase dir contents
 assert.equal(fs.existsSync('tmp/tree4'), false);
 
 // remove symbolic link to a dir
-shell.rm('-rf', 'tmp');
+result = shell.rm('-rf', 'tmp');
 shell.mkdir('tmp');
 shell.cp('-R', 'resources/rm', 'tmp');
-shell.rm('-f', 'tmp/rm/link_to_a_dir');
+result = shell.rm('-f', 'tmp/rm/link_to_a_dir');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(fs.existsSync('tmp/rm/link_to_a_dir'), false);
 assert.equal(fs.existsSync('tmp/rm/a_dir'), true);
 

--- a/test/sed.js
+++ b/test/sed.js
@@ -12,18 +12,24 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-shell.sed();
+result = shell.sed();
 assert.ok(shell.error());
+assert.equal(result.code, 1);
+assert.ok(result.stderr);
 
-shell.sed(/asdf/g); // too few args
+result = shell.sed(/asdf/g); // too few args
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
-shell.sed(/asdf/g, 'nada'); // too few args
+result = shell.sed(/asdf/g, 'nada'); // too few args
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
 assert.equal(fs.existsSync('asdfasdf'), false); // sanity check
-shell.sed(/asdf/g, 'nada', 'asdfasdf'); // no such file
+result = shell.sed(/asdf/g, 'nada', 'asdfasdf'); // no such file
 assert.ok(shell.error());
+assert.equal(result.code, 2);
+assert.equal(result.stderr, 'sed: no such file or directory: asdfasdf');
 
 // if at least one file is missing, this should be an error
 shell.cp('-f', 'resources/file1', 'tmp/file1');
@@ -31,6 +37,7 @@ assert.equal(fs.existsSync('asdfasdf'), false); // sanity check
 assert.equal(fs.existsSync('tmp/file1'), true); // sanity check
 var result = shell.sed(/asdf/g, 'nada', 'tmp/file1', 'asdfasdf');
 assert.ok(shell.error());
+assert.equal(result.code, 2);
 assert.equal(result.stderr, 'sed: no such file or directory: asdfasdf');
 
 //
@@ -40,14 +47,17 @@ assert.equal(result.stderr, 'sed: no such file or directory: asdfasdf');
 shell.cp('-f', 'resources/file1', 'tmp/file1');
 var result = shell.sed('test1', 'hello', 'tmp/file1'); // search string
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'hello');
 
 var result = shell.sed(/test1/, 'hello', 'tmp/file1'); // search regex
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'hello');
 
 var result = shell.sed(/test1/, 1234, 'tmp/file1'); // numeric replacement
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.toString(), '1234');
 
 var replaceFun = function (match) {
@@ -55,31 +65,37 @@ var replaceFun = function (match) {
 };
 var result = shell.sed(/test1/, replaceFun, 'tmp/file1'); // replacement function
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'TEST1test1');
 
 var result = shell.sed('-i', /test1/, 'hello', 'tmp/file1');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'hello');
 assert.equal(shell.cat('tmp/file1').toString(), 'hello');
 
 // make sure * in regex is not globbed
 var result = shell.sed(/alpha*beta/, 'hello', 'resources/grep/file');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'hello\nhowareyou\nhello\nthis line ends in.js\nlllllllllllllllll.js\n');
 
 // make sure * in string-regex is not globbed
 var result = shell.sed('alpha*beta', 'hello', 'resources/grep/file');
 assert.ok(!shell.error());
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'hello\nhowareyou\nhello\nthis line ends in.js\nlllllllllllllllll.js\n');
 
 // make sure * in regex is not globbed
 var result = shell.sed(/l*\.js/, '', 'resources/grep/file');
 assert.ok(!shell.error());
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'alphaaaaaaabeta\nhowareyou\nalphbeta\nthis line ends in\n\n');
 
 // make sure * in string-regex is not globbed
 var result = shell.sed('l*\\.js', '', 'resources/grep/file');
 assert.ok(!shell.error());
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'alphaaaaaaabeta\nhowareyou\nalphbeta\nthis line ends in\n\n');
 
 shell.cp('-f', 'resources/file1', 'tmp/file1');
@@ -88,16 +104,19 @@ shell.cp('-f', 'resources/file2', 'tmp/file2');
 // multiple file names
 var result = shell.sed('test', 'hello', 'tmp/file1', 'tmp/file2');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'hello1\nhello2');
 
 // array of file names (and try it out with a simple regex)
 var result = shell.sed(/t.*st/, 'hello', ['tmp/file1', 'tmp/file2']);
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'hello1\nhello2');
 
 // multiple file names, with in-place-replacement
 var result = shell.sed('-i', 'test', 'hello', ['tmp/file1', 'tmp/file2']);
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'hello1\nhello2');
 assert.equal(shell.cat('tmp/file1').toString(), 'hello1');
 assert.equal(shell.cat('tmp/file2').toString(), 'hello2');
@@ -108,6 +127,7 @@ assert.equal(shell.cat('tmp/file1.txt').toString(), 'test1\n');
 assert.equal(shell.cat('tmp/file2.txt').toString(), 'test2\n');
 var result = shell.sed('-i', 'test', 'hello', 'tmp/file*.txt');
 assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
 assert.equal(result.toString(), 'hello1\n\nhello2\n'); // TODO: fix sed's behavior
 assert.equal(shell.cat('tmp/file1.txt').toString(), 'hello1\n');
 assert.equal(shell.cat('tmp/file2.txt').toString(), 'hello2\n');

--- a/test/touch.js
+++ b/test/touch.js
@@ -8,32 +8,38 @@ shell.rm('-rf', 'tmp');
 shell.mkdir('tmp');
 
 // should handle args
-shell.touch();
+var result = shell.touch();
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
-shell.touch(1);
+result = shell.touch(1);
 assert.ok(shell.error());
+assert.equal(result.code, 1);
 
 // exits without error when trying to touch a directory
-shell.touch('tmp/');
+result = shell.touch('tmp/');
 assert.ok(!shell.error());
-shell.touch('tmp');
+assert.equal(result.code, 0);
+result = shell.touch('tmp');
 assert.ok(!shell.error());
+assert.equal(result.code, 0);
 
 // creates new files
 var testFile = tmpFile();
-shell.touch(testFile);
+result = shell.touch(testFile);
 assert(fs.existsSync(testFile));
 
 // does not create a file if told not to
 var testFile = tmpFile(true);
-shell.touch('-c', testFile);
+result = shell.touch('-c', testFile);
+assert.equal(result.code, 0);
 assert.ok(!fs.existsSync(testFile));
 
 // handles globs correctly
-shell.touch('tmp/file.txt');
-shell.touch('tmp/file.js');
-shell.touch('tmp/file*');
+result = shell.touch('tmp/file.txt');
+result = shell.touch('tmp/file.js');
+result = shell.touch('tmp/file*');
+assert.equal(result.code, 0);
 var files = shell.ls('tmp/file*');
 assert.ok(files.indexOf('tmp/file.txt') > -1);
 assert.ok(files.indexOf('tmp/file.js') > -1);
@@ -42,7 +48,8 @@ assert.equal(files.length, 2);
 // errors if reference file is not found
 var testFile = tmpFile();
 var refFile = tmpFile(true);
-shell.touch({'-r': refFile}, testFile);
+result = shell.touch({'-r': refFile}, testFile);
+assert.equal(result.code, 1);
 assert.ok(shell.error());
 
 // uses a reference file for mtime
@@ -50,19 +57,22 @@ var testFile = tmpFile(false);
 var testFile2 = tmpFile();
 shell.touch(testFile2);
 shell.exec(JSON.stringify(process.execPath)+' resources/exec/slow.js 3000');
-shell.touch(testFile);
+result = shell.touch(testFile);
 assert.ok(!shell.error());
+assert.equal(result.code, 0);
 assert.notEqual(fs.statSync(testFile).mtime.getTime(), fs.statSync(testFile2).mtime.getTime());
 assert.notEqual(fs.statSync(testFile).atime.getTime(), fs.statSync(testFile2).atime.getTime());
-shell.touch({'-r': testFile2}, testFile);
+result = shell.touch({'-r': testFile2}, testFile);
 assert.ok(!shell.error());
+assert.equal(result.code, 0);
 assert.equal(fs.statSync(testFile).mtime.getTime(), fs.statSync(testFile2).mtime.getTime());
 assert.equal(fs.statSync(testFile).atime.getTime(), fs.statSync(testFile2).atime.getTime());
 
 // sets mtime
 var testFile = tmpFile();
 var oldStat = resetUtimes(testFile);
-shell.touch(testFile);
+result = shell.touch(testFile);
+assert.equal(result.code, 0);
 assert(oldStat.mtime < fs.statSync(testFile).mtime);
 // sets atime
 assert(oldStat.atime < fs.statSync(testFile).atime);
@@ -70,20 +80,23 @@ assert(oldStat.atime < fs.statSync(testFile).atime);
 // does not sets mtime if told not to
 var testFile = tmpFile();
 var oldStat = resetUtimes(testFile);
-shell.touch('-a', testFile);
+result = shell.touch('-a', testFile);
+assert.equal(result.code, 0);
 assert.equal(oldStat.mtime.getTime(), fs.statSync(testFile).mtime.getTime());
 
 // does not sets atime if told not to
 var testFile = tmpFile();
 var oldStat = resetUtimes(testFile);
-shell.touch('-m', testFile);
+result = shell.touch('-m', testFile);
+assert.equal(result.code, 0);
 assert.equal(oldStat.atime.getTime(), fs.statSync(testFile).atime.getTime());
 
 // multiple files
 testFile = tmpFile(true);
 testFile2 = tmpFile(true);
 shell.rm('-f', testFile, testFile2);
-shell.touch(testFile, testFile2);
+result = shell.touch(testFile, testFile2);
+assert.equal(result.code, 0);
 assert(fs.existsSync(testFile));
 assert(fs.existsSync(testFile2));
 
@@ -91,7 +104,8 @@ assert(fs.existsSync(testFile2));
 testFile = tmpFile(true);
 testFile2 = tmpFile(true);
 shell.rm('-f', testFile, testFile2);
-shell.touch([testFile, testFile2]);
+result = shell.touch([testFile, testFile2]);
+assert.equal(result.code, 0);
 assert(fs.existsSync(testFile));
 assert(fs.existsSync(testFile2));
 

--- a/test/which.js
+++ b/test/which.js
@@ -24,6 +24,8 @@ assert.ok(!result);
 //
 
 var node = shell.which('node');
+assert.equal(node.code, 0);
+assert.ok(!node.stderr);
 assert.ok(!shell.error());
 assert.ok(fs.existsSync(node + ''));
 


### PR DESCRIPTION
This is a redo of #269.

This adds error codes as a `.code` attribute to ShellStrings, but doesn't implement the `errorCode()` function.

This also does not switch the implementation of the `error()` function (that should be in another PR, IMO).

Tests will be added soon.