### PR TITLE
feat(glob): expose config.globOptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,3 +669,13 @@ Will print each command as follows:
 cd dir/
 ls subdir/
 ```
+
+### config.globOptions
+
+Example:
+
+```javascript
+config.globOptions = {nodir: true};
+```
+
+Use this value for calls to `glob.sync()` instead of the default options.

--- a/shell.js
+++ b/shell.js
@@ -203,3 +203,14 @@ exports.config = common.config;
 //@ cd dir/
 //@ ls subdir/
 //@ ```
+
+//@
+//@ ### config.globOptions
+//@
+//@ Example:
+//@
+//@ ```javascript
+//@ config.globOptions = {nodir: true};
+//@ ```
+//@
+//@ Use this value for calls to `glob.sync()` instead of the default options.

--- a/src/common.js
+++ b/src/common.js
@@ -17,6 +17,7 @@ var config = {
   fatal: false,
   verbose: false,
   noglob: false,
+  globOptions: {},
   maxdepth: 255
 };
 exports.config = config;
@@ -179,7 +180,7 @@ exports.parseOptions = parseOptions;
 // For example:
 //   expand(['file*.js']) = ['file1.js', 'file2.js', ...]
 //   (if the files 'file1.js', 'file2.js', etc, exist in the current dir)
-function expand(list, opts) {
+function expand(list) {
   if (!Array.isArray(list)) {
     throw new TypeError('must be an array');
   }
@@ -189,7 +190,7 @@ function expand(list, opts) {
     if (typeof listEl !== 'string') {
       expanded.push(listEl);
     } else {
-      var ret = glob.sync(listEl, opts);
+      var ret = glob.sync(listEl, config.globOptions);
       // if glob fails, interpret the string literally
       expanded = expanded.concat(ret.length > 0 ? ret : [listEl]);
     }

--- a/test/config.js
+++ b/test/config.js
@@ -2,6 +2,7 @@ var shell = require('..');
 
 var assert = require('assert'),
     child = require('child_process');
+var common = require('../src/common');
 
 //
 // config.silent
@@ -44,3 +45,24 @@ child.exec(JSON.stringify(process.execPath)+' '+file, function(err, stdout) {
     shell.exit(123);
   });
 });
+
+//
+// config.globOptions
+//
+
+// Expands to directories by default
+var result = common.expand(['resources/*a*']);
+assert.equal(result.length, 4);
+assert.ok(result.indexOf('resources/a.txt') > -1);
+assert.ok(result.indexOf('resources/badlink') > -1);
+assert.ok(result.indexOf('resources/cat') > -1);
+assert.ok(result.indexOf('resources/external') > -1);
+
+// Check to make sure options get passed through (nodir is an example)
+shell.config.globOptions = {nodir: true};
+result = common.expand(['resources/*a*']);
+assert.equal(result.length, 2);
+assert.ok(result.indexOf('resources/a.txt') > -1);
+assert.ok(result.indexOf('resources/badlink') > -1);
+assert.ok(result.indexOf('resources/cat') < 0);
+assert.ok(result.indexOf('resources/external') < 0);


### PR DESCRIPTION
Allow users to customize the settings of `glob.sync()` (if they so-desire). This doesn't change the default behavior.

I imagine this is a feature a few users may want (users wanted something similar for `exec()` options in #163, #284, #132 ).