### PR TITLE
refactor(string): modify string protoype, but only for shelljs/global

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ containing the files if more than one file is given (a new line character is
 introduced between each file). Wildcard `*` accepted.
 
 
-### 'string'.to(file)
+### ShellString.prototype.to(file)
 
 Examples:
 
@@ -343,7 +343,7 @@ ShellStrings (such as those returned by `cat`, `grep`, etc). _Like Unix
 redirections, `to()` will overwrite any existing file!_
 
 
-### 'string'.toEnd(file)
+### ShellString.prototype.toEnd(file)
 
 Examples:
 

--- a/global.js
+++ b/global.js
@@ -1,3 +1,10 @@
 var shell = require('./shell.js');
+var common = require('./src/common');
 for (var cmd in shell)
   global[cmd] = shell[cmd];
+
+var _to = require('./src/to');
+String.prototype.to = common.wrap('to', _to);
+
+var _toEnd = require('./src/toEnd');
+String.prototype.toEnd = common.wrap('toEnd', _toEnd);

--- a/src/to.js
+++ b/src/to.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var path = require('path');
 
 //@
-//@ ### 'string'.to(file)
+//@ ### ShellString.prototype.to(file)
 //@
 //@ Examples:
 //@

--- a/src/toEnd.js
+++ b/src/toEnd.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var path = require('path');
 
 //@
-//@ ### 'string'.toEnd(file)
+//@ ### ShellString.prototype.toEnd(file)
 //@
 //@ Examples:
 //@

--- a/test/global.js
+++ b/test/global.js
@@ -1,0 +1,41 @@
+/* globals cat, config, cp, env, error, exit, mkdir, rm */
+
+require('../global');
+
+var assert = require('assert');
+var fs = require('fs');
+
+config.silent = true;
+
+rm('-rf', 'tmp');
+mkdir('tmp');
+
+//
+// Valids
+//
+
+assert.equal(process.env, env);
+
+// cat
+var result = cat('resources/cat/file1');
+assert.equal(error(), null);
+assert.equal(result.code, 0);
+assert.equal(result, 'test1\n');
+
+// rm
+cp('-f', 'resources/file1', 'tmp/file1');
+assert.equal(fs.existsSync('tmp/file1'), true);
+result = rm('tmp/file1');
+assert.equal(error(), null);
+assert.equal(result.code, 0);
+assert.equal(fs.existsSync('tmp/file1'), false);
+
+// String.prototype is modified for global require
+'foo'.to('tmp/testfile.txt');
+assert.equal('foo', cat('tmp/testfile.txt'));
+'bar'.toEnd('tmp/testfile.txt');
+assert.equal('foobar', cat('tmp/testfile.txt'));
+
+exit(123);
+
+


### PR DESCRIPTION
`require('shelljs/global')` extends String.prototype to have the `.to()` and `.toEnd()` methods again. This also adds tests for the global require.

This is along the lines of the discussion in #398. The advantage of this is that ShellJS is still backwards compatible for `require('shelljs/global')`, but we still have an option to avoid extending the String prototype (just use `require('shelljs')` instead). This would make things more convenient (and `global` is a convenience script primarily), and would ease the transition to ShellJS v0.7.