### PR TITLE
test(rm): add tests to prevent a future regression

### DIFF
--- a/test/rm.js
+++ b/test/rm.js
@@ -43,6 +43,26 @@ result = shell.rm('-f', 'asdfasdf');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
 
+// directory does not exist, but -fr specified
+result = shell.rm('-fr', 'fake_dir/');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+
+// directory does not exist, but *only -f* specified
+result = shell.rm('-f', 'fake_dir/');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+
+// file (in fake dir) does not exist, but -f specified
+result = shell.rm('-f', 'fake_dir/asdfasdf');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+
+// dir (in fake dir) does not exist, but -fr specified
+result = shell.rm('-fr', 'fake_dir/sub/');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+
 // simple rm
 shell.cp('-f', 'resources/file1', 'tmp/file1');
 assert.equal(fs.existsSync('tmp/file1'), true);


### PR DESCRIPTION
Fixes #332 

This is pretty straightforward. The issue existed on v0.6, but not on master. This just adds the tests to make sure we don't run into this issue again.

In case you're wondering, the "**only -f**" case is indeed bash-compatible. `rm -f real_dir/` is an error, `rm -f fake_dir/` is not (assuming that `fake_dir/` does not exist, of course).

Feel free to adjust the tests as necessary. I checked them against bash on Linux, and this is compatible with that.