### PR TITLE
docs: wildcards for all commands, other docs cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ shell.echo('hello world');
 
 
 All commands run synchronously, unless otherwise stated.
+All commands accept standard bash globbing characters (`*`, `?`, etc.),
+compatible with the [node glob module](https://github.com/isaacs/node-glob).
 
 For less-commonly used commands and features, please check out our [wiki
 page](https://github.com/shelljs/shelljs/wiki).
@@ -195,7 +197,7 @@ Available options:
 
 + `-f`: force (default behavior)
 + `-n`: no-clobber
-+ `-r, -R`: recursive
++ `-r`, `-R`: recursive
 
 Examples:
 
@@ -206,7 +208,7 @@ cp('-Rf', '/tmp/*', '/usr/local/*', '/home/tmp');
 cp('-Rf', ['/tmp/*', '/usr/local/*'], '/home/tmp'); // same as above
 ```
 
-Copies files. The wildcard `*` is accepted.
+Copies files.
 
 
 ### rm([options,] file [, file ...])
@@ -224,7 +226,7 @@ rm('some_file.txt', 'another_file.txt');
 rm(['some_file.txt', 'another_file.txt']); // same as above
 ```
 
-Removes files. The wildcard `*` is accepted.
+Removes files.
 
 
 ### mv([options ,] source [, source ...], dest')
@@ -242,7 +244,7 @@ mv('file1', 'file2', 'dir/');
 mv(['file1', 'file2'], 'dir/'); // same as above
 ```
 
-Moves files. The wildcard `*` is accepted.
+Moves files.
 
 
 ### mkdir([options,] dir [, dir ...])
@@ -296,7 +298,7 @@ var str = cat(['file1', 'file2']); // same as above
 
 Returns a string containing the given file, or a concatenated string
 containing the files if more than one file is given (a new line character is
-introduced between each file). Wildcard `*` accepted.
+introduced between each file).
 
 
 ### ShellString.prototype.to(file)
@@ -356,7 +358,7 @@ grep('GLOBAL_VARIABLE', '*.js');
 ```
 
 Reads input string from given files and returns a string containing all lines of the
-file that match the given `regex_filter`. Wildcard `*` accepted.
+file that match the given `regex_filter`.
 
 
 ### which(command)

--- a/shell.js
+++ b/shell.js
@@ -11,6 +11,8 @@ var common = require('./src/common');
 
 //@
 //@ All commands run synchronously, unless otherwise stated.
+//@ All commands accept standard bash globbing characters (`*`, `?`, etc.),
+//@ compatible with the [node glob module](https://github.com/isaacs/node-glob).
 //@
 //@ For less-commonly used commands and features, please check out our [wiki
 //@ page](https://github.com/shelljs/shelljs/wiki).

--- a/src/cat.js
+++ b/src/cat.js
@@ -15,7 +15,7 @@ var fs = require('fs');
 //@
 //@ Returns a string containing the given file, or a concatenated string
 //@ containing the files if more than one file is given (a new line character is
-//@ introduced between each file). Wildcard `*` accepted.
+//@ introduced between each file).
 function _cat(options, files) {
   var cat = common.readFromPipe(this);
 

--- a/src/cp.js
+++ b/src/cp.js
@@ -94,7 +94,7 @@ function cpdirSyncRecursive(sourceDir, destDir, opts) {
 //@
 //@ + `-f`: force (default behavior)
 //@ + `-n`: no-clobber
-//@ + `-r, -R`: recursive
+//@ + `-r`, `-R`: recursive
 //@
 //@ Examples:
 //@
@@ -105,7 +105,7 @@ function cpdirSyncRecursive(sourceDir, destDir, opts) {
 //@ cp('-Rf', ['/tmp/*', '/usr/local/*'], '/home/tmp'); // same as above
 //@ ```
 //@
-//@ Copies files. The wildcard `*` is accepted.
+//@ Copies files.
 function _cp(options, sources, dest) {
   options = common.parseOptions(options, {
     'f': '!no_force',

--- a/src/grep.js
+++ b/src/grep.js
@@ -17,7 +17,7 @@ var fs = require('fs');
 //@ ```
 //@
 //@ Reads input string from given files and returns a string containing all lines of the
-//@ file that match the given `regex_filter`. Wildcard `*` accepted.
+//@ file that match the given `regex_filter`.
 function _grep(options, regex, files) {
   options = common.parseOptions(options, {
     'v': 'inverse',

--- a/src/mv.js
+++ b/src/mv.js
@@ -18,7 +18,7 @@ var common = require('./common');
 //@ mv(['file1', 'file2'], 'dir/'); // same as above
 //@ ```
 //@
-//@ Moves files. The wildcard `*` is accepted.
+//@ Moves files.
 function _mv(options, sources, dest) {
   options = common.parseOptions(options, {
     'f': '!no_force',

--- a/src/rm.js
+++ b/src/rm.js
@@ -104,7 +104,7 @@ function isWriteable(file) {
 //@ rm(['some_file.txt', 'another_file.txt']); // same as above
 //@ ```
 //@
-//@ Removes files. The wildcard `*` is accepted.
+//@ Removes files.
 function _rm(options, files) {
   options = common.parseOptions(options, {
     'f': 'force',


### PR DESCRIPTION
Related to #398 

All commands support wildcards now, so this documents that. It points to the glob module as a reference on globbing (so people know which glob characters are supported).

I also did some other docs cleanups.

Feel free to rebase this off master if you do other merges first.