### PR TITLE
Add forEach() method to String-based ShellStrings

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -96,6 +96,44 @@ var ShellString = function (stdout, stderr, code) {
   } else {
     that = new String(stdout);
     that.stdout = stdout;
+
+    that.forEach = function (callback, opts) {
+      var options = opts || {};
+
+      if (typeof options !== 'object')
+        options = {};
+
+      if (typeof options.split === 'undefined') {
+        // if only regex provided, set split to 'regex'
+        if (options.regex)
+          options.split = 'regex';
+
+        // default to 'line' if no options given
+        else
+          options.split = 'line';
+      }
+
+      switch (options.split) {
+        case 'character':
+          this.stdout.split('').forEach(callback);
+          break;
+        case 'whitespace':
+          this.stdout.split(/\s+/).forEach(callback);
+          break;
+        case 'word':
+          this.stdout.split(/\W+/).forEach(callback);
+          break;
+        case 'regex':
+          this.stdout.split(options.regex || '').forEach(callback);
+          break;
+        case 'line':
+          this.stdout.split(/\n/).forEach(callback);
+          break;
+        default:
+          this.stdout.split(/\n/).forEach(callback);
+          break;
+      }
+    };
   }
   that.stderr = stderr;
   that.code = code;

--- a/test/cat.js
+++ b/test/cat.js
@@ -51,4 +51,19 @@ assert.equal(result.code, 0);
 assert.ok(result.search('test1') > -1); // file order might be random
 assert.ok(result.search('test2') > -1);
 
+// forEach
+var file3 = 'test1\ntest2\ntest3,test4 test5\ntest6xtest7\n';
+var line = file3.split('\n');
+var character = file3.split('');
+var word = file3.split(/\W+/);
+var whitespace = file3.split(/\s+/);
+var regex = file3.split(/x/);
+result = shell.cat('resources/cat/file3');
+result.forEach(function (a, i) { assert.equal(a, line[i]); });
+result.forEach(function (a, i) { assert.equal(a, line[i]); }, { split: 'line' });
+result.forEach(function (a, i) { assert.equal(a, character[i]); }, { split: 'character' });
+result.forEach(function (a, i) { assert.equal(a, word[i]); }, { split: 'word' });
+result.forEach(function (a, i) { assert.equal(a, whitespace[i]); }, { split: 'whitespace' });
+result.forEach(function (a, i) { assert.equal(a, regex[i]); }, { split: 'regex', regex: /x/ });
+result.forEach(function (a, i) { assert.equal(a, regex[i]); }, { regex: /x/ });
 shell.exit(123);

--- a/test/ls.js
+++ b/test/ls.js
@@ -96,7 +96,7 @@ assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
 assert.equal(result.indexOf('resources/cat/file1') > -1, true);
 assert.equal(result.indexOf('resources/cat/file2') > -1, true);
-assert.equal(result.length, 2);
+assert.equal(result.length, 3);
 
 // wildcard, simple
 result = shell.ls('resources/ls/*');

--- a/test/resources/cat/file3
+++ b/test/resources/cat/file3
@@ -1,0 +1,4 @@
+test1
+test2
+test3,test4 test5
+test6xtest7


### PR DESCRIPTION
Fixes #396 

Adds a `forEach()` method to String-based ShellStrings. This method behaves like `Array.forEach` in regular JavaScript, but it takes an optional object argument:

``` javascript
cat('file.txt').forEach(function (line) {}); // by default, splits by line
cat('file.txt').forEach(function (line) {}, { split: 'line' });
```

There are several built-in splitting methods: `'line'`, `'character'`, `'whitespace'`, and `'word'`. If no split argument is provided, the default splitting method is `'line'`.

An additional method, `'regex'`, is provided, which allows you to split by a custom expression, which can be a regex or a string:

``` javascript
cat('file.txt').forEach(function (split) {}, { split: 'regex', regex: /\n\t/g });
cat('file.txt').forEach(function (split) {}, { split: 'regex', regex: '\n\t' });
```

In this case, `split: 'regex'` is optional. Simply passing `{ regex: /\n\t/g }` is enough.
