### PR TITLE
docs(error): deprecate relying on string value

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,8 +642,12 @@ Follows Python's [tempfile algorithm](http://docs.python.org/library/tempfile.ht
 
 
 ### error()
-Tests if error occurred in the last command. Returns `null` if no error occurred,
-otherwise returns string explaining the error
+Tests if error occurred in the last command. Returns a truthy value if an
+error returned and a falsy value otherwise.
+
+**Note**: do not rely on the
+return value to be an error message. If you need the last error message, use
+the `.stderr` attribute from the last command's return value instead.
 
 
 ### ShellString(str)

--- a/src/error.js
+++ b/src/error.js
@@ -2,8 +2,12 @@ var common = require('./common');
 
 //@
 //@ ### error()
-//@ Tests if error occurred in the last command. Returns `null` if no error occurred,
-//@ otherwise returns string explaining the error
+//@ Tests if error occurred in the last command. Returns a truthy value if an
+//@ error returned and a falsy value otherwise.
+//@
+//@ **Note**: do not rely on the
+//@ return value to be an error message. If you need the last error message, use
+//@ the `.stderr` attribute from the last command's return value instead.
 function error() {
   return common.state.error;
 }


### PR DESCRIPTION
This is the PR I proposed in #397. This deprecates relying on `shell.error()` to return an error string. This will give us the freedom to either keep it the same, or change it in the future, but this keeps the actual implementation the same currently.