### PR TITLE
chore: add "Team" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,3 +736,9 @@ config.globOptions = {nodir: true};
 ```
 
 Use this value for calls to `glob.sync()` instead of the default options.
+
+## Team
+
+| [![Nate Fischer](https://avatars.githubusercontent.com/u/5801521?s=130)](https://github.com/nfischer) | [![Ari Porad](https://avatars1.githubusercontent.com/u/1817508?v=3&s=130)](http://github.com/ariporad) |
+|:---:|:---:|
+| [Nate Fischer](https://github.com/nfischer) | [Ari Porad](http://github.com/ariporad) |

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -18,7 +18,7 @@ docs = docs.replace(/\/\/\@include (.+)/g, function(match, path) {
 docs = docs.replace(/\/\/\@ ?/g, '');
 
 // Wipe out the old docs
-ShellString(cat('README.md').replace(/## Command reference(.|\n)*/, '## Command reference')).to('README.md');
+ShellString(cat('README.md').replace(/## Command reference(.|\n)*\n## Team/, '## Command reference\n## Team')).to('README.md');
 
 // Append new docs to README
 sed('-i', /## Command reference/, '## Command reference\n\n' + docs, 'README.md');


### PR DESCRIPTION
This adds a section to the bottom of the README that looks like:

> ## Team
>
> | [![Nate Fischer](https://avatars.githubusercontent.com/u/5801521?s=130)](https://github.com/nfischer) | [![Ari Porad](https://avatars1.githubusercontent.com/u/1817508?v=3&s=130)](http://github.com/ariporad) |
> |:---:|:---:|
> | [Nate Fischer](https://github.com/nfischer) | [Ari Porad](http://github.com/ariporad) |

This also modifies the `generate-docs` script so that it doesn't override this section of the README.

Inspired by @dthree's [cash](https://github.com/dthree/cash) README.