### PR TITLE
fix(ls): no trailing newline for empty directories

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -91,7 +91,8 @@ var ShellString = function (stdout, stderr, code) {
   var that;
   if (stdout instanceof Array) {
     that = stdout;
-    that.stdout = stdout.join('\n')+'\n';
+    that.stdout = stdout.join('\n');
+    if (stdout.length > 0) that.stdout += '\n';
   } else {
     that = new String(stdout);
     that.stdout = stdout;

--- a/test/ls.js
+++ b/test/ls.js
@@ -394,6 +394,15 @@ result.to('tmp/testingToOutput.txt');
 assert.equal(shell.cat('tmp/testingToOutput.txt'), result.stdout);
 shell.rm('tmp/testingToOutput.txt');
 
+// No trailing newline for ls() on empty directories
+shell.mkdir('foo');
+assert.ok(!shell.error());
+result = shell.ls('foo');
+assert.ok(!shell.error());
+assert.equal(result.stdout, '');
+shell.rm('-r', 'foo');
+assert.ok(!shell.error());
+
 // Check stderr field
 assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
 result = shell.ls('resources/ls/file1', '/asdfasdf');


### PR DESCRIPTION
`ls('empty')` used to have a `.stdout` property of `"\n"`, which is wrong. This fixes that. Trailing newlines are only appended for arrays that have length \> 0.

Once this gets fixed, almost all newline output will be consistent for the various shelljs commands. This is a partial fix for #420 (`pwd()`, `echo()`, and `which()` still need to be fixed).