### PR TITLE
Allow exec to handle stdin inputs

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -70,7 +70,10 @@ function execSync(cmd, opts, pipe) {
         "  , fs = require('fs');",
         "var childProcess = child.exec("+JSON.stringify(cmd)+", "+optString+", function(err) {",
         "  fs.writeFileSync("+JSON.stringify(codeFile)+", err ? err.code.toString() : '0');",
-        " if("+JSON.stringify(!opts.silent)+"){  process.stdin.end();}",
+        "  if("+JSON.stringify(!opts.silent)+"){",
+        "    if(process.platform === 'win32') {process.exit();}",
+        "    else{process.stdin.end();}",
+        "  }",
         "});",
         "var stdoutStream = fs.createWriteStream("+JSON.stringify(stdoutFile)+");",
         "var stderrStream = fs.createWriteStream("+JSON.stringify(stderrFile)+");",
@@ -116,9 +119,12 @@ function execSync(cmd, opts, pipe) {
         "  , fs = require('fs');",
         "var childProcess = child.exec("+JSON.stringify(cmd)+", "+optString+", function(err) {",
         "  fs.writeFileSync("+JSON.stringify(codeFile)+", err ? err.code.toString() : '0');",
-        "  process.stdin.end();",
+        "  if("+JSON.stringify(!opts.silent)+"){",
+        "    if(process.platform === 'win32') {process.exit();}",
+        "    else{process.stdin.end();}",
+        "  }",
         "});",
-        "process.stdin.pipe(childProcess.stdin)"
+        "if("+JSON.stringify(!opts.silent)+"){  process.stdin.pipe(childProcess.stdin)}",
       ].join('\n') +
       (pipe ? "\nchildProcess.stdin.end("+JSON.stringify(pipe)+");\n" : '\n');
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -70,13 +70,15 @@ function execSync(cmd, opts, pipe) {
         "  , fs = require('fs');",
         "var childProcess = child.exec("+JSON.stringify(cmd)+", "+optString+", function(err) {",
         "  fs.writeFileSync("+JSON.stringify(codeFile)+", err ? err.code.toString() : '0');",
+        " if("+JSON.stringify(!opts.silent)+"){  process.stdin.end();}",
         "});",
         "var stdoutStream = fs.createWriteStream("+JSON.stringify(stdoutFile)+");",
         "var stderrStream = fs.createWriteStream("+JSON.stringify(stderrFile)+");",
         "childProcess.stdout.pipe(stdoutStream, {end: false});",
         "childProcess.stderr.pipe(stderrStream, {end: false});",
         "childProcess.stdout.pipe(process.stdout);",
-        "childProcess.stderr.pipe(process.stderr);"
+        "childProcess.stderr.pipe(process.stderr);",
+        "if("+JSON.stringify(!opts.silent)+"){  process.stdin.pipe(childProcess.stdin)}",
       ].join('\n') +
       (pipe ? "\nchildProcess.stdin.end("+JSON.stringify(pipe)+");\n" : '\n') +
       [
@@ -114,7 +116,9 @@ function execSync(cmd, opts, pipe) {
         "  , fs = require('fs');",
         "var childProcess = child.exec("+JSON.stringify(cmd)+", "+optString+", function(err) {",
         "  fs.writeFileSync("+JSON.stringify(codeFile)+", err ? err.code.toString() : '0');",
-        "});"
+        "  process.stdin.end();",
+        "});",
+        "process.stdin.pipe(childProcess.stdin)"
       ].join('\n') +
       (pipe ? "\nchildProcess.stdin.end("+JSON.stringify(pipe)+");\n" : '\n');
 


### PR DESCRIPTION
## Handling stdin inputs

Fix #424.

Well not really..
It will not work with `npm init`. It seems that `npm init` improperly returns after execution. Node's exec callback is never called. 

I tested it using Node v5.11.0 with the following script waiting for input : 

``` javascript
'use strict';

const through2 = require('through2');

process.stdin.setEncoding('utf8');

process.stdin
  .pipe(through2({ decodeStrings : false }, function onChunk(chunk, _, next) {
    if (chunk === 'exit\n') {
      process.exit();
    }
    this.push(chunk);
    next();
  }))
  .pipe(process.stdout);
```
## Exec refactoring

After diving in node child_process, it seems that creating & executing a script file is the only solution. 

Synchronous versions of spawn and exec only allow to get the full output if you didn't set the opts.stdio option. But then you can't have the live output. [Wontfix](https://github.com/nodejs/node-v0.x-archive/issues/9265) (BTW : opened for shelljs)

Then I tried to create a custom stream to intercept the output  but opts.stdio only accepts a small set of streams ([see waiting for merge doc update](https://github.com/ryansobol/node/blob/stdio/doc/api/child_process.markdown#stream-object)) : 
- fs.ReadStream
- fs.WriteStream
- net.Socket
- tty.ReadStream
- tty.WriteStream
  None of them can be used for our case.
