### PR TITLE
chore: test against node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - NODE_VERSION="iojs-v3"
   - NODE_VERSION="4"
   - NODE_VERSION="5"
+  - NODE_VERSION="6"
 
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Node.js API. You can use it to eliminate your shell script's dependency on Unix 
 its familiar and powerful commands. You can also install it globally so you can run it from outside
 Node projects - say goodbye to those gnarly Bash scripts!
 
-ShellJS supports node `v0.11`, `v0.12`, `v4`, `v5`, and all releases of iojs.
+ShellJS supports node `v0.11`, `v0.12`, `v4`, `v5`, `v6`, and all releases of iojs.
 
 The project is [unit-tested](http://travis-ci.org/shelljs/shelljs) and battled-tested in projects like:
 

--- a/test/pwd.js
+++ b/test/pwd.js
@@ -23,6 +23,6 @@ var _pwd = shell.pwd();
 assert.equal(_pwd.code, 0);
 assert.ok(!_pwd.stderr);
 assert.equal(shell.error(), null);
-assert.equal(path.basename(_pwd), 'tmp');
+assert.equal(path.basename(_pwd.toString()), 'tmp');
 
 shell.exit(123);


### PR DESCRIPTION
Looks like node v6 just got released. Just tried this out via nvm and saw that one of our tests broke for node v6, so I fixed that test.

Not sure if appveyor can test against node v6 yet, but I added it to the mix anyway.