### PR TITLE
test(ls): add case for trailing slash on dir name

### DIFF
--- a/test/ls.js
+++ b/test/ls.js
@@ -58,6 +58,18 @@ assert.equal(result.indexOf('filename(with)[chars$]^that.must+be-escaped') > -1,
 assert.equal(result.indexOf('a_dir') > -1, true);
 assert.equal(result.length, 6);
 
+// simple arg, with a trailing slash
+result = shell.ls('resources/ls/');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+assert.equal(result.indexOf('file1') > -1, true);
+assert.equal(result.indexOf('file2') > -1, true);
+assert.equal(result.indexOf('file1.js') > -1, true);
+assert.equal(result.indexOf('file2.js') > -1, true);
+assert.equal(result.indexOf('filename(with)[chars$]^that.must+be-escaped') > -1, true);
+assert.equal(result.indexOf('a_dir') > -1, true);
+assert.equal(result.length, 6);
+
 // no args, 'all' option
 shell.cd('resources/ls');
 result = shell.ls('-A');


### PR DESCRIPTION
In response to [this comment](https://github.com/shelljs/shelljs/issues/446#issuecomment-222088271). It appears this behavior doesn't work correctly on OS X 15.5 (but works on ubuntu and windows).