### PR TITLE
Implement uniq for ShellJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,22 @@ Return the contents of the files, sorted line-by-line. Sorting multiple
 files mixes their content, just like unix sort does.
 
 
+### uniq([options,] [input, [output]])
+Available options:
+
++ `-i`: Ignore differences in case when comparing
+
+Examples:
+
+```javascript
+uniq('foo.txt');
+uniq('-i', 'foo.txt');
+uniq('-i', 'foo.txt', 'bar.txt');
+```
+
+Filter adjacent matching lines from input
+
+
 ### grep([options,] regex_filter, file [, file ...])
 ### grep([options,] regex_filter, file_array)
 Available options:

--- a/shell.js
+++ b/shell.js
@@ -79,6 +79,10 @@ exports.sed = common.wrap('sed', _sed, {idx: 3});
 var _sort = require('./src/sort');
 exports.sort = common.wrap('sort', _sort, {idx: 1});
 
+//@include ./src/uniq
+var _sort = require('./src/uniq');
+exports.sort = common.wrap('uniq', _uniq, {idx: 1});
+
 //@include ./src/grep
 var _grep = require('./src/grep');
 exports.grep = common.wrap('grep', _grep, {idx: 2});

--- a/shell.js
+++ b/shell.js
@@ -80,8 +80,8 @@ var _sort = require('./src/sort');
 exports.sort = common.wrap('sort', _sort, {idx: 1});
 
 //@include ./src/uniq
-var _sort = require('./src/uniq');
-exports.sort = common.wrap('uniq', _uniq, {idx: 1});
+var _uniq = require('./src/uniq');
+exports.uniq = common.wrap('uniq', _uniq, {idx: 1});
 
 //@include ./src/grep
 var _grep = require('./src/grep');

--- a/src/common.js
+++ b/src/common.js
@@ -101,7 +101,7 @@ var ShellString = function (stdout, stderr, code) {
   that.code = code;
   that.to    = function() {wrap('to', _to, {idx: 1}).apply(that.stdout, arguments); return that;};
   that.toEnd = function() {wrap('toEnd', _toEnd, {idx: 1}).apply(that.stdout, arguments); return that;};
-  ['cat', 'head', 'sed', 'sort', 'tail', 'grep', 'exec'].forEach(function (cmd) {
+  ['cat', 'head', 'sed', 'sort', 'uniq', 'tail', 'grep', 'exec'].forEach(function (cmd) {
     that[cmd] = function() {return shell[cmd].apply(that.stdout, arguments);};
   });
   return that;

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -1,0 +1,49 @@
+var common = require('./common');
+var fs = require('fs');
+
+//@
+//@ ### uniq([options,] file)
+//@ Available options:
+//@
+//@ + `-i`: Ignore differences in case when comparing
+//@
+//@ Examples:
+//@
+//@ ```javascript
+//@ uniq('foo.txt');
+//@ uniq('-i', 'foo.txt');
+//@ ```
+//@
+//@ Filter adjacent matching lines from input
+function _uniq(options, input) {
+  options = common.parseOptions(options, {
+    'i': 'ignoreCase'
+  });
+
+  // Check if this is coming from a pipe
+  var pipe = common.readFromPipe(this);
+
+  if (!input && !pipe)
+    common.error('no input given');
+  if(input && pipe)
+      common.error('too many inputs')
+
+  if (pipe)
+    files.unshift('-');
+
+  var lines = (pipe ? pipe : fs.readFileSync(input, 'utf8')).
+              trimRight().
+              split(/\r*\n/);
+
+  var uniqed = [];
+  lines.forEach(function(line){
+      var cmp = options.ignoreCase ? 
+                  line.toLocaleLowerCase().localeCompare(uniqed[-1].toLocaleLowerCase()) :
+                  line.localeCompare(uniqed[-1]);
+      if(cmp !== 0)uniqed.push(line)
+  });
+
+  return new common.ShellString(uniqed.join('\n'), common.state.error, common.state.errorCode);
+}
+
+module.exports = _uniq;

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -35,15 +35,15 @@ function _uniq(options, input) {
               trimRight().
               split(/\r*\n/);
 
-  var uniqed = [];
-  lines.forEach(function(line){
+  var uniqed = lines.slice(0,1);
+  lines.slice(1).forEach(function(line){
       var cmp = options.ignoreCase ? 
-                  line.toLocaleLowerCase().localeCompare(uniqed[-1].toLocaleLowerCase()) :
-                  line.localeCompare(uniqed[-1]);
+                  line.toLocaleLowerCase().localeCompare(uniqed[uniqed.length-1].toLocaleLowerCase()) :
+                  line.localeCompare(uniqed[uniqed.length-1]);
       if(cmp !== 0)uniqed.push(line)
   });
 
-  return new common.ShellString(uniqed.join('\n'), common.state.error, common.state.errorCode);
+  return new common.ShellString(uniqed.join('\n') + '\n', common.state.error, common.state.errorCode);
 }
 
 module.exports = _uniq;

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -2,7 +2,7 @@ var common = require('./common');
 var fs = require('fs');
 
 //@
-//@ ### uniq([options,] file)
+//@ ### uniq([options,] [input, [output]])
 //@ Available options:
 //@
 //@ + `-i`: Ignore differences in case when comparing
@@ -12,10 +12,11 @@ var fs = require('fs');
 //@ ```javascript
 //@ uniq('foo.txt');
 //@ uniq('-i', 'foo.txt');
+//@ uniq('-i', 'foo.txt', 'bar.txt');
 //@ ```
 //@
 //@ Filter adjacent matching lines from input
-function _uniq(options, input) {
+function _uniq(options, input, output) {
   options = common.parseOptions(options, {
     'i': 'ignoreCase'
   });
@@ -25,13 +26,8 @@ function _uniq(options, input) {
 
   if (!input && !pipe)
     common.error('no input given');
-  if(input && pipe)
-      common.error('too many inputs')
 
-  if (pipe)
-    files.unshift('-');
-
-  var lines = (pipe ? pipe : fs.readFileSync(input, 'utf8')).
+  var lines = (input ? fs.readFileSync(input, 'utf8') : pipe).
               trimRight().
               split(/\r*\n/);
 
@@ -42,8 +38,12 @@ function _uniq(options, input) {
                   line.localeCompare(uniqed[uniqed.length-1]);
       if(cmp !== 0)uniqed.push(line)
   });
-
-  return new common.ShellString(uniqed.join('\n') + '\n', common.state.error, common.state.errorCode);
+  var res = new common.ShellString(uniqed.join('\n') + '\n', common.state.error, common.state.errorCode);
+  if(output){
+      res.to(output);
+  }else{
+      return res;
+  }
 }
 
 module.exports = _uniq;

--- a/test/resources/uniq/file1
+++ b/test/resources/uniq/file1
@@ -1,0 +1,4 @@
+foo
+bar
+bar
+baz

--- a/test/resources/uniq/file1t
+++ b/test/resources/uniq/file1t
@@ -1,0 +1,3 @@
+foo
+bar
+baz

--- a/test/resources/uniq/file1u
+++ b/test/resources/uniq/file1u
@@ -1,0 +1,3 @@
+foo
+bar
+baz

--- a/test/resources/uniq/file2
+++ b/test/resources/uniq/file2
@@ -1,0 +1,4 @@
+foo
+bar
+Bar
+baz

--- a/test/resources/uniq/file2u
+++ b/test/resources/uniq/file2u
@@ -1,0 +1,3 @@
+foo
+bar
+baz

--- a/test/resources/uniq/file3
+++ b/test/resources/uniq/file3
@@ -1,0 +1,3 @@
+foo
+bar
+baz

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -19,14 +19,29 @@ result = shell.sort('/adsfasdf'); // file does not exist
 assert.ok(shell.error());
 assert.ok(result.code);
 
+//uniq file1
 result = shell.uniq('resources/uniq/file1');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
 assert.equal(result + '', shell.cat('resources/uniq/file1u').trimRight() + '\n');
 
+//uniq -i file2
 result = shell.uniq('-i', 'resources/uniq/file2');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
 assert.equal(result + '', shell.cat('resources/uniq/file2u').trimRight() + '\n');
+
+//uniq file1 file2
+shell.uniq('resources/uniq/file1', 'resources/uniq/file1t');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+assert.equal(shell.cat('resources/uniq/file1u').trimRight(), 
+             shell.cat('resources/uniq/file1t').trimRight());
+             
+//cat file1 |uniq
+result = shell.cat('resources/uniq/file1').uniq();
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+assert.equal(result + '', shell.cat('resources/uniq/file1u').trimRight() + '\n');
 
 shell.exit(123);

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -1,0 +1,32 @@
+var shell = require('..');
+
+var assert = require('assert'),
+    fs = require('fs');
+
+shell.config.silent = true;
+
+shell.rm('-rf', 'tmp');
+shell.mkdir('tmp');
+
+var result;
+
+result = shell.uniq();
+assert.ok(shell.error());
+assert.ok(result.code);
+
+assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+result = shell.sort('/adsfasdf'); // file does not exist
+assert.ok(shell.error());
+assert.ok(result.code);
+
+result = shell.uniq('resources/uniq/file1');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+assert.equal(result + '', shell.cat('resources/uniq/file1u').trimRight() + '\n');
+
+result = shell.uniq('-i', 'resources/uniq/file2');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+assert.equal(result + '', shell.cat('resources/uniq/file2u').trimRight() + '\n');
+
+shell.exit(123);


### PR DESCRIPTION
The [uniq](http://manpages.ubuntu.com/manpages/precise/en/man1/uniq.1.html) utility removes adjacent identical lines from it's input. I have implemented uniq with support for the -i (ignore case) option.