### PR TITLE
chore(gendocs): add `npm run gendocs` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "main": "./shell.js",
   "scripts": {
     "test": "node scripts/run-tests",
+    "gendocs": "node scripts/generate-docs",
     "changelog": "bash scripts/changelog.sh"
   },
   "bin": {


### PR DESCRIPTION
Now you can generate documentation by running `npm run gendocs`. Once this is merged, we can add this as a step to the contributing guidelines along the lines of:

> ### Before committing:
>
>  - Run `npm test` to make sure tests & linting pass
>  - Run `npm run gendocs` to make sure docs are up to date
>
> Is travis-only failing? Make sure you run `npm run gendocs` before committing!