### PR TITLE
chore: clarify message for when docs are not generated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ os:
 script:
   - npm test
   # make sure when the docs are generated nothing changes (a.k.a. the docs have already been generated)
-  - node scripts/generate-docs.js
-  - git diff --quiet # make sure no files have changed
+  - npm run gendocs
+  - npm run after-travis "Make sure to generate docs!"
 
 # Gitter
 notifications:

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "node scripts/run-tests",
     "gendocs": "node scripts/generate-docs",
     "lint": "jshint .",
+    "after-travis": "travis-check-changes",
     "changelog": "bash scripts/changelog.sh"
   },
   "bin": {
@@ -40,7 +41,8 @@
   },
   "devDependencies": {
     "coffee-script": "^1.10.0",
-    "jshint": "^2.9.2"
+    "jshint": "^2.9.2",
+    "travis-check-changes": "^0.2.0"
   },
   "optionalDependencies": {},
   "engines": {


### PR DESCRIPTION
I noticed an issue we had was that if someone fails to generate docs, it isn't always clear to them that travis is failing for that reason. I wrote out my [own module](https://github.com/nfischer/travis-check-changes) to handle this sort of situation, but with hopefully nicer error reporting.

This PR updates ShellJS to use the module as a dev dependency, with an error message that is hopefully a bit more explanatory than what we had before.