### PR TITLE
chore: revert depreciate shelljs/make (#431)

### DIFF
--- a/make.js
+++ b/make.js
@@ -1,8 +1,5 @@
 require('./global');
 
-console.error('WARNING: shelljs/make is deprecated as of ShellJS v0.8.');
-console.error('Please migrate your code to use an alternate task runner.');
-
 global.config.fatal = true;
 global.target = {};
 


### PR DESCRIPTION
This reverts commit 5a31c7c4369b5e6dbf71b005d040c525ec07b68e from #431.

This reverts the deprecation of the make command as noted in #340.