### PR TITLE
chore: update release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,20 +1,15 @@
 # Release steps
 
 1. Ensure master passes CI tests
-1. Bump version:
-  - `$ npm version <major|minor|patch>`
+2. `npm run gendocs`
+3. Bump version, create tags, push, and release:
+  - `$ npm run <release:major|release:minor|release:patch>`
 
-    >`major` - breaking API changes  
-    >`minor` - backwards-compatible features  
-    >`patch` - backwards-compatible bug fixes  
-1. Update README manually if the changes are not documented in-code. Run
-  `scripts/generate-docs.js` just to be safe
-1. Update CHANGELOG.md
+    >`major` - breaking API changes
+    >`minor` - backwards-compatible features
+    >`patch` - backwards-compatible bug fixes
+4. Update CHANGELOG.md
   - `$ npm run changelog`
   - `$ git push`
-1. Push the bump commit, version tags, and publish
-  - `$ git push`
-  - `$ git push --tags`
-  - `$ npm publish`
-1. Generate the documentup website by visiting
+5. Generate the documentup website by visiting
   [http://documentup.com/shelljs/shelljs/__recompile] in your browser

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "gendocs": "node scripts/generate-docs",
     "lint": "jshint .",
     "after-travis": "travis-check-changes",
-    "changelog": "shelljs-changelog"
+    "changelog": "shelljs-changelog",
+    "release:major": "shelljs-release major",
+    "release:minor": "shelljs-release minor",
+    "release:patch": "shelljs-release patch"
   },
   "bin": {
     "shjs": "./bin/shjs"
@@ -43,6 +46,7 @@
     "coffee-script": "^1.10.0",
     "jshint": "^2.9.2",
     "shelljs-changelog": "^0.2.0",
+    "shelljs-release": "^0.2.0",
     "travis-check-changes": "^0.2.0"
   },
   "optionalDependencies": {},


### PR DESCRIPTION
Similar to shelljs/shx#63, this switches to the new release script. I also updated the release steps accordingly. Feel free to double check the release steps I wrote out, since we want to be sure these are in the right order.