### PR TITLE
refactor: expose pipe-ability to command configuration

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -71,15 +71,15 @@ exports.test = common.wrap('test', _test);
 
 //@include ./src/cat
 var _cat = require('./src/cat');
-exports.cat = common.wrap('cat', _cat, {idx: 1, receivesPipe: true});
+exports.cat = common.wrap('cat', _cat, {idx: 1, canReceivePipe: true});
 
 //@include ./src/head
 var _head = require('./src/head');
-exports.head = common.wrap('head', _head, {idx: 1, receivesPipe: true});
+exports.head = common.wrap('head', _head, {idx: 1, canReceivePipe: true});
 
 //@include ./src/tail
 var _tail = require('./src/tail');
-exports.tail = common.wrap('tail', _tail, {idx: 1, receivesPipe: true});
+exports.tail = common.wrap('tail', _tail, {idx: 1, canReceivePipe: true});
 
 // The below commands have been moved to common.ShellString(), and are only here
 // for generating the docs
@@ -88,15 +88,15 @@ exports.tail = common.wrap('tail', _tail, {idx: 1, receivesPipe: true});
 
 //@include ./src/sed
 var _sed = require('./src/sed');
-exports.sed = common.wrap('sed', _sed, {idx: 3, receivesPipe: true}); // don't glob-expand regexes
+exports.sed = common.wrap('sed', _sed, {idx: 3, canReceivePipe: true}); // don't glob-expand regexes
 
 //@include ./src/sort
 var _sort = require('./src/sort');
-exports.sort = common.wrap('sort', _sort, {idx: 1, receivesPipe: true});
+exports.sort = common.wrap('sort', _sort, {idx: 1, canReceivePipe: true});
 
 //@include ./src/grep
 var _grep = require('./src/grep');
-exports.grep = common.wrap('grep', _grep, {idx: 2, receivesPipe: true}); // don't glob-expand the regex
+exports.grep = common.wrap('grep', _grep, {idx: 2, canReceivePipe: true}); // don't glob-expand the regex
 
 //@include ./src/which
 var _which = require('./src/which');
@@ -130,7 +130,7 @@ exports.env = process.env;
 
 //@include ./src/exec
 var _exec = require('./src/exec');
-exports.exec = common.wrap('exec', _exec, {notUnix:true, receivesPipe: true});
+exports.exec = common.wrap('exec', _exec, {notUnix:true, canReceivePipe: true});
 
 //@include ./src/chmod
 var _chmod = require('./src/chmod');

--- a/shell.js
+++ b/shell.js
@@ -71,15 +71,15 @@ exports.test = common.wrap('test', _test);
 
 //@include ./src/cat
 var _cat = require('./src/cat');
-exports.cat = common.wrap('cat', _cat, {idx: 1});
+exports.cat = common.wrap('cat', _cat, {idx: 1, receivesPipe: true});
 
 //@include ./src/head
 var _head = require('./src/head');
-exports.head = common.wrap('head', _head, {idx: 1});
+exports.head = common.wrap('head', _head, {idx: 1, receivesPipe: true});
 
 //@include ./src/tail
 var _tail = require('./src/tail');
-exports.tail = common.wrap('tail', _tail, {idx: 1});
+exports.tail = common.wrap('tail', _tail, {idx: 1, receivesPipe: true});
 
 // The below commands have been moved to common.ShellString(), and are only here
 // for generating the docs
@@ -88,15 +88,15 @@ exports.tail = common.wrap('tail', _tail, {idx: 1});
 
 //@include ./src/sed
 var _sed = require('./src/sed');
-exports.sed = common.wrap('sed', _sed, {idx: 3}); // don't glob-expand regexes
+exports.sed = common.wrap('sed', _sed, {idx: 3, receivesPipe: true}); // don't glob-expand regexes
 
 //@include ./src/sort
 var _sort = require('./src/sort');
-exports.sort = common.wrap('sort', _sort, {idx: 1});
+exports.sort = common.wrap('sort', _sort, {idx: 1, receivesPipe: true});
 
 //@include ./src/grep
 var _grep = require('./src/grep');
-exports.grep = common.wrap('grep', _grep, {idx: 2}); // don't glob-expand the regex
+exports.grep = common.wrap('grep', _grep, {idx: 2, receivesPipe: true}); // don't glob-expand the regex
 
 //@include ./src/which
 var _which = require('./src/which');
@@ -130,7 +130,7 @@ exports.env = process.env;
 
 //@include ./src/exec
 var _exec = require('./src/exec');
-exports.exec = common.wrap('exec', _exec, {notUnix:true});
+exports.exec = common.wrap('exec', _exec, {notUnix:true, receivesPipe: true});
 
 //@include ./src/chmod
 var _chmod = require('./src/chmod');

--- a/src/common.js
+++ b/src/common.js
@@ -36,7 +36,7 @@ var platform = os.type().match(/^Win/) ? 'win' : 'unix';
 exports.platform = platform;
 
 // This is populated by calls to commonl.wrap()
-var pipeRhsCmds = [];
+var pipeMethods = [];
 
 function log() {
   if (!config.silent)
@@ -106,7 +106,7 @@ function ShellString(stdout, stderr, code) {
   that.toEnd = function() {wrap('toEnd', _toEnd, {idx: 1}).apply(that.stdout, arguments); return that;};
   // A list of all commands that can appear on the right-hand side of a pipe
   // (populated by calls to common.wrap())
-  pipeRhsCmds.forEach(function (cmd) {
+  pipeMethods.forEach(function (cmd) {
     that[cmd] = function() {return shell[cmd].apply(that.stdout, arguments);};
   });
   return that;
@@ -256,8 +256,8 @@ exports.extend = extend;
 // command-logging, and other nice things
 function wrap(cmd, fn, options) {
   options = options || {};
-  if (options.receivesPipe) {
-    pipeRhsCmds.push(cmd);
+  if (options.canReceivePipe) {
+    pipeMethods.push(cmd);
   }
   return function() {
     var retValue = null;

--- a/src/common.js
+++ b/src/common.js
@@ -35,6 +35,9 @@ delete process.env.OLDPWD; // initially, there's no previous directory
 var platform = os.type().match(/^Win/) ? 'win' : 'unix';
 exports.platform = platform;
 
+// This is populated by calls to commonl.wrap()
+var pipeRhsCmds = [];
+
 function log() {
   if (!config.silent)
     console.error.apply(console, arguments);
@@ -102,7 +105,8 @@ function ShellString(stdout, stderr, code) {
   that.to    = function() {wrap('to', _to, {idx: 1}).apply(that.stdout, arguments); return that;};
   that.toEnd = function() {wrap('toEnd', _toEnd, {idx: 1}).apply(that.stdout, arguments); return that;};
   // A list of all commands that can appear on the right-hand side of a pipe
-  ['cat', 'head', 'sed', 'sort', 'tail', 'grep', 'exec'].forEach(function (cmd) {
+  // (populated by calls to common.wrap())
+  pipeRhsCmds.forEach(function (cmd) {
     that[cmd] = function() {return shell[cmd].apply(that.stdout, arguments);};
   });
   return that;
@@ -251,6 +255,10 @@ exports.extend = extend;
 // Common wrapper for all Unix-like commands that performs glob expansion,
 // command-logging, and other nice things
 function wrap(cmd, fn, options) {
+  options = options || {};
+  if (options.receivesPipe) {
+    pipeRhsCmds.push(cmd);
+  }
   return function() {
     var retValue = null;
 
@@ -266,7 +274,7 @@ function wrap(cmd, fn, options) {
         console.error.apply(console, [cmd].concat(args));
       }
 
-      if (options && options.notUnix) { // this branch is for exec()
+      if (options.notUnix) { // this branch is for exec()
         retValue = fn.apply(this, args);
       } else { // and this branch is for everything else
         if (args[0] instanceof Object && args[0].constructor.name === 'Object') {
@@ -307,7 +315,7 @@ function wrap(cmd, fn, options) {
 
         // Perform glob-expansion on all arguments after idx, but preserve the
         // arguments before it (like regexes for sed and grep)
-        if (!config.noglob && options && typeof options.idx === 'number')
+        if (!config.noglob && typeof options.idx === 'number')
           args = args.slice(0, options.idx).concat(expand(args.slice(options.idx)));
         try {
           retValue = fn.apply(this, args);


### PR DESCRIPTION
I think this is one of the first steps we'll need to take in order to create a better setup for creating new commands/plugins. Now, contributors need only specify that their command can receive input from a pipe with the `receivesPipe` option set to `true`, instead of modifying the array that used to explicitly contain each command that could receive input from a pipe.

This cuts out one more spot where contributors need to make a modification.