### PR TITLE
Added recurs. mkdir dirname() failure check.

### DIFF
--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -6,6 +6,12 @@ var path = require('path');
 function mkdirSyncRecursive(dir) {
   var baseDir = path.dirname(dir);
 
+  // Prevents some potential problems arising from malformed UNCs or 
+  // insufficient permissions.
+  if(baseDir == dir) {
+    throw "dirname() failed: [" + dir + "]";
+  }
+
   // Base dir exists, no recursion necessary
   if (fs.existsSync(baseDir)) {
     fs.mkdirSync(dir, parseInt('0777', 8));

--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -9,7 +9,7 @@ function mkdirSyncRecursive(dir) {
   // Prevents some potential problems arising from malformed UNCs or 
   // insufficient permissions.
   if(baseDir == dir) {
-    throw "dirname() failed: [" + dir + "]";
+    common.error("dirname() failed: [" + dir + "]");
   }
 
   // Base dir exists, no recursion necessary


### PR DESCRIPTION
Prevents an infinite loop with malformed UNCs and/or permission problems.

See https://github.com/nodejs/node/issues/7461 for the context in which I needed this fix. Let me know your thoughts. I thought it might be better to install this at a lower level the Node.js community thought it'd be disruptive.

Thanks.
