### PR TITLE
refactor: commands now register themselves

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -8,7 +8,6 @@
 
 var common = require('./src/common');
 
-
 //@
 //@ All commands run synchronously, unless otherwise stated.
 //@ All commands accept standard bash globbing characters (`*`, `?`, etc.),
@@ -24,62 +23,50 @@ var common = require('./src/common');
 // ```
 // //@include ./src/fileName
 // var functionName = require('./src/fileName');
-// exports.nameOfCommand = common.wrap(nameOfCommand, functionName, {idx: firstIndexToExpand});
+// exports.nameOfCommand = common.wrap(nameOfCommand, functionName, {globStart: firstIndexToExpand});
 // ```
 //
 // The //@include includes the docs for that command
 //
-// firstIndexToExpand should usually be 1 (so, put {idx: 1})
+// firstIndexToExpand should usually be 1 (so, put {globStart: 1})
 // Increase this value if the command takes arguments that shouldn't be expanded
 // with wildcards, such as with the regexes for sed & grep
 
 //@include ./src/cd
-var _cd = require('./src/cd');
-exports.cd = common.wrap('cd', _cd, {idx: 1});
+require('./src/cd');
 
 //@include ./src/pwd
-var _pwd = require('./src/pwd');
-exports.pwd = common.wrap('pwd', _pwd);
+require('./src/pwd');
 
 //@include ./src/ls
-var _ls = require('./src/ls');
-exports.ls = common.wrap('ls', _ls, {idx: 1});
+require('./src/ls');
 
 //@include ./src/find
-var _find = require('./src/find');
-exports.find = common.wrap('find', _find, {idx: 1});
+require('./src/find');
 
 //@include ./src/cp
-var _cp = require('./src/cp');
-exports.cp = common.wrap('cp', _cp, {idx: 1});
+require('./src/cp');
 
 //@include ./src/rm
-var _rm = require('./src/rm');
-exports.rm = common.wrap('rm', _rm, {idx: 1});
+require('./src/rm');
 
 //@include ./src/mv
-var _mv = require('./src/mv');
-exports.mv = common.wrap('mv', _mv, {idx: 1});
+require('./src/mv');
 
 //@include ./src/mkdir
-var _mkdir = require('./src/mkdir');
-exports.mkdir = common.wrap('mkdir', _mkdir, {idx: 1});
+require('./src/mkdir');
 
 //@include ./src/test
-var _test = require('./src/test');
-exports.test = common.wrap('test', _test);
+require('./src/test');
 
 //@include ./src/cat
-var _cat = require('./src/cat');
-exports.cat = common.wrap('cat', _cat, {idx: 1, canReceivePipe: true});
+require('./src/cat');
 
 //@include ./src/head
-var _head = require('./src/head');
-exports.head = common.wrap('head', _head, {idx: 1, canReceivePipe: true});
+require('./src/head');
 
 //@include ./src/tail
-var _tail = require('./src/tail');
-exports.tail = common.wrap('tail', _tail, {idx: 1, canReceivePipe: true});
+require('./src/tail');
 
 // The below commands have been moved to common.ShellString(), and are only here
 // for generating the docs
@@ -87,36 +74,25 @@ exports.tail = common.wrap('tail', _tail, {idx: 1, canReceivePipe: true});
 //@include ./src/toEnd
 
 //@include ./src/sed
-var _sed = require('./src/sed');
-exports.sed = common.wrap('sed', _sed, {idx: 3, canReceivePipe: true}); // don't glob-expand regexes
+require('./src/sed');
 
 //@include ./src/sort
-var _sort = require('./src/sort');
-exports.sort = common.wrap('sort', _sort, {idx: 1, canReceivePipe: true});
+require('./src/sort');
 
 //@include ./src/grep
-var _grep = require('./src/grep');
-exports.grep = common.wrap('grep', _grep, {idx: 2, canReceivePipe: true}); // don't glob-expand the regex
+require('./src/grep');
 
 //@include ./src/which
-var _which = require('./src/which');
-exports.which = common.wrap('which', _which);
+require('./src/which');
 
 //@include ./src/echo
-var _echo = require('./src/echo');
-exports.echo = common.wrap('echo', _echo);
+require('./src/echo');
 
 //@include ./src/dirs
-var _dirs = require('./src/dirs').dirs;
-exports.dirs = common.wrap('dirs', _dirs, {idx: 1});
-var _pushd = require('./src/dirs').pushd;
-exports.pushd = common.wrap('pushd', _pushd, {idx: 1});
-var _popd = require('./src/dirs').popd;
-exports.popd = common.wrap('popd', _popd, {idx: 1});
+require('./src/dirs');
 
 //@include ./src/ln
-var _ln = require('./src/ln');
-exports.ln = common.wrap('ln', _ln, {idx: 1});
+require('./src/ln');
 
 //@
 //@ ### exit(code)
@@ -129,20 +105,16 @@ exports.exit = process.exit;
 exports.env = process.env;
 
 //@include ./src/exec
-var _exec = require('./src/exec');
-exports.exec = common.wrap('exec', _exec, {notUnix:true, canReceivePipe: true});
+require('./src/exec');
 
 //@include ./src/chmod
-var _chmod = require('./src/chmod');
-exports.chmod = common.wrap('chmod', _chmod, {idx: 1});
+require('./src/chmod');
 
 //@include ./src/touch
-var _touch = require('./src/touch');
-exports.touch = common.wrap('touch', _touch, {idx: 1});
+require('./src/touch');
 
 //@include ./src/set
-var _set = require('./src/set');
-exports.set = common.wrap('set', _set);
+require('./src/set');
 
 
 //@
@@ -150,12 +122,11 @@ exports.set = common.wrap('set', _set);
 //@
 
 //@include ./src/tempdir
-var _tempDir = require('./src/tempdir');
-exports.tempdir = common.wrap('tempdir', _tempDir);
+require('./src/tempdir');
 
 //@include ./src/error
-var _error = require('./src/error');
-exports.error = _error;
+
+exports.error = require('./src/error');
 
 //@include ./src/common
 exports.ShellString = common.ShellString;

--- a/src/cat.js
+++ b/src/cat.js
@@ -1,6 +1,8 @@
 var common = require('./common');
 var fs = require('fs');
 
+common.register('cat', _cat, {globStart: 1, canReceivePipe: true});
+
 //@
 //@ ### cat(file [, file ...])
 //@ ### cat(file_array)

--- a/src/cd.js
+++ b/src/cd.js
@@ -1,6 +1,8 @@
 var fs = require('fs');
 var common = require('./common');
 
+common.register('cd', _cd, {globStart: 1});
+
 //@
 //@ ### cd([dir])
 //@ Changes to directory `dir` for the duration of the script. Changes to home

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -30,6 +30,8 @@ var PERMS = (function (base) {
   READ  : 4
 });
 
+common.register('chmod', _chmod, {globStart: 1});
+
 //@
 //@ ### chmod(octal_mode || octal_string, file)
 //@ ### chmod(symbolic_mode, file)

--- a/src/common.js
+++ b/src/common.js
@@ -102,8 +102,8 @@ function ShellString(stdout, stderr, code) {
   }
   that.stderr = stderr;
   that.code = code;
-  that.to    = function() {wrap('to', _to, {idx: 1}).apply(that.stdout, arguments); return that;};
-  that.toEnd = function() {wrap('toEnd', _toEnd, {idx: 1}).apply(that.stdout, arguments); return that;};
+  that.to    = function() {wrap('to', _to, {globStart: 1}).apply(that.stdout, arguments); return that;};
+  that.toEnd = function() {wrap('toEnd', _toEnd, {globStart: 1}).apply(that.stdout, arguments); return that;};
   // A list of all commands that can appear on the right-hand side of a pipe
   // (populated by calls to common.wrap())
   pipeMethods.forEach(function (cmd) {
@@ -313,10 +313,10 @@ function wrap(cmd, fn, options) {
             return arg;
         });
 
-        // Perform glob-expansion on all arguments after idx, but preserve the
-        // arguments before it (like regexes for sed and grep)
-        if (!config.noglob && typeof options.idx === 'number')
-          args = args.slice(0, options.idx).concat(expand(args.slice(options.idx)));
+        // Perform glob-expansion on all arguments after globStart, but preserve
+        // the arguments before it (like regexes for sed and grep)
+        if (!config.noglob && typeof options.globStart === 'number')
+          args = args.slice(0, options.globStart).concat(expand(args.slice(options.globStart)));
         try {
           retValue = fn.apply(this, args);
         } catch (e) {
@@ -348,3 +348,9 @@ function _readFromPipe(that) {
   return that instanceof String ? that.toString() : '';
 }
 exports.readFromPipe = _readFromPipe;
+
+// Register a new ShellJS command
+function _register(name, implementation, wrapOptions) {
+  shell[name] = wrap(name, implementation, wrapOptions);
+}
+exports.register = _register;

--- a/src/cp.js
+++ b/src/cp.js
@@ -3,6 +3,8 @@ var path = require('path');
 var common = require('./common');
 var os = require('os');
 
+common.register('cp', _cp, {globStart: 1});
+
 // Buffered file copy, synchronous
 // (Using readFileSync() + writeFileSync() could easily cause a memory overflow
 //  with large files)

--- a/src/dirs.js
+++ b/src/dirs.js
@@ -2,6 +2,10 @@ var common = require('./common');
 var _cd = require('./cd');
 var path = require('path');
 
+common.register('dirs', _dirs, {globStart: 1});
+common.register('pushd', _pushd, {globStart: 1});
+common.register('popd', _popd, {globStart: 1});
+
 // Pushd/popd/dirs internals
 var _dirStack = [];
 

--- a/src/echo.js
+++ b/src/echo.js
@@ -1,5 +1,7 @@
 var common = require('./common');
 
+common.register('echo', _echo);
+
 //@
 //@ ### echo(string [, string ...])
 //@

--- a/src/exec.js
+++ b/src/exec.js
@@ -7,6 +7,8 @@ var child = require('child_process');
 
 var DEFAULT_MAXBUFFER_SIZE = 20*1024*1024;
 
+common.register('exec', _exec, {notUnix:true, canReceivePipe: true});
+
 // Hack to run child_process.exec() synchronously (sync avoids callback hell)
 // Uses a custom wait loop that checks for a flag file, created when the child process is done.
 // (Can't do a wait loop that checks for internal Node variables/messages as

--- a/src/find.js
+++ b/src/find.js
@@ -3,6 +3,8 @@ var path = require('path');
 var common = require('./common');
 var _ls = require('./ls');
 
+common.register('find', _find, {globStart: 1});
+
 //@
 //@ ### find(path [, path ...])
 //@ ### find(path_array)

--- a/src/grep.js
+++ b/src/grep.js
@@ -1,6 +1,8 @@
 var common = require('./common');
 var fs = require('fs');
 
+common.register('grep', _grep, {globStart: 2, canReceivePipe: true}); // don't glob-expand the regex
+
 //@
 //@ ### grep([options,] regex_filter, file [, file ...])
 //@ ### grep([options,] regex_filter, file_array)

--- a/src/head.js
+++ b/src/head.js
@@ -1,6 +1,8 @@
 var common = require('./common');
 var fs = require('fs');
 
+common.register('head', _head, {globStart: 1, canReceivePipe: true});
+
 // This reads n or more lines, or the entire file, whichever is less.
 function readSomeLines(file, numLines) {
   var BUF_LENGTH = 64*1024,

--- a/src/ln.js
+++ b/src/ln.js
@@ -2,6 +2,8 @@ var fs = require('fs');
 var path = require('path');
 var common = require('./common');
 
+common.register('ln', _ln, {globStart: 1});
+
 //@
 //@ ### ln([options,] source, dest)
 //@ Available options:

--- a/src/ls.js
+++ b/src/ls.js
@@ -5,6 +5,8 @@ var glob = require('glob');
 
 var globPatternRecursive = path.sep + '**' + path.sep + '*';
 
+common.register('ls', _ls, {globStart: 1});
+
 //@
 //@ ### ls([options,] [path, ...])
 //@ ### ls([options,] path_array)

--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -2,6 +2,8 @@ var common = require('./common');
 var fs = require('fs');
 var path = require('path');
 
+common.register('mkdir', _mkdir, {globStart: 1});
+
 // Recursively creates 'dir'
 function mkdirSyncRecursive(dir) {
   var baseDir = path.dirname(dir);

--- a/src/mv.js
+++ b/src/mv.js
@@ -4,6 +4,8 @@ var common = require('./common');
 var cp = require('./cp');
 var rm = require('./rm');
 
+common.register('mv', _mv, {globStart: 1});
+
 //@
 //@ ### mv([options ,] source [, source ...], dest')
 //@ ### mv([options ,] source_array, dest')

--- a/src/pwd.js
+++ b/src/pwd.js
@@ -1,6 +1,8 @@
 var path = require('path');
 var common = require('./common');
 
+common.register('pwd', _pwd);
+
 //@
 //@ ### pwd()
 //@ Returns the current directory.

--- a/src/rm.js
+++ b/src/rm.js
@@ -1,6 +1,8 @@
 var common = require('./common');
 var fs = require('fs');
 
+common.register('rm', _rm, {globStart: 1});
+
 // Recursively removes 'dir'
 // Adapted from https://github.com/ryanmcgrath/wrench-js
 //

--- a/src/sed.js
+++ b/src/sed.js
@@ -1,6 +1,8 @@
 var common = require('./common');
 var fs = require('fs');
 
+common.register('sed', _sed, {globStart: 3, canReceivePipe: true}); // don't glob-expand regexes
+
 //@
 //@ ### sed([options,] search_regex, replacement, file [, file ...])
 //@ ### sed([options,] search_regex, replacement, file_array)

--- a/src/set.js
+++ b/src/set.js
@@ -1,5 +1,7 @@
 var common = require('./common');
 
+common.register('set', _set);
+
 //@
 //@ ### set(options)
 //@ Available options:

--- a/src/sort.js
+++ b/src/sort.js
@@ -1,6 +1,8 @@
 var common = require('./common');
 var fs = require('fs');
 
+common.register('sort', _sort, {globStart: 1, canReceivePipe: true});
+
 // parse out the number prefix of a line
 function parseNumber (str) {
   var match = str.match(/^\s*(\d*)\s*(.*)$/);

--- a/src/tail.js
+++ b/src/tail.js
@@ -1,6 +1,8 @@
 var common = require('./common');
 var fs = require('fs');
 
+common.register('tail', _tail, {globStart: 1, canReceivePipe: true});
+
 //@
 //@ ### tail([{'-n', \<num\>},] file [, file ...])
 //@ ### tail([{'-n', \<num\>},] file_array)

--- a/src/tempdir.js
+++ b/src/tempdir.js
@@ -2,6 +2,8 @@ var common = require('./common');
 var os = require('os');
 var fs = require('fs');
 
+common.register('tempdir', _tempDir);
+
 // Returns false if 'dir' is not a writeable directory, 'dir' otherwise
 function writeableDir(dir) {
   if (!dir || !fs.existsSync(dir))

--- a/src/test.js
+++ b/src/test.js
@@ -1,6 +1,8 @@
 var common = require('./common');
 var fs = require('fs');
 
+common.register('test', _test);
+
 //@
 //@ ### test(expression)
 //@ Available expression primaries:

--- a/src/touch.js
+++ b/src/touch.js
@@ -1,6 +1,8 @@
 var common = require('./common');
 var fs = require('fs');
 
+common.register('touch', _touch, {globStart: 1});
+
 //@
 //@ ### touch([options,] file [, file ...])
 //@ ### touch([options,] file_array)

--- a/src/which.js
+++ b/src/which.js
@@ -2,6 +2,8 @@ var common = require('./common');
 var fs = require('fs');
 var path = require('path');
 
+common.register('which', _which);
+
 // XP's system default value for PATHEXT system variable, just in case it's not
 // set on Windows.
 var XP_DEFAULT_PATHEXT = '.com;.exe;.bat;.cmd;.vbs;.vbe;.js;.jse;.wsf;.wsh';


### PR DESCRIPTION
This is based off the plugin API spec. All ShellJS commands now register themselves from within their source file. The only modification that is required to `shell.js` is to put:

```javascript
//@include ./src/foo
require('./src/foo');
```

for a hypothetical new command named `foo()` implemented inside of `src/foo.js`.

In a possible future plugin, the `//@include` would be unnecessary (that's for our internal docs) and the `require()` statement would be all that is needed by the plugin's end-user. The plugin hypothetically doesn't even need to export anything, because the plugin author can require ShellJS as a peer dependency and modify the existing ShellJS instance using a call to `common.register()`.

Let's wait to merge this until after #452 is merged, since I can quickly resolve the merge conflict. Send feedback my way in the meantime, however.