### PR TITLE
refactor: hook new uniq() command using new format

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -80,8 +80,7 @@ require('./src/sed');
 require('./src/sort');
 
 //@include ./src/uniq
-var _uniq = require('./src/uniq');
-exports.uniq = common.wrap('uniq', _uniq, {idx: 1, canReceivePipe: true});
+require('./src/uniq');
 
 //@include ./src/grep
 require('./src/grep');

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -10,6 +10,8 @@ function lpad(c, str){
   return res;
 }
 
+common.register('uniq', _uniq, {globStart: 1, canReceivePipe: true});
+
 //@
 //@ ### uniq([options,] [input, [output]])
 //@ Available options:

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -39,6 +39,12 @@ assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
 assert.equal(result + '', shell.cat('resources/uniq/file2u').toString());
 
+// with glob character
+result = shell.uniq('-i', 'resources/uniq/fi?e2');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+assert.equal(result + '', shell.cat('resources/uniq/file2u').toString());
+
 //uniq file1 file2
 shell.uniq('resources/uniq/file1', 'resources/uniq/file1t');
 assert.equal(shell.error(), null);


### PR DESCRIPTION
Fixes the new uniq() command to use the new format. This also adds a test to make sure it permits globbing (this was broken after merging #452 because of a recent refactor).