### PR TITLE
refactor: add wrapOutput option to auto-ShellString-ify command output

### DIFF
--- a/src/cat.js
+++ b/src/cat.js
@@ -1,7 +1,11 @@
 var common = require('./common');
 var fs = require('fs');
 
-common.register('cat', _cat, {globStart: 1, canReceivePipe: true});
+common.register('cat', _cat, {
+  globStart: 1,
+  canReceivePipe: true,
+  wrapOutput: true,
+});
 
 //@
 //@ ### cat(file [, file ...])
@@ -33,6 +37,6 @@ function _cat(options, files) {
     cat += fs.readFileSync(file, 'utf8');
   });
 
-  return new common.ShellString(cat, common.state.error, common.state.errorCode);
+  return cat;
 }
 module.exports = _cat;

--- a/src/cd.js
+++ b/src/cd.js
@@ -1,7 +1,10 @@
 var fs = require('fs');
 var common = require('./common');
 
-common.register('cd', _cd, {globStart: 1});
+common.register('cd', _cd, {
+  globStart: 1,
+  wrapOutput: true,
+});
 
 //@
 //@ ### cd([dir])
@@ -33,6 +36,6 @@ function _cd(options, dir) {
     }
     if (err) common.error(err);
   }
-  return new common.ShellString('', common.state.error, common.state.errorCode);
+  return '';
 }
 module.exports = _cd;

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -30,7 +30,10 @@ var PERMS = (function (base) {
   READ  : 4
 });
 
-common.register('chmod', _chmod, {globStart: 1});
+common.register('chmod', _chmod, {
+  globStart: 1,
+  wrapOutput: true,
+});
 
 //@
 //@ ### chmod(octal_mode || octal_string, file)
@@ -210,6 +213,6 @@ function _chmod(options, mode, filePattern) {
       fs.chmodSync(file, newPerms);
     }
   });
-  return new common.ShellString('', common.state.error, common.state.errorCode);
+  return '';
 }
 module.exports = _chmod;

--- a/src/common.js
+++ b/src/common.js
@@ -343,6 +343,11 @@ function wrap(cmd, fn, options) {
         throw e;
     }
 
+    if (options.wrapOutput &&
+        (typeof retValue === 'string' || Array.isArray(retValue))) {
+      retValue = new ShellString(retValue, state.error, state.errorCode);
+    }
+
     state.currentCmd = 'shell.js';
     return retValue;
   };

--- a/src/echo.js
+++ b/src/echo.js
@@ -1,6 +1,6 @@
 var common = require('./common');
 
-common.register('echo', _echo);
+common.register('echo', _echo, {wrapOutput: true});
 
 //@
 //@ ### echo(string [, string ...])
@@ -18,6 +18,6 @@ function _echo(opts, messages) {
   // allow strings starting with '-', see issue #20
   messages = [].slice.call(arguments, opts ? 0 : 1);
   console.log.apply(console, messages);
-  return new common.ShellString(messages.join(' '), '', 0);
+  return messages.join(' ');
 }
 module.exports = _echo;

--- a/src/find.js
+++ b/src/find.js
@@ -3,7 +3,10 @@ var path = require('path');
 var common = require('./common');
 var _ls = require('./ls');
 
-common.register('find', _find, {globStart: 1});
+common.register('find', _find, {
+  globStart: 1,
+  wrapOutput: true,
+});
 
 //@
 //@ ### find(path [, path ...])
@@ -48,6 +51,6 @@ function _find(options, paths) {
     }
   });
 
-  return new common.ShellString(list, common.state.error, common.state.errorCode);
+  return list;
 }
 module.exports = _find;

--- a/src/grep.js
+++ b/src/grep.js
@@ -8,6 +8,7 @@ common.register('grep', _grep, {
     'v': 'inverse',
     'l': 'nameOnly',
   },
+  wrapOutput: true,
 });
 
 //@
@@ -60,6 +61,6 @@ function _grep(options, regex, files) {
     }
   });
 
-  return new common.ShellString(grep.join('\n')+'\n', common.state.error, common.state.errorCode);
+  return grep.join('\n')+'\n';
 }
 module.exports = _grep;

--- a/src/head.js
+++ b/src/head.js
@@ -7,6 +7,7 @@ common.register('head', _head, {
   cmdOptions: {
     'n': 'numLines',
   },
+  wrapOutput: true,
 });
 
 // This reads n or more lines, or the entire file, whichever is less.
@@ -98,6 +99,6 @@ function _head(options, files) {
 
   if (shouldAppendNewline)
     head.push(''); // to add a trailing newline once we join
-  return new common.ShellString(head.join('\n'), common.state.error, common.state.errorCode);
+  return head.join('\n');
 }
 module.exports = _head;

--- a/src/ln.js
+++ b/src/ln.js
@@ -8,6 +8,7 @@ common.register('ln', _ln, {
     's': 'symlink',
     'f': 'force',
   },
+  wrapOutput: true,
 });
 
 //@
@@ -68,6 +69,6 @@ function _ln(options, source, dest) {
       common.error(err.message);
     }
   }
-  return new common.ShellString('', common.state.error, common.state.errorCode);
+  return '';
 }
 module.exports = _ln;

--- a/src/ls.js
+++ b/src/ls.js
@@ -14,8 +14,8 @@ common.register('ls', _ls, {
     'd': 'directory',
     'l': 'long',
   },
+  wrapOutput: true,
 });
-
 
 //@
 //@ ### ls([options,] [path, ...])
@@ -104,7 +104,7 @@ function _ls(options, paths) {
   });
 
   // Add methods, to make this more compatible with ShellStrings
-  return new common.ShellString(list, common.state.error, common.state.errorCode);
+  return list;
 }
 
 function addLsAttributes(path, stats) {

--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -7,6 +7,7 @@ common.register('mkdir', _mkdir, {
   cmdOptions: {
     'p': 'fullpath',
   },
+  wrapOutput: true,
 });
 
 // Recursively creates 'dir'
@@ -85,6 +86,6 @@ function _mkdir(options, dirs) {
         throw e;
     }
   });
-  return new common.ShellString('', common.state.error, common.state.errorCode);
+  return '';
 } // mkdir
 module.exports = _mkdir;

--- a/src/mv.js
+++ b/src/mv.js
@@ -10,6 +10,7 @@ common.register('mv', _mv, {
     'f': '!no_force',
     'n': 'no_force',
   },
+  wrapOutput: true,
 });
 
 //@
@@ -88,6 +89,6 @@ function _mv(options, sources, dest) {
       }
     }
   }); // forEach(src)
-  return new common.ShellString('', common.state.error, common.state.errorCode);
+  return '';
 } // mv
 module.exports = _mv;

--- a/src/pwd.js
+++ b/src/pwd.js
@@ -1,13 +1,13 @@
 var path = require('path');
 var common = require('./common');
 
-common.register('pwd', _pwd);
+common.register('pwd', _pwd, {wrapOutput: true});
 
 //@
 //@ ### pwd()
 //@ Returns the current directory.
 function _pwd() {
   var pwd = path.resolve(process.cwd());
-  return new common.ShellString(pwd, '', common.state.errorCode);
+  return pwd;
 }
 module.exports = _pwd;

--- a/src/rm.js
+++ b/src/rm.js
@@ -8,6 +8,7 @@ common.register('rm', _rm, {
     'r': 'recursive',
     'R': 'recursive',
   },
+  wrapOutput: true,
 });
 
 // Recursively removes 'dir'
@@ -149,6 +150,6 @@ function _rm(options, files) {
       rmdirSyncRecursive(file, options.force);
     }
   }); // forEach(file)
-  return new common.ShellString('', common.state.error, common.state.errorCode);
+  return '';
 } // rm
 module.exports = _rm;

--- a/src/sed.js
+++ b/src/sed.js
@@ -7,6 +7,7 @@ common.register('sed', _sed, {
   cmdOptions: {
     'i': 'inplace',
   },
+  wrapOutput: true,
 });
 
 //@
@@ -67,6 +68,6 @@ function _sed(options, regex, replacement, files) {
       fs.writeFileSync(file, result, 'utf8');
   });
 
-  return new common.ShellString(sed.join('\n'), common.state.error, common.state.errorCode);
+  return sed.join('\n');
 }
 module.exports = _sed;

--- a/src/sort.js
+++ b/src/sort.js
@@ -7,9 +7,9 @@ common.register('sort', _sort, {
   cmdOptions: {
     'r': 'reverse',
     'n': 'numerical',
-  }
+  },
+  wrapOutput: true,
 });
-
 
 // parse out the number prefix of a line
 function parseNumber (str) {
@@ -86,7 +86,7 @@ function _sort(options, files) {
   if (options.reverse)
     sorted = sorted.reverse();
 
-  return new common.ShellString(sorted.join('\n')+'\n', common.state.error, common.state.errorCode);
+  return sorted.join('\n')+'\n';
 }
 
 module.exports = _sort;

--- a/src/tail.js
+++ b/src/tail.js
@@ -7,6 +7,7 @@ common.register('tail', _tail, {
   cmdOptions: {
     'n': 'numLines',
   },
+  wrapOutput: true,
 });
 
 //@
@@ -67,6 +68,6 @@ function _tail(options, files) {
 
   if (shouldAppendNewline)
     tail.push(''); // to add a trailing newline once we join
-  return new common.ShellString(tail.join('\n'), common.state.error, common.state.errorCode);
+  return tail.join('\n');
 }
 module.exports = _tail;

--- a/src/touch.js
+++ b/src/touch.js
@@ -10,6 +10,7 @@ common.register('touch', _touch, {
     'm': 'mtime_only',
     'r': 'reference',
   },
+  wrapOutput: true,
 });
 
 //@
@@ -45,7 +46,7 @@ function _touch(opts, files) {
   files.forEach(function(f) {
     touchFile(opts, f);
   });
-  return new common.ShellString('', common.state.error, common.state.errorCode);
+  return '';
 }
 
 function touchFile(opts, file) {

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -18,6 +18,7 @@ common.register('uniq', _uniq, {
     'c': 'count',
     'd': 'duplicates',
   },
+  wrapOutput: true,
 });
 
 //@
@@ -67,13 +68,12 @@ function _uniq(options, input, output) {
                  return (options.count ? (lpad(7,obj.count) + ' ') : '') + obj.ln;
                }).join('\n') + '\n';
 
-  var res = new common.ShellString(uniqed, common.state.error, common.state.errorCode);
   if(output){
-    res.to(output);
+    (new common.ShellString(uniqed)).to(output);
     //if uniq writes to output, nothing is passed to the next command in the pipeline (if any)
-    return new common.ShellString('', common.state.error, common.state.errorCode);
+    return '';
   }else{
-    return res;
+    return uniqed;
   }
 }
 

--- a/src/which.js
+++ b/src/which.js
@@ -2,7 +2,7 @@ var common = require('./common');
 var fs = require('fs');
 var path = require('path');
 
-common.register('which', _which);
+common.register('which', _which, {wrapOutput: true});
 
 // XP's system default value for PATHEXT system variable, just in case it's not
 // set on Windows.
@@ -95,6 +95,6 @@ function _which(options, cmd) {
 
   where = where || path.resolve(cmd);
 
-  return new common.ShellString(where, '', common.state.errorCode);
+  return where;
 }
 module.exports = _which;


### PR DESCRIPTION
This lets you return a plain JS string (like before), but pass the `wrapOutput` option to `common.register()` in order to wrap this string in a ShellString. This wraps it with the following default parameters (which I think will work properly most of the time):

```js
return myReturnValue;
// This gets wrapped to imitate the statement:
return new common.ShellString(myReturnValue, common.state.error, common.state.errorCode);
// If any errors have occurred, put these in the .stderr attribute
// Whatever the resulting exit code is (0 unless there's an error), set that for the .code attribute
```

By default, `common.register()` works as before (so collaborators must opt-in for this feature). This lets functions return non-string output, or return a custom-built ShellString (if these default values aren't suitable).

**Do not merge until after #479 is either closed or merged**