### PR TITLE
fix: resolve a cylcic-dependency problem

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -6,7 +6,13 @@
 // http://github.com/arturadib/shelljs
 //
 
-var common = require('./src/common');
+var commonPath = './src/common';
+var common = require(commonPath);
+if (!common.register) {
+  // If this isn't defined yet, we haven't fully finished loading ./src/common
+  delete require.cache[require.resolve(commonPath)];
+  common = require(commonPath);
+}
 
 //@
 //@ All commands run synchronously, unless otherwise stated.


### PR DESCRIPTION
If a plugin was imported before the ShellJS instance was created, the user's script would crash (`common.register` wouldn't be instantiated yet). Now plugins can be imported either before or after the ShellJS instance is created.

One really cool consequence of this fix is that now plugins are compatible with the `shelljs/global` script:

```js
require('shelljs-plugin-open');
require('shelljs/global');

open('file.txt'); // it works!
```

Another cool consequence is that this would allow me to rewrite [shelljs-exec-proxy](https://github.com/nfischer/shelljs-exec-proxy) as a ShellJS plugin, which would let it play nicely with other plugins (such as shelljs-plugin-open).