### PR TITLE
refactor: expose plugin utils & add initial tests

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,16 @@
+// Various utilties exposed to plugins
+
+require('.'); // Create the ShellJS instance (mandatory)
+
+var common = require('./src/common');
+
+var exportedAttributes = [
+  'error',        // For signaling errors from within commands
+  'parseOptions', // For custom option parsing
+  'readFromPipe', // For commands with the .canReceivePipe attribute
+  'register',     // For registering plugins
+];
+
+exportedAttributes.forEach(function (attr) {
+  exports[attr] = common[attr];
+});

--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,6 @@
 // Various utilties exposed to plugins
 
-require('.'); // Create the ShellJS instance (mandatory)
+require('./shell'); // Create the ShellJS instance (mandatory)
 
 var common = require('./src/common');
 

--- a/shell.js
+++ b/shell.js
@@ -6,13 +6,7 @@
 // http://github.com/arturadib/shelljs
 //
 
-var commonPath = './src/common';
-var common = require(commonPath);
-if (!common.register) {
-  // If this isn't defined yet, we haven't fully finished loading ./src/common
-  delete require.cache[require.resolve(commonPath)];
-  common = require(commonPath);
-}
+var common = require('./src/common');
 
 //@
 //@ All commands run synchronously, unless otherwise stated.

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,0 +1,97 @@
+var plugin = require('../plugin');
+var shell = require('..');
+
+var assert = require('assert');
+
+shell.config.silent = true;
+
+var data = 0;
+var ret;
+var fname;
+
+function fooImplementation(options, arg) {
+  // Some sort of side effect, so we know when this is called
+  if (arg)
+    fname = arg;
+  else
+    fname = plugin.readFromPipe(this);
+
+  if (arg === 'exitWithCode5')
+    plugin.error('Exited with code 5', 5);
+
+  if (options.flag)
+    data = 12;
+  else
+    data++;
+  return 'hello world';
+}
+
+// All plugin utils exist
+assert.equal(typeof plugin.error, 'function');
+assert.equal(typeof plugin.parseOptions, 'function');
+assert.equal(typeof plugin.readFromPipe, 'function');
+assert.equal(typeof plugin.register, 'function');
+
+// The plugin does not exist before it's registered
+assert.ok(!shell.foo);
+
+// Register the plugin
+plugin.register('foo', fooImplementation, {
+  globStart: 1,
+  cmdOptions: {
+    'f': 'flag',
+  },
+  wrapOutput: true,
+  canReceivePipe: true,
+});
+
+// The plugin exists after registering
+assert.equal(typeof shell.foo, 'function');
+
+// The command fails for invalid options
+ret = shell.foo('-n', 'filename');
+assert.equal(ret.code, 1);
+assert.equal(ret.stdout, '');
+assert.equal(ret.stderr, 'foo: option not recognized: n');
+assert.equal(shell.error(), 'foo: option not recognized: n');
+
+// The command succeeds for normal calls
+assert.equal(data, 0);
+shell.foo('filename');
+assert.equal(data, 1);
+assert.equal(fname, 'filename');
+shell.foo('filename2');
+assert.equal(data, 2);
+assert.equal(fname, 'filename2');
+
+// The command parses options
+shell.foo('-f', 'filename');
+assert.equal(data, 12);
+assert.equal(fname, 'filename');
+
+// The command supports globbing
+shell.foo('-f', 're*u?ces');
+assert.equal(data, 12);
+assert.equal(fname, 'resources');
+
+// Plugins are also compatible with shelljs/global
+require('../global');
+assert.equal(typeof global.foo, 'function');
+assert.equal(global.foo, shell.foo);
+
+// Plugins can be added as methods to ShellStrings
+ret = shell.ShellString('hello world\n');
+assert.equal(ret.toString(), 'hello world\n');
+assert.equal(typeof ret.grep, 'function'); // existing methods persist
+assert.equal(typeof ret.foo, 'function');
+ret.foo();
+assert.equal(fname, 'hello world\n'); // readFromPipe() works
+
+// Plugins can signal errors
+ret = shell.foo('exitWithCode5');
+assert.equal(ret.code, 5);
+assert.equal(ret.stdout, '');
+assert.equal(ret.stderr, 'foo: Exited with code 5');
+assert.equal(shell.error(), 'foo: Exited with code 5');
+
+shell.exit(123);


### PR DESCRIPTION
After more experimentation, I realized that #482 wasn't a perfect approach, but that this would be a better one. Even after #482, `shell.error()` was actually broken. This fixes that issue.

This also starts differentiating internal implementations (`src/common.js`) from exposed parts of the plugin API (`plugin.js`). This is of course still far from a complete plugin API, but this should be enough to make simple plugins (and still get benefits like globbing, shelljs-style error signaling, etc.).

All implementations are still within `src/common.js`, and internal commands still rely on that directly, but external plugins are intended to use `var plugin = require('shelljs/plugin')` to get functions like `plugin.register()`. This also makes it easy to modify the plugin API without breaking ShellJS commands.

I also started unit tests for the plugin API. This creates one sample plugin (with all the bells and whistles like automatic option parsing) and then makes sure it works properly. We may also want to create a simpler plugin (i.e. no automatic option-parsing, no wrapping the return value, etc.) and test that.

If you have any suggestions on naming conventions, or think there's a better approach to this issue, let me know. Like I said, this is still far from complete, but suggestions are welcome.