### PR TITLE
fix: conflicting options now properly override each other

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -156,7 +156,7 @@ function parseOptions(opt, map) {
       if (c in map) {
         optionName = map[c];
         if (optionName[0] === '!')
-          options[optionName.slice(1, optionName.length-1)] = false;
+          options[optionName.slice(1)] = false;
         else
           options[optionName] = true;
       } else {

--- a/test/common.js
+++ b/test/common.js
@@ -74,13 +74,18 @@ assert.ok(result.no_force === false);
 assert.ok(result.force === undefined); // this key shouldn't exist
 
 // common.parseOptions (the last of the conflicting options should hold)
-result = common.parseOptions('-fn', {
+var options = {
   'n': 'no_force',
   'f': '!no_force',
   'R': 'recursive'
-});
+};
+result = common.parseOptions('-fn', options);
 assert.ok(result.recursive === false);
 assert.ok(result.no_force === true);
+assert.ok(result.force === undefined); // this key shouldn't exist
+result = common.parseOptions('-nf', options);
+assert.ok(result.recursive === false);
+assert.ok(result.no_force === false);
 assert.ok(result.force === undefined); // this key shouldn't exist
 
 // common.parseOptions using an object to hold options


### PR DESCRIPTION
Found this bug by looking at @ariporad's branch [here](https://github.com/shelljs/shelljs/commit/50e741e2e08e5e521e012d53d1fb3b19bfc0191e#diff-2c36c683dff5798fefed561dbec17803R158). Credit for finding this goes to him.

I added a unit test for it, and sure enough, the unit test won't pass unless this patch is applied.