### PR TITLE
refactor: switch from notUnix to unix in wrap()

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -274,7 +274,7 @@ function wrap(cmd, fn, options) {
         console.error.apply(console, [cmd].concat(args));
       }
 
-      if (options.notUnix) { // this branch is for exec()
+      if (options.unix === false) { // this branch is for exec()
         retValue = fn.apply(this, args);
       } else { // and this branch is for everything else
         if (args[0] instanceof Object && args[0].constructor.name === 'Object') {

--- a/src/exec.js
+++ b/src/exec.js
@@ -7,7 +7,10 @@ var child = require('child_process');
 
 var DEFAULT_MAXBUFFER_SIZE = 20*1024*1024;
 
-common.register('exec', _exec, {notUnix:true, canReceivePipe: true});
+common.register('exec', _exec, {
+  unix: false,
+  canReceivePipe: true,
+});
 
 // Hack to run child_process.exec() synchronously (sync avoids callback hell)
 // Uses a custom wait loop that checks for a flag file, created when the child process is done.


### PR DESCRIPTION
This is another refactor idea I got from one of @ariporad's refactors (I forget where exactly).

Instead of specifying `notUnix: true`, this specifies `unix: false` (probably a bit clearer down the road).