### PR TITLE
refactor: glob by default for commands

### DIFF
--- a/src/cat.js
+++ b/src/cat.js
@@ -2,9 +2,7 @@ var common = require('./common');
 var fs = require('fs');
 
 common.register('cat', _cat, {
-  globStart: 1,
   canReceivePipe: true,
-  wrapOutput: true,
 });
 
 //@

--- a/src/cd.js
+++ b/src/cd.js
@@ -1,10 +1,7 @@
 var fs = require('fs');
 var common = require('./common');
 
-common.register('cd', _cd, {
-  globStart: 1,
-  wrapOutput: true,
-});
+common.register('cd', _cd, {});
 
 //@
 //@ ### cd([dir])

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -31,8 +31,6 @@ var PERMS = (function (base) {
 });
 
 common.register('chmod', _chmod, {
-  globStart: 1,
-  wrapOutput: true,
 });
 
 //@

--- a/src/common.js
+++ b/src/common.js
@@ -101,7 +101,6 @@ function ShellString(stdout, stderr, code) {
   }
   that.stderr = stderr;
   that.code = code;
-
   // A list of all commands that can appear on the right-hand side of a pipe
   // (populated by calls to common.wrap())
   pipeMethods.forEach(function (cmd) {
@@ -313,7 +312,7 @@ function wrap(cmd, fn, options) {
 
         // Perform glob-expansion on all arguments after globStart, but preserve
         // the arguments before it (like regexes for sed and grep)
-        if (!config.noglob && typeof options.globStart === 'number') {
+        if (!config.noglob && options.allowGlobbing === true) {
           args = args.slice(0, options.globStart).concat(expand(args.slice(options.globStart)));
         }
 
@@ -359,11 +358,21 @@ function _readFromPipe(that) {
 }
 exports.readFromPipe = _readFromPipe;
 
+var DEFAULT_WRAP_OPTIONS = {
+  allowGlobbing: true,
+  canReceivePipe: false,
+  cmdOptions: false,
+  globStart: 1,
+  pipeOnly: false,
+  unix: true,
+  wrapOutput: true,
+};
+
 // Register a new ShellJS command
 function _register(name, implementation, wrapOptions) {
   wrapOptions = wrapOptions || {};
-  if (wrapOptions.pipeOnly && wrapOptions.canReceivePipe === false)
-    throw new Error('pipeOnly (true) conflicts with canReceivePipe (false)');
+  // If an option isn't specified, use the default
+  wrapOptions = objectAssign({}, DEFAULT_WRAP_OPTIONS, wrapOptions);
   if (wrapOptions.pipeOnly) {
     wrapOptions.canReceivePipe = true;
     shellMethods[name] = wrap(name, implementation, wrapOptions);

--- a/src/cp.js
+++ b/src/cp.js
@@ -3,14 +3,16 @@ var path = require('path');
 var common = require('./common');
 var os = require('os');
 
-common.register('cp', _cp, {globStart: 1, cmdOptions: {
+common.register('cp', _cp, {
+  cmdOptions: {
     'f': '!no_force',
     'n': 'no_force',
     'R': 'recursive',
     'r': 'recursive',
     'L': 'followsymlink',
     'P': 'noFollowsymlink',
-  }
+  },
+  wrapOutput: false,
 });
 
 // Buffered file copy, synchronous

--- a/src/dirs.js
+++ b/src/dirs.js
@@ -2,9 +2,15 @@ var common = require('./common');
 var _cd = require('./cd');
 var path = require('path');
 
-common.register('dirs', _dirs, {globStart: 1});
-common.register('pushd', _pushd, {globStart: 1});
-common.register('popd', _popd, {globStart: 1});
+common.register('dirs', _dirs, {
+  wrapOutput: false,
+});
+common.register('pushd', _pushd, {
+  wrapOutput: false,
+});
+common.register('popd', _popd, {
+  wrapOutput: false,
+});
 
 // Pushd/popd/dirs internals
 var _dirStack = [];

--- a/src/echo.js
+++ b/src/echo.js
@@ -1,6 +1,8 @@
 var common = require('./common');
 
-common.register('echo', _echo, {wrapOutput: true});
+common.register('echo', _echo, {
+  allowGlobbing: false,
+});
 
 //@
 //@ ### echo(string [, string ...])

--- a/src/exec.js
+++ b/src/exec.js
@@ -10,6 +10,7 @@ var DEFAULT_MAXBUFFER_SIZE = 20*1024*1024;
 common.register('exec', _exec, {
   unix: false,
   canReceivePipe: true,
+  wrapOutput: false,
 });
 
 // Hack to run child_process.exec() synchronously (sync avoids callback hell)

--- a/src/find.js
+++ b/src/find.js
@@ -3,10 +3,7 @@ var path = require('path');
 var common = require('./common');
 var _ls = require('./ls');
 
-common.register('find', _find, {
-  globStart: 1,
-  wrapOutput: true,
-});
+common.register('find', _find, {});
 
 //@
 //@ ### find(path [, path ...])

--- a/src/grep.js
+++ b/src/grep.js
@@ -8,7 +8,6 @@ common.register('grep', _grep, {
     'v': 'inverse',
     'l': 'nameOnly',
   },
-  wrapOutput: true,
 });
 
 //@

--- a/src/head.js
+++ b/src/head.js
@@ -2,12 +2,10 @@ var common = require('./common');
 var fs = require('fs');
 
 common.register('head', _head, {
-  globStart: 1,
   canReceivePipe: true,
   cmdOptions: {
     'n': 'numLines',
   },
-  wrapOutput: true,
 });
 
 // This reads n or more lines, or the entire file, whichever is less.

--- a/src/ln.js
+++ b/src/ln.js
@@ -3,12 +3,10 @@ var path = require('path');
 var common = require('./common');
 
 common.register('ln', _ln, {
-  globStart: 1,
   cmdOptions: {
     's': 'symlink',
     'f': 'force',
   },
-  wrapOutput: true,
 });
 
 //@

--- a/src/ls.js
+++ b/src/ls.js
@@ -6,7 +6,6 @@ var glob = require('glob');
 var globPatternRecursive = path.sep + '**' + path.sep + '*';
 
 common.register('ls', _ls, {
-  globStart: 1,
   cmdOptions: {
     'R': 'recursive',
     'A': 'all',
@@ -14,7 +13,6 @@ common.register('ls', _ls, {
     'd': 'directory',
     'l': 'long',
   },
-  wrapOutput: true,
 });
 
 //@

--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -3,11 +3,9 @@ var fs = require('fs');
 var path = require('path');
 
 common.register('mkdir', _mkdir, {
-  globStart: 1,
   cmdOptions: {
     'p': 'fullpath',
   },
-  wrapOutput: true,
 });
 
 // Recursively creates 'dir'

--- a/src/mv.js
+++ b/src/mv.js
@@ -5,12 +5,10 @@ var cp = require('./cp');
 var rm = require('./rm');
 
 common.register('mv', _mv, {
-  globStart: 1,
   cmdOptions: {
     'f': '!no_force',
     'n': 'no_force',
   },
-  wrapOutput: true,
 });
 
 //@

--- a/src/pwd.js
+++ b/src/pwd.js
@@ -1,7 +1,9 @@
 var path = require('path');
 var common = require('./common');
 
-common.register('pwd', _pwd, {wrapOutput: true});
+common.register('pwd', _pwd, {
+  allowGlobbing: false,
+});
 
 //@
 //@ ### pwd()

--- a/src/rm.js
+++ b/src/rm.js
@@ -2,13 +2,11 @@ var common = require('./common');
 var fs = require('fs');
 
 common.register('rm', _rm, {
-  globStart: 1,
   cmdOptions: {
     'f': 'force',
     'r': 'recursive',
     'R': 'recursive',
   },
-  wrapOutput: true,
 });
 
 // Recursively removes 'dir'

--- a/src/sed.js
+++ b/src/sed.js
@@ -7,7 +7,6 @@ common.register('sed', _sed, {
   cmdOptions: {
     'i': 'inplace',
   },
-  wrapOutput: true,
 });
 
 //@

--- a/src/set.js
+++ b/src/set.js
@@ -1,6 +1,9 @@
 var common = require('./common');
 
-common.register('set', _set);
+common.register('set', _set, {
+  allowGlobbing: false,
+  wrapOutput: false,
+});
 
 //@
 //@ ### set(options)

--- a/src/sort.js
+++ b/src/sort.js
@@ -2,13 +2,11 @@ var common = require('./common');
 var fs = require('fs');
 
 common.register('sort', _sort, {
-  globStart: 1,
   canReceivePipe: true,
   cmdOptions: {
     'r': 'reverse',
     'n': 'numerical',
   },
-  wrapOutput: true,
 });
 
 // parse out the number prefix of a line

--- a/src/tail.js
+++ b/src/tail.js
@@ -2,12 +2,10 @@ var common = require('./common');
 var fs = require('fs');
 
 common.register('tail', _tail, {
-  globStart: 1,
   canReceivePipe: true,
   cmdOptions: {
     'n': 'numLines',
   },
-  wrapOutput: true,
 });
 
 //@

--- a/src/tempdir.js
+++ b/src/tempdir.js
@@ -2,7 +2,10 @@ var common = require('./common');
 var os = require('os');
 var fs = require('fs');
 
-common.register('tempdir', _tempDir);
+common.register('tempdir', _tempDir, {
+  allowGlobbing: false,
+  wrapOutput: false,
+});
 
 // Returns false if 'dir' is not a writeable directory, 'dir' otherwise
 function writeableDir(dir) {

--- a/src/test.js
+++ b/src/test.js
@@ -12,6 +12,7 @@ common.register('test', _test, {
     'p': 'pipe',
     'S': 'socket',
   },
+  wrapOutput: false,
 });
 
 

--- a/src/to.js
+++ b/src/to.js
@@ -3,8 +3,8 @@ var fs = require('fs');
 var path = require('path');
 
 common.register('to', _to, {
-  globStart: 1,
   pipeOnly: true,
+  wrapOutput: false,
 });
 
 //@

--- a/src/toEnd.js
+++ b/src/toEnd.js
@@ -3,8 +3,8 @@ var fs = require('fs');
 var path = require('path');
 
 common.register('toEnd', _toEnd, {
-  globStart: 1,
   pipeOnly: true,
+  wrapOutput: false,
 });
 
 //@

--- a/src/touch.js
+++ b/src/touch.js
@@ -2,7 +2,6 @@ var common = require('./common');
 var fs = require('fs');
 
 common.register('touch', _touch, {
-  globStart: 1,
   cmdOptions: {
     'a': 'atime_only',
     'c': 'no_create',
@@ -10,7 +9,6 @@ common.register('touch', _touch, {
     'm': 'mtime_only',
     'r': 'reference',
   },
-  wrapOutput: true,
 });
 
 //@

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -11,14 +11,12 @@ function lpad(c, str){
 }
 
 common.register('uniq', _uniq, {
-  globStart: 1,
   canReceivePipe: true,
   cmdOptions: {
     'i': 'ignoreCase',
     'c': 'count',
     'd': 'duplicates',
   },
-  wrapOutput: true,
 });
 
 //@

--- a/src/which.js
+++ b/src/which.js
@@ -2,7 +2,9 @@ var common = require('./common');
 var fs = require('fs');
 var path = require('path');
 
-common.register('which', _which, {wrapOutput: true});
+common.register('which', _which, {
+  allowGlobbing: false,
+});
 
 // XP's system default value for PATHEXT system variable, just in case it's not
 // set on Windows.

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -37,7 +37,6 @@ assert.ok(!shell.foo);
 
 // Register the plugin
 plugin.register('foo', fooImplementation, {
-  globStart: 1,
   cmdOptions: {
     'f': 'flag',
   },
@@ -69,7 +68,7 @@ shell.foo('-f', 'filename');
 assert.equal(data, 12);
 assert.equal(fname, 'filename');
 
-// The command supports globbing
+// The command supports globbing by default
 shell.foo('-f', 're*u?ces');
 assert.equal(data, 12);
 assert.equal(fname, 'resources');


### PR DESCRIPTION
This PR accomplishes:

- `globStart` defaults to 1
- commands have argument globbing by default
- to opt out of globbing, use `allowGlobbing: false`

Commands have been refactored to take advantage of this new default value.

Also, this PR begins to store default values in a JS object for each `wrapOption`, which will probably make it easier to keep track of the defaults in the long run. Because this uses `common.expand()`, this will have a slight conflict with #490 (this is just because I renamed `expand` to `objectAssign` in that PR). I'll resolve the conflict after either PR is merged and update accordingly.

This might be a good time to discuss if we want `wrapOutput` to be true by default, since it seems like it'll be the norm for a command to use that option.