### PR TITLE
refactor: allow pipeOnly commands (methods on ShellStrings)

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -68,10 +68,11 @@ require('./src/head');
 //@include ./src/tail
 require('./src/tail');
 
-// The below commands have been moved to common.ShellString(), and are only here
-// for generating the docs
 //@include ./src/to
+require('./src/to');
+
 //@include ./src/toEnd
+require('./src/toEnd');
 
 //@include ./src/sed
 require('./src/sed');

--- a/src/to.js
+++ b/src/to.js
@@ -2,6 +2,11 @@ var common = require('./common');
 var fs = require('fs');
 var path = require('path');
 
+common.register('to', _to, {
+  globStart: 1,
+  pipeOnly: true,
+});
+
 //@
 //@ ### ShellString.prototype.to(file)
 //@
@@ -22,7 +27,7 @@ function _to(options, file) {
       common.error('no such file or directory: ' + path.dirname(file));
 
   try {
-    fs.writeFileSync(file, this.toString(), 'utf8');
+    fs.writeFileSync(file, this.stdout || this.toString(), 'utf8');
     return this;
   } catch(e) {
     common.error('could not write to file (code '+e.code+'): '+file, true);

--- a/src/toEnd.js
+++ b/src/toEnd.js
@@ -2,6 +2,11 @@ var common = require('./common');
 var fs = require('fs');
 var path = require('path');
 
+common.register('toEnd', _toEnd, {
+  globStart: 1,
+  pipeOnly: true,
+});
+
 //@
 //@ ### ShellString.prototype.toEnd(file)
 //@
@@ -21,7 +26,7 @@ function _toEnd(options, file) {
       common.error('no such file or directory: ' + path.dirname(file));
 
   try {
-    fs.appendFileSync(file, this.toString(), 'utf8');
+    fs.appendFileSync(file, this.stdout || this.toString(), 'utf8');
     return this;
   } catch(e) {
     common.error('could not append to file (code '+e.code+'): '+file, true);

--- a/test/to.js
+++ b/test/to.js
@@ -39,6 +39,7 @@ assert.equal(result, 'hello world');
 
 // With a glob
 shell.ShellString('goodbye').to('tmp/t*1');
+assert.equal(fs.existsSync('tmp/t*1'), false, 'globs are not interpreted literally');
 result = shell.cat('tmp/to1');
 assert.equal(shell.error(), null);
 assert.equal(result, 'goodbye');

--- a/test/toEnd.js
+++ b/test/toEnd.js
@@ -41,6 +41,7 @@ assert.equal(result, 'world'); //Check that the result is what we expect
 // With a glob
 shell.ShellString('good').to('tmp/toE*1');
 shell.ShellString('bye').toEnd('tmp/toE*1');
+assert.equal(fs.existsSync('tmp/toE*1'), false, 'globs are not interpreted literally');
 result = shell.cat('tmp/toEnd1');
 assert.equal(shell.error(), null);
 assert.equal(result, 'goodbye');


### PR DESCRIPTION
Fixes #487 

This implements the `pipeOnly` option to `wrapOptions`. This is false by default.

This checks for conflicts between `pipeOnly` and `canReceivePipe` and throws an exception.

This also refactors some code to take advantage of these new changes. Two test cases were modified in order to give better error messages (in case globbing ever breaks for `.to()` or `.toEnd()`).