### PR TITLE
feat: add overWrite option for commands

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -375,8 +375,9 @@ function _register(name, implementation, wrapOptions) {
   // If an option isn't specified, use the default
   wrapOptions = objectAssign({}, DEFAULT_WRAP_OPTIONS, wrapOptions);
 
-  if (shell[name] && !wrapOptions.overWrite)
-    return;
+  if (shell[name] && !wrapOptions.overWrite) {
+    throw new Error('unable to overwrite `' + name + '` command');
+  }
 
   if (wrapOptions.pipeOnly) {
     wrapOptions.canReceivePipe = true;

--- a/src/common.js
+++ b/src/common.js
@@ -366,6 +366,7 @@ var DEFAULT_WRAP_OPTIONS = {
   pipeOnly: false,
   unix: true,
   wrapOutput: true,
+  overWrite: false,
 };
 
 // Register a new ShellJS command
@@ -373,6 +374,10 @@ function _register(name, implementation, wrapOptions) {
   wrapOptions = wrapOptions || {};
   // If an option isn't specified, use the default
   wrapOptions = objectAssign({}, DEFAULT_WRAP_OPTIONS, wrapOptions);
+
+  if (shell[name] && !wrapOptions.overWrite)
+    return;
+
   if (wrapOptions.pipeOnly) {
     wrapOptions.canReceivePipe = true;
     shellMethods[name] = wrap(name, implementation, wrapOptions);

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -95,7 +95,9 @@ assert.equal(shell.error(), 'foo: Exited with code 5');
 
 // Cannot overwrite an existing command by default
 var oldCat = shell.cat;
-plugin.register('cat', fooImplementation);
+assert.throws(function () {
+  plugin.register('cat', fooImplementation);
+}, 'Error: unable to overwrite `cat` command');
 assert.equal(shell.cat, oldCat);
 
 shell.exit(123);

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -93,4 +93,9 @@ assert.equal(ret.stdout, '');
 assert.equal(ret.stderr, 'foo: Exited with code 5');
 assert.equal(shell.error(), 'foo: Exited with code 5');
 
+// Cannot overwrite an existing command by default
+var oldCat = shell.cat;
+plugin.register('cat', fooImplementation);
+assert.equal(shell.cat, oldCat);
+
 shell.exit(123);


### PR DESCRIPTION
Commands are no longer overwritten by default (probably safer and smarter), but there is an option to allow that behavior if necessary (like if someone hypothetically writes a better `find()` command to replace the builtin one).