### PR TITLE
refactor: readFromPipe() requires no arguments

### DIFF
--- a/src/cat.js
+++ b/src/cat.js
@@ -21,7 +21,7 @@ common.register('cat', _cat, {
 //@ containing the files if more than one file is given (a new line character is
 //@ introduced between each file).
 function _cat(options, files) {
-  var cat = common.readFromPipe(this);
+  var cat = common.readFromPipe();
 
   if (!files && !cat) common.error('no paths given');
 

--- a/src/common.js
+++ b/src/common.js
@@ -277,6 +277,10 @@ function wrap(cmd, fn, options) {
         console.error.apply(console, [cmd].concat(args));
       }
 
+      // If this is coming from a pipe, let's set the pipedValue (otherwise, set
+      // it to the empty string)
+      state.pipedValue = (this && typeof this.stdout === 'string') ? this.stdout : '';
+
       if (options.unix === false) { // this branch is for exec()
         retValue = fn.apply(this, args);
       } else { // and this branch is for everything else
@@ -359,8 +363,8 @@ exports.wrap = wrap;
 
 // This returns all the input that is piped into the current command (or the
 // empty string, if this isn't on the right-hand side of a pipe
-function _readFromPipe(that) {
-  return typeof that.stdout === 'string' ? that.stdout : '';
+function _readFromPipe() {
+  return state.pipedValue;
 }
 exports.readFromPipe = _readFromPipe;
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -239,7 +239,7 @@ function _exec(command, options, callback) {
   options = options || {};
   if (!command) common.error('must specify command');
 
-  var pipe = common.readFromPipe(this);
+  var pipe = common.readFromPipe();
 
   // Callback is defined instead of options.
   if (typeof options === 'function') {

--- a/src/grep.js
+++ b/src/grep.js
@@ -29,7 +29,7 @@ common.register('grep', _grep, {
 //@ file that match the given `regex_filter`.
 function _grep(options, regex, files) {
   // Check if this is coming from a pipe
-  var pipe = common.readFromPipe(this);
+  var pipe = common.readFromPipe();
 
   if (!files && !pipe) common.error('no paths given', 2);
 

--- a/src/head.js
+++ b/src/head.js
@@ -53,7 +53,7 @@ function readSomeLines(file, numLines) {
 //@ Read the start of a file.
 function _head(options, files) {
   var head = [];
-  var pipe = common.readFromPipe(this);
+  var pipe = common.readFromPipe();
 
   if (!files && !pipe) common.error('no paths given');
 

--- a/src/sed.js
+++ b/src/sed.js
@@ -27,7 +27,7 @@ common.register('sed', _sed, {
 //@ using the given search regex and replacement string or function. Returns the new string after replacement.
 function _sed(options, regex, replacement, files) {
   // Check if this is coming from a pipe
-  var pipe = common.readFromPipe(this);
+  var pipe = common.readFromPipe();
 
   if (typeof replacement !== 'string' && typeof replacement !== 'function') {
     if (typeof replacement === 'number') {

--- a/src/sort.js
+++ b/src/sort.js
@@ -57,7 +57,7 @@ function numericalCmp(a, b) {
 //@ files mixes their content, just like unix sort does.
 function _sort(options, files) {
   // Check if this is coming from a pipe
-  var pipe = common.readFromPipe(this);
+  var pipe = common.readFromPipe();
 
   if (!files && !pipe) common.error('no files given');
 

--- a/src/tail.js
+++ b/src/tail.js
@@ -26,7 +26,7 @@ common.register('tail', _tail, {
 //@ Read the end of a file.
 function _tail(options, files) {
   var tail = [];
-  var pipe = common.readFromPipe(this);
+  var pipe = common.readFromPipe();
 
   if (!files && !pipe) common.error('no paths given');
 

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -38,7 +38,7 @@ common.register('uniq', _uniq, {
 //@ Filter adjacent matching lines from input
 function _uniq(options, input, output) {
   // Check if this is coming from a pipe
-  var pipe = common.readFromPipe(this);
+  var pipe = common.readFromPipe();
 
   if (!input && !pipe) common.error('no input given');
 

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -14,7 +14,7 @@ function fooImplementation(options, arg) {
   if (arg) {
     fname = arg;
   } else {
-    fname = plugin.readFromPipe(this);
+    fname = plugin.readFromPipe();
   }
 
   if (arg === 'exitWithCode5') {


### PR DESCRIPTION
`readFromPipe()` no longer requires `this` to be passed in as the first parameter.

Fixes #485 