### PR TITLE
refactor: replace fs.existsSync

### DIFF
--- a/src/cat.js
+++ b/src/cat.js
@@ -28,7 +28,7 @@ function _cat(options, files) {
   files = [].slice.call(arguments, 1);
 
   files.forEach(function (file) {
-    if (!fs.existsSync(file)) {
+    if (!common.existsSync(file)) {
       common.error('no such file or directory: ' + file);
     }
 

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -102,7 +102,7 @@ function _chmod(options, mode, filePattern) {
 
   files.forEach(function innerChmod(file) {
     file = path.resolve(file);
-    if (!fs.existsSync(file)) {
+    if (!common.existsSync(file)) {
       common.error('File not found: ' + file);
     }
 

--- a/src/common.js
+++ b/src/common.js
@@ -81,6 +81,16 @@ function error(msg, _code, _continue) {
 }
 exports.error = error;
 
+function existsSync(file) {
+  try {
+    fs.accessSync(file);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+exports.existsSync = existsSync;
+
 //@
 //@ ### ShellString(str)
 //@

--- a/src/common.js
+++ b/src/common.js
@@ -83,7 +83,7 @@ exports.error = error;
 
 function existsSync(file) {
   try {
-    fs.accessSync(file);
+    fs.statSync(file);
     return true;
   } catch (e) {
     return false;

--- a/src/cp.js
+++ b/src/cp.js
@@ -19,7 +19,7 @@ common.register('cp', _cp, {
 // (Using readFileSync() + writeFileSync() could easily cause a memory overflow
 //  with large files)
 function copyFileSync(srcFile, destFile, options) {
-  if (!fs.existsSync(srcFile)) {
+  if (!common.existsSync(srcFile)) {
     common.error('copyFileSync: no such file or directory: ' + srcFile);
   }
 
@@ -135,7 +135,7 @@ function cpdirSyncRecursive(sourceDir, destDir, opts) {
       }
     } else {
       /* At this point, we've hit a file actually worth copying... so copy it on over. */
-      if (fs.existsSync(destFile) && opts.no_force) {
+      if (common.existsSync(destFile) && opts.no_force) {
         common.log('skipping existing file: ' + files[i]);
       } else {
         copyFileSync(srcFile, destFile, opts);
@@ -204,7 +204,7 @@ function _cp(options, sources, dest) {
     dest = arguments[arguments.length - 1];
   }
 
-  var destExists = fs.existsSync(dest);
+  var destExists = common.existsSync(dest);
   var destStat = destExists && fs.statSync(dest);
 
   // Dest is not existing dir, but multiple sources given
@@ -218,7 +218,7 @@ function _cp(options, sources, dest) {
   }
 
   sources.forEach(function (src) {
-    if (!fs.existsSync(src)) {
+    if (!common.existsSync(src)) {
       common.error('no such file or directory: ' + src, true);
       return; // skip file
     }
@@ -251,7 +251,7 @@ function _cp(options, sources, dest) {
         thisDest = path.normalize(dest + '/' + path.basename(src));
       }
 
-      if (fs.existsSync(thisDest) && options.no_force) {
+      if (common.existsSync(thisDest) && options.no_force) {
         return; // skip file
       }
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -37,7 +37,7 @@ function execSync(cmd, opts, pipe) {
   var previousStderrContent = '';
   // Echoes stdout and stderr changes from running process, if not silent
   function updateStream(streamFile) {
-    if (opts.silent || !fs.existsSync(streamFile)) {
+    if (opts.silent || !common.existsSync(streamFile)) {
       return;
     }
 
@@ -61,10 +61,10 @@ function execSync(cmd, opts, pipe) {
     previousStreamContent = streamContent;
   }
 
-  if (fs.existsSync(scriptFile)) common.unlinkSync(scriptFile);
-  if (fs.existsSync(stdoutFile)) common.unlinkSync(stdoutFile);
-  if (fs.existsSync(stderrFile)) common.unlinkSync(stderrFile);
-  if (fs.existsSync(codeFile)) common.unlinkSync(codeFile);
+  if (common.existsSync(scriptFile)) common.unlinkSync(scriptFile);
+  if (common.existsSync(stdoutFile)) common.unlinkSync(stdoutFile);
+  if (common.existsSync(stderrFile)) common.unlinkSync(stderrFile);
+  if (common.existsSync(codeFile)) common.unlinkSync(codeFile);
 
   var execCommand = JSON.stringify(process.execPath) + ' ' + JSON.stringify(scriptFile);
   var script;
@@ -134,9 +134,9 @@ function execSync(cmd, opts, pipe) {
     // sleepFile is used as a dummy I/O op to mitigate unnecessary CPU usage
     // (tried many I/O sync ops, writeFileSync() seems to be only one that is effective in reducing
     // CPU usage, though apparently not so much on Windows)
-    while (!fs.existsSync(codeFile)) { updateStream(stdoutFile); fs.writeFileSync(sleepFile, 'a'); }
-    while (!fs.existsSync(stdoutFile)) { updateStream(stdoutFile); fs.writeFileSync(sleepFile, 'a'); }
-    while (!fs.existsSync(stderrFile)) { updateStream(stderrFile); fs.writeFileSync(sleepFile, 'a'); }
+    while (!common.existsSync(codeFile)) { updateStream(stdoutFile); fs.writeFileSync(sleepFile, 'a'); }
+    while (!common.existsSync(stdoutFile)) { updateStream(stdoutFile); fs.writeFileSync(sleepFile, 'a'); }
+    while (!common.existsSync(stderrFile)) { updateStream(stderrFile); fs.writeFileSync(sleepFile, 'a'); }
     try { common.unlinkSync(sleepFile); } catch (e) {}
   }
 

--- a/src/grep.js
+++ b/src/grep.js
@@ -41,7 +41,7 @@ function _grep(options, regex, files) {
 
   var grep = [];
   files.forEach(function (file) {
-    if (!fs.existsSync(file) && file !== '-') {
+    if (!common.existsSync(file) && file !== '-') {
       common.error('no such file or directory: ' + file, 2, true);
       return;
     }

--- a/src/head.js
+++ b/src/head.js
@@ -72,7 +72,7 @@ function _head(options, files) {
 
   var shouldAppendNewline = false;
   files.forEach(function (file) {
-    if (!fs.existsSync(file) && file !== '-') {
+    if (!common.existsSync(file) && file !== '-') {
       common.error('no such file or directory: ' + file, true);
       return;
     }

--- a/src/ln.js
+++ b/src/ln.js
@@ -34,7 +34,7 @@ function _ln(options, source, dest) {
   var isAbsolute = (path.resolve(source) === sourcePath);
   dest = path.resolve(process.cwd(), String(dest));
 
-  if (fs.existsSync(dest)) {
+  if (common.existsSync(dest)) {
     if (!options.force) {
       common.error('Destination file exists', true);
     }
@@ -46,7 +46,7 @@ function _ln(options, source, dest) {
     var isWindows = common.platform === 'win';
     var linkType = isWindows ? 'file' : null;
     var resolvedSourcePath = isAbsolute ? sourcePath : path.resolve(process.cwd(), path.dirname(dest), source);
-    if (!fs.existsSync(resolvedSourcePath)) {
+    if (!common.existsSync(resolvedSourcePath)) {
       common.error('Source file does not exist', true);
     } else if (isWindows && fs.statSync(resolvedSourcePath).isDirectory()) {
       linkType = 'junction';
@@ -58,7 +58,7 @@ function _ln(options, source, dest) {
       common.error(err.message);
     }
   } else {
-    if (!fs.existsSync(source)) {
+    if (!common.existsSync(source)) {
       common.error('Source file does not exist', true);
     }
     try {

--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -20,7 +20,7 @@ function mkdirSyncRecursive(dir) {
   }
 
   // Base dir exists, no recursion necessary
-  if (fs.existsSync(baseDir)) {
+  if (common.existsSync(baseDir)) {
     fs.mkdirSync(dir, parseInt('0777', 8));
     return;
   }
@@ -68,7 +68,7 @@ function _mkdir(options, dirs) {
 
     // Base dir does not exist, and no -p option given
     var baseDir = path.dirname(dir);
-    if (!fs.existsSync(baseDir) && !options.fullpath) {
+    if (!common.existsSync(baseDir) && !options.fullpath) {
       common.error('no such file or directory: ' + baseDir, true);
       return; // skip dir
     }

--- a/src/mv.js
+++ b/src/mv.js
@@ -41,7 +41,7 @@ function _mv(options, sources, dest) {
     common.error('invalid arguments');
   }
 
-  var exists = fs.existsSync(dest);
+  var exists = common.existsSync(dest);
   var stats = exists && fs.statSync(dest);
 
   // Dest is not existing dir, but multiple sources given
@@ -55,7 +55,7 @@ function _mv(options, sources, dest) {
   }
 
   sources.forEach(function (src) {
-    if (!fs.existsSync(src)) {
+    if (!common.existsSync(src)) {
       common.error('no such file or directory: ' + src, true);
       return; // skip file
     }
@@ -65,11 +65,11 @@ function _mv(options, sources, dest) {
     // When copying to '/path/dir':
     //    thisDest = '/path/dir/file1'
     var thisDest = dest;
-    if (fs.existsSync(dest) && fs.statSync(dest).isDirectory()) {
+    if (common.existsSync(dest) && fs.statSync(dest).isDirectory()) {
       thisDest = path.normalize(dest + '/' + path.basename(src));
     }
 
-    if (fs.existsSync(thisDest) && options.no_force) {
+    if (common.existsSync(thisDest) && options.no_force) {
       common.error('dest file already exists: ' + thisDest, true);
       return; // skip file
     }

--- a/src/rm.js
+++ b/src/rm.js
@@ -50,7 +50,7 @@ function rmdirSyncRecursive(dir, force) {
     while (true) {
       try {
         result = fs.rmdirSync(dir);
-        if (fs.existsSync(dir)) throw { code: 'EAGAIN' };
+        if (common.existsSync(dir)) throw { code: 'EAGAIN' };
         break;
       } catch (er) {
         // In addition to error codes, also check if the directory still exists and loop again if true

--- a/src/sed.js
+++ b/src/sed.js
@@ -54,7 +54,7 @@ function _sed(options, regex, replacement, files) {
 
   var sed = [];
   files.forEach(function (file) {
-    if (!fs.existsSync(file) && file !== '-') {
+    if (!common.existsSync(file) && file !== '-') {
       common.error('no such file or directory: ' + file, 2, true);
       return;
     }

--- a/src/sort.js
+++ b/src/sort.js
@@ -69,7 +69,7 @@ function _sort(options, files) {
 
   var lines = [];
   files.forEach(function (file) {
-    if (!fs.existsSync(file) && file !== '-') {
+    if (!common.existsSync(file) && file !== '-') {
       // exit upon any sort of error
       common.error('no such file or directory: ' + file);
     }

--- a/src/tail.js
+++ b/src/tail.js
@@ -46,7 +46,7 @@ function _tail(options, files) {
 
   var shouldAppendNewline = false;
   files.forEach(function (file) {
-    if (!fs.existsSync(file) && file !== '-') {
+    if (!common.existsSync(file) && file !== '-') {
       common.error('no such file or directory: ' + file, true);
       return;
     }

--- a/src/tempdir.js
+++ b/src/tempdir.js
@@ -9,7 +9,7 @@ common.register('tempdir', _tempDir, {
 
 // Returns false if 'dir' is not a writeable directory, 'dir' otherwise
 function writeableDir(dir) {
-  if (!dir || !fs.existsSync(dir)) return false;
+  if (!dir || !common.existsSync(dir)) return false;
 
   if (!fs.statSync(dir).isDirectory()) return false;
 

--- a/src/test.js
+++ b/src/test.js
@@ -57,7 +57,7 @@ function _test(options, path) {
     }
   }
 
-  if (!fs.existsSync(path)) return false;
+  if (!common.existsSync(path)) return false;
 
   if (options.exists) return true;
 

--- a/src/to.js
+++ b/src/to.js
@@ -22,7 +22,7 @@ common.register('to', _to, {
 function _to(options, file) {
   if (!file) common.error('wrong arguments');
 
-  if (!fs.existsSync(path.dirname(file))) {
+  if (!common.existsSync(path.dirname(file))) {
     common.error('no such file or directory: ' + path.dirname(file));
   }
 

--- a/src/toEnd.js
+++ b/src/toEnd.js
@@ -21,7 +21,7 @@ common.register('toEnd', _toEnd, {
 function _toEnd(options, file) {
   if (!file) common.error('wrong arguments');
 
-  if (!fs.existsSync(path.dirname(file))) {
+  if (!common.existsSync(path.dirname(file))) {
     common.error('no such file or directory: ' + path.dirname(file));
   }
 

--- a/src/which.js
+++ b/src/which.js
@@ -22,7 +22,7 @@ function splitPath(p) {
 }
 
 function checkPath(pathName) {
-  return fs.existsSync(pathName) && !fs.statSync(pathName).isDirectory();
+  return common.existsSync(pathName) && !fs.statSync(pathName).isDirectory();
 }
 
 //@

--- a/test/cat.js
+++ b/test/cat.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 shell.config.silent = true;
 
@@ -17,7 +17,7 @@ assert.ok(shell.error());
 assert.equal(result.code, 1);
 assert.equal(result.stderr, 'cat: no paths given');
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 result = shell.cat('/asdfasdf'); // file does not exist
 assert.ok(shell.error());
 assert.equal(result.code, 1);

--- a/test/cd.js
+++ b/test/cd.js
@@ -2,7 +2,6 @@ var shell = require('..');
 
 var assert = require('assert');
 var path = require('path');
-var fs = require('fs');
 var common = require('../src/common');
 
 shell.config.silent = true;
@@ -17,13 +16,13 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 var result = shell.cd('/asdfasdf'); // dir does not exist
 assert.ok(shell.error());
 assert.equal(result.code, 1);
 assert.equal(result.stderr, 'cd: no such file or directory: /asdfasdf');
 
-assert.equal(fs.existsSync('resources/file1'), true); // sanity check
+assert.equal(common.existsSync('resources/file1'), true); // sanity check
 result = shell.cd('resources/file1'); // file, not dir
 assert.ok(shell.error());
 assert.equal(result.code, 1);
@@ -61,7 +60,7 @@ assert.equal(process.cwd(), path.resolve(cur.toString()));
 
 result = shell.cd(cur);
 result = shell.rm('-f', 'tmp/*');
-assert.equal(fs.existsSync('tmp/file1'), false);
+assert.equal(common.existsSync('tmp/file1'), false);
 result = shell.cd('resources');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
@@ -71,7 +70,7 @@ assert.equal(result.code, 0);
 result = shell.cd('../tmp');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('file1'), true);
+assert.equal(common.existsSync('file1'), true);
 
 // Test tilde expansion
 

--- a/test/cp.js
+++ b/test/cp.js
@@ -49,28 +49,28 @@ shell.rm('-rf', 'tmp/*');
 result = shell.cp('-@', 'resources/file1', 'tmp/file1'); // option not supported, files OK
 assert.ok(shell.error());
 assert.equal(result.code, 1);
-assert.equal(fs.existsSync('tmp/file1'), false);
+assert.equal(common.existsSync('tmp/file1'), false);
 assert.equal(result.stderr, 'cp: option not recognized: @');
 
 result = shell.cp('-Z', 'asdfasdf', 'tmp/file2'); // option not supported, files NOT OK
 assert.ok(shell.error());
 assert.equal(result.code, 1);
-assert.equal(fs.existsSync('tmp/file2'), false);
+assert.equal(common.existsSync('tmp/file2'), false);
 assert.equal(result.stderr, 'cp: option not recognized: Z');
 
 result = shell.cp('asdfasdf', 'tmp'); // source does not exist
 assert.ok(shell.error());
 assert.equal(result.code, 1);
 assert.equal(numLines(result.stderr), 1);
-assert.equal(fs.existsSync('tmp/asdfasdf'), false);
+assert.equal(common.existsSync('tmp/asdfasdf'), false);
 assert.equal(result.stderr, 'cp: no such file or directory: asdfasdf');
 
 result = shell.cp('asdfasdf1', 'asdfasdf2', 'tmp'); // sources do not exist
 assert.ok(shell.error());
 assert.equal(result.code, 1);
 assert.equal(numLines(result.stderr), 2);
-assert.equal(fs.existsSync('tmp/asdfasdf1'), false);
-assert.equal(fs.existsSync('tmp/asdfasdf2'), false);
+assert.equal(common.existsSync('tmp/asdfasdf1'), false);
+assert.equal(common.existsSync('tmp/asdfasdf2'), false);
 assert.equal(result.stderr, 'cp: no such file or directory: asdfasdf1\ncp: no such file or directory: asdfasdf2');
 
 result = shell.cp('asdfasdf1', 'asdfasdf2', 'resources/file1'); // too many sources (dest is file)
@@ -81,7 +81,7 @@ assert.equal(result.stderr, 'cp: dest is not a directory (too many sources)');
 result = shell.cp('resources/file1', 'resources/file2', 'tmp/a_file'); // too many sources
 assert.ok(shell.error());
 assert.equal(result.code, 1);
-assert.equal(fs.existsSync('tmp/a_file'), false);
+assert.equal(common.existsSync('tmp/a_file'), false);
 assert.equal(result.stderr, 'cp: dest is not a directory (too many sources)');
 
 //
@@ -121,14 +121,14 @@ result = shell.cp('resources/file1', 'tmp');
 assert.equal(shell.error(), null);
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/file1'), true);
+assert.equal(common.existsSync('tmp/file1'), true);
 
 // simple - to file
 result = shell.cp('resources/file2', 'tmp/file2');
 assert.equal(shell.error(), null);
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/file2'), true);
+assert.equal(common.existsSync('tmp/file2'), true);
 
 // simple - file list
 shell.rm('-rf', 'tmp/*');
@@ -136,8 +136,8 @@ result = shell.cp('resources/file1', 'resources/file2', 'tmp');
 assert.equal(shell.error(), null);
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/file1'), true);
-assert.equal(fs.existsSync('tmp/file2'), true);
+assert.equal(common.existsSync('tmp/file1'), true);
+assert.equal(common.existsSync('tmp/file2'), true);
 
 // simple - file list, array syntax
 shell.rm('-rf', 'tmp/*');
@@ -145,16 +145,16 @@ result = shell.cp(['resources/file1', 'resources/file2'], 'tmp');
 assert.equal(shell.error(), null);
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/file1'), true);
-assert.equal(fs.existsSync('tmp/file2'), true);
+assert.equal(common.existsSync('tmp/file1'), true);
+assert.equal(common.existsSync('tmp/file2'), true);
 
 result = shell.cp('resources/file2', 'tmp/file3');
-assert.equal(fs.existsSync('tmp/file3'), true);
+assert.equal(common.existsSync('tmp/file3'), true);
 result = shell.cp('-f', 'resources/file2', 'tmp/file3'); // file exists, but -f specified
 assert.equal(shell.error(), null);
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/file3'), true);
+assert.equal(common.existsSync('tmp/file3'), true);
 
 // glob
 shell.rm('-rf', 'tmp/*');
@@ -162,12 +162,12 @@ result = shell.cp('resources/file?', 'tmp');
 assert.equal(shell.error(), null);
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.ok(fs.existsSync('tmp/file1'));
-assert.ok(fs.existsSync('tmp/file2'));
-assert.ok(!fs.existsSync('tmp/file1.js'));
-assert.ok(!fs.existsSync('tmp/file2.js'));
-assert.ok(!fs.existsSync('tmp/file1.txt'));
-assert.ok(!fs.existsSync('tmp/file2.txt'));
+assert.ok(common.existsSync('tmp/file1'));
+assert.ok(common.existsSync('tmp/file2'));
+assert.ok(!common.existsSync('tmp/file1.js'));
+assert.ok(!common.existsSync('tmp/file2.js'));
+assert.ok(!common.existsSync('tmp/file1.txt'));
+assert.ok(!common.existsSync('tmp/file2.txt'));
 
 // wildcard
 shell.rm('tmp/file1', 'tmp/file2');
@@ -175,12 +175,12 @@ result = shell.cp('resources/file*', 'tmp');
 assert.equal(shell.error(), null);
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.ok(fs.existsSync('tmp/file1'));
-assert.ok(fs.existsSync('tmp/file2'));
-assert.ok(fs.existsSync('tmp/file1.js'));
-assert.ok(fs.existsSync('tmp/file2.js'));
-assert.ok(fs.existsSync('tmp/file1.txt'));
-assert.ok(fs.existsSync('tmp/file2.txt'));
+assert.ok(common.existsSync('tmp/file1'));
+assert.ok(common.existsSync('tmp/file2'));
+assert.ok(common.existsSync('tmp/file1.js'));
+assert.ok(common.existsSync('tmp/file2.js'));
+assert.ok(common.existsSync('tmp/file1.txt'));
+assert.ok(common.existsSync('tmp/file2.txt'));
 
 // recursive, with regular files
 shell.rm('-rf', 'tmp/*');
@@ -188,8 +188,8 @@ result = shell.cp('-R', 'resources/file1', 'resources/file2', 'tmp');
 assert.equal(shell.error(), null);
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.ok(fs.existsSync('tmp/file1'));
-assert.ok(fs.existsSync('tmp/file2'));
+assert.ok(common.existsSync('tmp/file1'));
+assert.ok(common.existsSync('tmp/file2'));
 
 // recursive, nothing exists
 shell.rm('-rf', 'tmp/*');
@@ -213,8 +213,8 @@ result = shell.cp('-R', 'resources/file*.txt', 'tmp');
 assert.equal(shell.error(), null);
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.ok(fs.existsSync('tmp/file1.txt'));
-assert.ok(fs.existsSync('tmp/file2.txt'));
+assert.ok(common.existsSync('tmp/file1.txt'));
+assert.ok(common.existsSync('tmp/file2.txt'));
 
 // recursive, copying one regular file (also related to Github issue #376)
 shell.rm('-rf', 'tmp/*');
@@ -222,7 +222,7 @@ result = shell.cp('-R', 'resources/file1.txt', 'tmp');
 assert.equal(shell.error(), null);
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.ok(fs.existsSync('tmp/file1.txt'));
+assert.ok(common.existsSync('tmp/file1.txt'));
 assert.ok(!fs.statSync('tmp/file1.txt').isDirectory()); // don't let it be a dir
 
 // recursive, everything exists, no force flag
@@ -292,7 +292,7 @@ result = shell.cp('-r', 'resources/issue44', 'tmp/dir2/dir3');
 assert.ok(shell.error());
 assert.equal(result.stderr, 'cp: cannot create directory \'tmp/dir2/dir3\': No such file or directory');
 assert.equal(result.code, 1);
-assert.equal(fs.existsSync('tmp/dir2'), false);
+assert.equal(common.existsSync('tmp/dir2'), false);
 
 // recursive, copies entire directory
 shell.rm('-rf', 'tmp/*');
@@ -300,13 +300,13 @@ result = shell.cp('-r', 'resources/cp/dir_a', 'tmp/dest');
 assert.equal(shell.error(), null);
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/dest/z'), true);
+assert.equal(common.existsSync('tmp/dest/z'), true);
 
 // recursive, with trailing slash, does the exact same
 shell.rm('-rf', 'tmp/*');
 result = shell.cp('-r', 'resources/cp/dir_a/', 'tmp/dest');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/dest/z'), true);
+assert.equal(common.existsSync('tmp/dest/z'), true);
 
 // On Windows, permission bits are quite different so skip those tests for now
 if (common.platform !== 'win') {
@@ -324,16 +324,16 @@ result = shell.cp('-r', 'resources/ls/', 'tmp/');
 assert.ok(!shell.error());
 assert.ok(!result.stderr);
 assert.equal(result.code, 0);
-assert.ok(fs.existsSync('tmp/.hidden_file'));
+assert.ok(common.existsSync('tmp/.hidden_file'));
 
 // no-recursive will copy regular files only
 shell.rm('-rf', 'tmp/');
 shell.mkdir('tmp/');
 result = shell.cp('resources/file1.txt', 'resources/ls/', 'tmp/');
 assert.ok(shell.error());
-assert.ok(!fs.existsSync('tmp/.hidden_file')); // doesn't copy dir contents
-assert.ok(!fs.existsSync('tmp/ls')); // doesn't copy dir itself
-assert.ok(fs.existsSync('tmp/file1.txt'));
+assert.ok(!common.existsSync('tmp/.hidden_file')); // doesn't copy dir contents
+assert.ok(!common.existsSync('tmp/ls')); // doesn't copy dir itself
+assert.ok(common.existsSync('tmp/file1.txt'));
 
 // no-recursive will copy regular files only
 shell.rm('-rf', 'tmp/');
@@ -341,12 +341,12 @@ shell.mkdir('tmp/');
 result = shell.cp('resources/file1.txt', 'resources/file2.txt', 'resources/cp',
   'resources/ls/', 'tmp/');
 assert.ok(shell.error());
-assert.ok(!fs.existsSync('tmp/.hidden_file')); // doesn't copy dir contents
-assert.ok(!fs.existsSync('tmp/ls')); // doesn't copy dir itself
-assert.ok(!fs.existsSync('tmp/a')); // doesn't copy dir contents
-assert.ok(!fs.existsSync('tmp/cp')); // doesn't copy dir itself
-assert.ok(fs.existsSync('tmp/file1.txt'));
-assert.ok(fs.existsSync('tmp/file2.txt'));
+assert.ok(!common.existsSync('tmp/.hidden_file')); // doesn't copy dir contents
+assert.ok(!common.existsSync('tmp/ls')); // doesn't copy dir itself
+assert.ok(!common.existsSync('tmp/a')); // doesn't copy dir contents
+assert.ok(!common.existsSync('tmp/cp')); // doesn't copy dir itself
+assert.ok(common.existsSync('tmp/file1.txt'));
+assert.ok(common.existsSync('tmp/file2.txt'));
 
 if (process.platform !== 'win32') {
   // -R implies -P
@@ -376,7 +376,7 @@ if (process.platform !== 'win32') {
   assert.equal(shell.error(), null);
   assert.ok(!result.stderr);
   assert.equal(result.code, 0);
-  assert.equal(fs.existsSync('tmp/dest/z'), true);
+  assert.equal(common.existsSync('tmp/dest/z'), true);
 }
 
 // using -R on a link to a folder *does* follow the link

--- a/test/global.js
+++ b/test/global.js
@@ -1,9 +1,9 @@
 /* globals cat, config, cp, env, error, exit, mkdir, rm */
 
 require('../global');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 config.silent = true;
 
@@ -24,11 +24,11 @@ assert.equal(result, 'test1\n');
 
 // rm
 cp('-f', 'resources/file1', 'tmp/file1');
-assert.equal(fs.existsSync('tmp/file1'), true);
+assert.equal(common.existsSync('tmp/file1'), true);
 result = rm('tmp/file1');
 assert.equal(error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/file1'), false);
+assert.equal(common.existsSync('tmp/file1'), false);
 
 // String.prototype is modified for global require
 'foo'.to('tmp/testfile.txt');

--- a/test/grep.js
+++ b/test/grep.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 shell.config.silent = true;
 
@@ -22,7 +22,7 @@ result = shell.grep(/asdf/g); // too few args
 assert.ok(shell.error());
 assert.equal(result.code, 2);
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 result = shell.grep(/asdf/g, '/asdfasdf'); // no such file
 assert.ok(shell.error());
 assert.equal(result.stderr, 'grep: no such file or directory: /asdfasdf');
@@ -30,8 +30,8 @@ assert.equal(result.code, 2);
 
 // if at least one file is missing, this should be an error
 shell.cp('-f', 'resources/file1', 'tmp/file1');
-assert.equal(fs.existsSync('asdfasdf'), false); // sanity check
-assert.equal(fs.existsSync('tmp/file1'), true); // sanity check
+assert.equal(common.existsSync('asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('tmp/file1'), true); // sanity check
 result = shell.grep(/asdf/g, 'tmp/file1', 'asdfasdf');
 assert.ok(shell.error());
 assert.equal(result.stderr, 'grep: no such file or directory: asdfasdf');

--- a/test/head.js
+++ b/test/head.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 shell.config.silent = true;
 
@@ -18,7 +18,7 @@ result = shell.head();
 assert.ok(shell.error());
 assert.equal(result.code, 1);
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 result = shell.head('/adsfasdf'); // file does not exist
 assert.ok(shell.error());
 assert.equal(result.code, 1);

--- a/test/ln.js
+++ b/test/ln.js
@@ -68,7 +68,7 @@ assert.equal(result.code, 1);
 //
 
 result = shell.ln('tmp/file1', 'tmp/linkfile1');
-assert(fs.existsSync('tmp/linkfile1'));
+assert(common.existsSync('tmp/linkfile1'));
 assert.equal(
   fs.readFileSync('tmp/file1').toString(),
   fs.readFileSync('tmp/linkfile1').toString()
@@ -83,7 +83,7 @@ assert.equal(result.code, 0);
 // With glob
 shell.rm('tmp/linkfile1');
 result = shell.ln('tmp/fi*1', 'tmp/linkfile1');
-assert(fs.existsSync('tmp/linkfile1'));
+assert(common.existsSync('tmp/linkfile1'));
 assert.equal(
   fs.readFileSync('tmp/file1').toString(),
   fs.readFileSync('tmp/linkfile1').toString()
@@ -96,7 +96,7 @@ assert.equal(
 assert.equal(result.code, 0);
 
 skipOnWinForEPERM(shell.ln.bind(shell, '-s', 'file2', 'tmp/linkfile2'), function () {
-  assert(fs.existsSync('tmp/linkfile2'));
+  assert(common.existsSync('tmp/linkfile2'));
   assert.equal(
         fs.readFileSync('tmp/file2').toString(),
         fs.readFileSync('tmp/linkfile2').toString()
@@ -112,8 +112,8 @@ skipOnWinForEPERM(shell.ln.bind(shell, '-s', 'file2', 'tmp/linkfile2'), function
 shell.mkdir('tmp/ln');
 shell.touch('tmp/ln/hello');
 result = shell.ln('-s', 'ln', 'tmp/dir1');
-assert(fs.existsSync('tmp/ln/hello'));
-assert(fs.existsSync('tmp/dir1/hello'));
+assert(common.existsSync('tmp/ln/hello'));
+assert(common.existsSync('tmp/dir1/hello'));
 assert.equal(result.code, 0);
 
 // To current directory
@@ -121,8 +121,8 @@ shell.cd('tmp');
 result = shell.ln('-s', './', 'dest');
 assert.equal(result.code, 0);
 shell.touch('testfile.txt');
-assert(fs.existsSync('testfile.txt'));
-assert(fs.existsSync('dest/testfile.txt'));
+assert(common.existsSync('testfile.txt'));
+assert(common.existsSync('dest/testfile.txt'));
 shell.rm('-f', 'dest');
 shell.mkdir('dir1');
 shell.cd('dir1');
@@ -130,15 +130,15 @@ result = shell.ln('-s', './', '../dest');
 assert.equal(result.code, 0);
 shell.touch('insideDir.txt');
 shell.cd('..');
-assert(fs.existsSync('testfile.txt'));
-assert(fs.existsSync('dest/testfile.txt'));
-assert(fs.existsSync('dir1/insideDir.txt'));
-assert(!fs.existsSync('dest/insideDir.txt'));
+assert(common.existsSync('testfile.txt'));
+assert(common.existsSync('dest/testfile.txt'));
+assert(common.existsSync('dir1/insideDir.txt'));
+assert(!common.existsSync('dest/insideDir.txt'));
 shell.cd('..');
 
 result = shell.ln('-f', 'tmp/file1.js', 'tmp/file2.js');
 assert.equal(result.code, 0);
-assert(fs.existsSync('tmp/file2.js'));
+assert(common.existsSync('tmp/file2.js'));
 assert.equal(
   fs.readFileSync('tmp/file1.js').toString(),
   fs.readFileSync('tmp/file2.js').toString()
@@ -150,7 +150,7 @@ assert.equal(
 );
 
 skipOnWinForEPERM(shell.ln.bind(shell, '-sf', 'file1.txt', 'tmp/file2.txt'), function () {
-  assert(fs.existsSync('tmp/file2.txt'));
+  assert(common.existsSync('tmp/file2.txt'));
   assert.equal(
         fs.readFileSync('tmp/file1.txt').toString(),
         fs.readFileSync('tmp/file2.txt').toString()
@@ -164,7 +164,7 @@ skipOnWinForEPERM(shell.ln.bind(shell, '-sf', 'file1.txt', 'tmp/file2.txt'), fun
 
 // Abspath regression
 skipOnWinForEPERM(shell.ln.bind(shell, '-sf', 'file1', path.resolve('tmp/abspath')), function () {
-  assert(fs.existsSync('tmp/abspath'));
+  assert(common.existsSync('tmp/abspath'));
   assert.equal(
         fs.readFileSync('tmp/file1').toString(),
         fs.readFileSync('tmp/abspath').toString()
@@ -182,7 +182,7 @@ skipOnWinForEPERM(shell.ln.bind(shell, '-sf', 'file1.txt', 'tmp/file2.txt'), fun
     // Move the symlink first, as the reverse confuses `mv`.
   shell.mv('tmp/file2.txt', 'tmp/new/file2.txt');
   shell.mv('tmp/file1.txt', 'tmp/new/file1.txt');
-  assert(fs.existsSync('tmp/new/file2.txt'));
+  assert(common.existsSync('tmp/new/file2.txt'));
   assert.equal(
         fs.readFileSync('tmp/new/file1.txt').toString(),
         fs.readFileSync('tmp/new/file2.txt').toString()

--- a/test/ls.js
+++ b/test/ls.js
@@ -1,4 +1,5 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
 var fs = require('fs');
@@ -15,7 +16,7 @@ var k;
 // Invalids
 //
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 var result = shell.ls('/asdfasdf'); // no such file or dir
 assert.ok(shell.error());
 assert.equal(result.code, 2);
@@ -417,7 +418,7 @@ shell.rm('-r', 'foo');
 assert.ok(!shell.error());
 
 // Check stderr field
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 result = shell.ls('resources/ls/file1', '/asdfasdf');
 assert.ok(shell.error());
 assert.equal('ls: no such file or directory: /asdfasdf', result.stderr);

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -1,4 +1,5 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
 var fs = require('fs');
@@ -33,13 +34,13 @@ assert.equal(result.code, 1);
 assert.equal(result.stderr, 'mkdir: path already exists: resources/badlink');
 assert.equal(fs.lstatSync('resources/badlink').mtime.toString(), mtime); // didn't mess with file
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 result = shell.mkdir('/asdfasdf/foobar'); // root path does not exist
 assert.ok(shell.error());
 assert.equal(result.code, 1);
 assert.equal(result.stderr, 'mkdir: no such file or directory: /asdfasdf');
-assert.equal(fs.existsSync('/asdfasdf'), false);
-assert.equal(fs.existsSync('/asdfasdf/foobar'), false);
+assert.equal(common.existsSync('/asdfasdf'), false);
+assert.equal(common.existsSync('/asdfasdf/foobar'), false);
 
 // Check for invalid permissions
 if (process.platform !== 'win32') {
@@ -52,7 +53,7 @@ if (process.platform !== 'win32') {
   assert.equal(result.code, 1);
   assert.equal(result.stderr, 'mkdir: cannot create directory nowritedir/foo: Permission denied');
   assert.ok(shell.error());
-  assert.equal(fs.existsSync(dirName + '/foo'), false);
+  assert.equal(common.existsSync(dirName + '/foo'), false);
   shell.rm('-rf', dirName); // clean up
 }
 
@@ -60,59 +61,59 @@ if (process.platform !== 'win32') {
 // Valids
 //
 
-assert.equal(fs.existsSync('tmp/t1'), false);
+assert.equal(common.existsSync('tmp/t1'), false);
 result = shell.mkdir('tmp/t1'); // simple dir
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/t1'), true);
+assert.equal(common.existsSync('tmp/t1'), true);
 
-assert.equal(fs.existsSync('tmp/t2'), false);
-assert.equal(fs.existsSync('tmp/t3'), false);
+assert.equal(common.existsSync('tmp/t2'), false);
+assert.equal(common.existsSync('tmp/t3'), false);
 result = shell.mkdir('tmp/t2', 'tmp/t3'); // multiple dirs
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/t2'), true);
-assert.equal(fs.existsSync('tmp/t3'), true);
+assert.equal(common.existsSync('tmp/t2'), true);
+assert.equal(common.existsSync('tmp/t3'), true);
 
-assert.equal(fs.existsSync('tmp/t1'), true);
-assert.equal(fs.existsSync('tmp/t4'), false);
+assert.equal(common.existsSync('tmp/t1'), true);
+assert.equal(common.existsSync('tmp/t4'), false);
 result = shell.mkdir('tmp/t1', 'tmp/t4'); // one dir exists, one doesn't
 assert.equal(numLines(shell.error()), 1);
-assert.equal(fs.existsSync('tmp/t1'), true);
-assert.equal(fs.existsSync('tmp/t4'), true);
+assert.equal(common.existsSync('tmp/t1'), true);
+assert.equal(common.existsSync('tmp/t4'), true);
 
-assert.equal(fs.existsSync('tmp/a'), false);
+assert.equal(common.existsSync('tmp/a'), false);
 result = shell.mkdir('-p', 'tmp/a/b/c');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
+assert.equal(common.existsSync('tmp/a/b/c'), true);
 shell.rm('-Rf', 'tmp/a'); // revert
 
 // multiple dirs
 result = shell.mkdir('-p', 'tmp/zzza', 'tmp/zzzb', 'tmp/zzzc');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/zzza'), true);
-assert.equal(fs.existsSync('tmp/zzzb'), true);
-assert.equal(fs.existsSync('tmp/zzzc'), true);
+assert.equal(common.existsSync('tmp/zzza'), true);
+assert.equal(common.existsSync('tmp/zzzb'), true);
+assert.equal(common.existsSync('tmp/zzzc'), true);
 
 // multiple dirs, array syntax
 result = shell.mkdir('-p', ['tmp/yyya', 'tmp/yyyb', 'tmp/yyyc']);
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/yyya'), true);
-assert.equal(fs.existsSync('tmp/yyyb'), true);
-assert.equal(fs.existsSync('tmp/yyyc'), true);
+assert.equal(common.existsSync('tmp/yyya'), true);
+assert.equal(common.existsSync('tmp/yyyb'), true);
+assert.equal(common.existsSync('tmp/yyyc'), true);
 
 // globbed dir
 result = shell.mkdir('-p', 'tmp/mydir');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/mydir'), true);
+assert.equal(common.existsSync('tmp/mydir'), true);
 result = shell.mkdir('-p', 'tmp/m*ir');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/mydir'), true);
-assert.equal(fs.existsSync('tmp/m*ir'), false); // doesn't create literal name
+assert.equal(common.existsSync('tmp/mydir'), true);
+assert.equal(common.existsSync('tmp/m*ir'), false); // doesn't create literal name
 
 shell.exit(123);

--- a/test/mv.js
+++ b/test/mv.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 var numLines = require('./utils/utils').numLines;
 
 shell.config.silent = true;
@@ -33,22 +33,22 @@ assert.equal(result.stderr, 'mv: missing <source> and/or <dest>');
 
 result = shell.mv('-Z', 'tmp/file1', 'tmp/file1'); // option not supported
 assert.ok(shell.error());
-assert.equal(fs.existsSync('tmp/file1'), true);
+assert.equal(common.existsSync('tmp/file1'), true);
 assert.equal(result.code, 1);
 assert.equal(result.stderr, 'mv: option not recognized: Z');
 
 result = shell.mv('asdfasdf', 'tmp'); // source does not exist
 assert.ok(shell.error());
 assert.equal(numLines(shell.error()), 1);
-assert.equal(fs.existsSync('tmp/asdfasdf'), false);
+assert.equal(common.existsSync('tmp/asdfasdf'), false);
 assert.equal(result.code, 1);
 assert.equal(result.stderr, 'mv: no such file or directory: asdfasdf');
 
 result = shell.mv('asdfasdf1', 'asdfasdf2', 'tmp'); // sources do not exist
 assert.ok(shell.error());
 assert.equal(numLines(shell.error()), 2);
-assert.equal(fs.existsSync('tmp/asdfasdf1'), false);
-assert.equal(fs.existsSync('tmp/asdfasdf2'), false);
+assert.equal(common.existsSync('tmp/asdfasdf1'), false);
+assert.equal(common.existsSync('tmp/asdfasdf2'), false);
 assert.equal(result.code, 1);
 assert.equal(result.stderr, 'mv: no such file or directory: asdfasdf1\nmv: no such file or directory: asdfasdf2');
 
@@ -78,16 +78,16 @@ assert.equal(result.stderr, 'mv: dest file already exists: tmp/file2');
 
 result = shell.mv('tmp/file1', 'tmp/file2', 'tmp/a_file'); // too many sources (exist, but dest is file)
 assert.ok(shell.error());
-assert.equal(fs.existsSync('tmp/a_file'), false);
+assert.equal(common.existsSync('tmp/a_file'), false);
 assert.equal(result.code, 1);
 assert.equal(result.stderr, 'mv: dest is not a directory (too many sources)');
 
 result = shell.mv('tmp/file*', 'tmp/file1'); // can't use wildcard when dest is file
 assert.ok(shell.error());
-assert.equal(fs.existsSync('tmp/file1'), true);
-assert.equal(fs.existsSync('tmp/file2'), true);
-assert.equal(fs.existsSync('tmp/file1.js'), true);
-assert.equal(fs.existsSync('tmp/file2.js'), true);
+assert.equal(common.existsSync('tmp/file1'), true);
+assert.equal(common.existsSync('tmp/file2'), true);
+assert.equal(common.existsSync('tmp/file1.js'), true);
+assert.equal(common.existsSync('tmp/file2.js'), true);
 assert.equal(result.code, 1);
 assert.equal(result.stderr, 'mv: dest is not a directory (too many sources)');
 
@@ -101,20 +101,20 @@ shell.cd('tmp');
 shell.mkdir('tmp2');
 result = shell.mv('*', 'tmp2'); // has to handle self (tmp2 --> tmp2) without throwing error
 assert.ok(shell.error()); // there's an error, but not fatal
-assert.equal(fs.existsSync('tmp2/file1'), true); // moved OK
+assert.equal(common.existsSync('tmp2/file1'), true); // moved OK
 assert.equal(result.code, 1);
 result = shell.mv('tmp2/*', '.'); // revert
-assert.equal(fs.existsSync('file1'), true); // moved OK
+assert.equal(common.existsSync('file1'), true); // moved OK
 assert.equal(result.code, 0);
 
 result = shell.mv('file1', 'file3'); // one source
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('file1'), false);
-assert.equal(fs.existsSync('file3'), true);
+assert.equal(common.existsSync('file1'), false);
+assert.equal(common.existsSync('file3'), true);
 result = shell.mv('file3', 'file1'); // revert
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('file1'), true);
+assert.equal(common.existsSync('file1'), true);
 assert.equal(result.code, 0);
 
 // two sources
@@ -123,14 +123,14 @@ shell.mkdir('-p', 't');
 result = shell.mv('file1', 'file2', 't');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('file1'), false);
-assert.equal(fs.existsSync('file2'), false);
-assert.equal(fs.existsSync('t/file1'), true);
-assert.equal(fs.existsSync('t/file2'), true);
+assert.equal(common.existsSync('file1'), false);
+assert.equal(common.existsSync('file2'), false);
+assert.equal(common.existsSync('t/file1'), true);
+assert.equal(common.existsSync('t/file2'), true);
 result = shell.mv('t/*', '.'); // revert
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('file1'), true);
-assert.equal(fs.existsSync('file2'), true);
+assert.equal(common.existsSync('file1'), true);
+assert.equal(common.existsSync('file2'), true);
 
 // two sources, array style
 shell.rm('-rf', 't');
@@ -138,29 +138,29 @@ shell.mkdir('-p', 't');
 result = shell.mv(['file1', 'file2'], 't'); // two sources
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('file1'), false);
-assert.equal(fs.existsSync('file2'), false);
-assert.equal(fs.existsSync('t/file1'), true);
-assert.equal(fs.existsSync('t/file2'), true);
+assert.equal(common.existsSync('file1'), false);
+assert.equal(common.existsSync('file2'), false);
+assert.equal(common.existsSync('t/file1'), true);
+assert.equal(common.existsSync('t/file2'), true);
 result = shell.mv('t/*', '.'); // revert
-assert.equal(fs.existsSync('file1'), true);
-assert.equal(fs.existsSync('file2'), true);
+assert.equal(common.existsSync('file1'), true);
+assert.equal(common.existsSync('file2'), true);
 
 result = shell.mv('file*.js', 't'); // wildcard
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('file1.js'), false);
-assert.equal(fs.existsSync('file2.js'), false);
-assert.equal(fs.existsSync('t/file1.js'), true);
-assert.equal(fs.existsSync('t/file2.js'), true);
+assert.equal(common.existsSync('file1.js'), false);
+assert.equal(common.existsSync('file2.js'), false);
+assert.equal(common.existsSync('t/file1.js'), true);
+assert.equal(common.existsSync('t/file2.js'), true);
 result = shell.mv('t/*', '.'); // revert
-assert.equal(fs.existsSync('file1.js'), true);
-assert.equal(fs.existsSync('file2.js'), true);
+assert.equal(common.existsSync('file1.js'), true);
+assert.equal(common.existsSync('file2.js'), true);
 
 result = shell.mv('-f', 'file1', 'file2'); // dest exists, but -f given
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('file1'), false);
-assert.equal(fs.existsSync('file2'), true);
+assert.equal(common.existsSync('file1'), false);
+assert.equal(common.existsSync('file2'), true);
 
 shell.exit(123);

--- a/test/rm.js
+++ b/test/rm.js
@@ -1,4 +1,5 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
 var path = require('path');
@@ -34,7 +35,7 @@ assert.equal(result.stderr, 'rm: no paths given');
 result = shell.rm('-@', 'resources/file1'); // invalid option
 assert.ok(shell.error());
 assert.equal(result.code, 1);
-assert.equal(fs.existsSync('resources/file1'), true);
+assert.equal(common.existsSync('resources/file1'), true);
 assert.equal(result.stderr, 'rm: option not recognized: @');
 
 //
@@ -68,61 +69,61 @@ assert.equal(result.code, 0);
 
 // simple rm
 shell.cp('-f', 'resources/file1', 'tmp/file1');
-assert.equal(fs.existsSync('tmp/file1'), true);
+assert.equal(common.existsSync('tmp/file1'), true);
 result = shell.rm('tmp/file1');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/file1'), false);
+assert.equal(common.existsSync('tmp/file1'), false);
 
 // recursive dir removal - small-caps '-r'
 shell.mkdir('-p', 'tmp/a/b/c');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
+assert.equal(common.existsSync('tmp/a/b/c'), true);
 result = shell.rm('-rf', 'tmp/a');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/a'), false);
+assert.equal(common.existsSync('tmp/a'), false);
 
 // recursive dir removal - capital '-R'
 shell.mkdir('-p', 'tmp/a/b/c');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
+assert.equal(common.existsSync('tmp/a/b/c'), true);
 result = shell.rm('-Rf', 'tmp/a');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/a'), false);
+assert.equal(common.existsSync('tmp/a'), false);
 
 // recursive dir removal - absolute path
 shell.mkdir('-p', 'tmp/a/b/c');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
+assert.equal(common.existsSync('tmp/a/b/c'), true);
 result = shell.rm('-Rf', path.resolve('./tmp/a'));
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/a'), false);
+assert.equal(common.existsSync('tmp/a'), false);
 
 // wildcard
 shell.cp('-f', 'resources/file*', 'tmp');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/file1'), true);
-assert.equal(fs.existsSync('tmp/file2'), true);
-assert.equal(fs.existsSync('tmp/file1.js'), true);
-assert.equal(fs.existsSync('tmp/file2.js'), true);
+assert.equal(common.existsSync('tmp/file1'), true);
+assert.equal(common.existsSync('tmp/file2'), true);
+assert.equal(common.existsSync('tmp/file1.js'), true);
+assert.equal(common.existsSync('tmp/file2.js'), true);
 result = shell.rm('tmp/file*');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/file1'), false);
-assert.equal(fs.existsSync('tmp/file2'), false);
-assert.equal(fs.existsSync('tmp/file1.js'), false);
-assert.equal(fs.existsSync('tmp/file2.js'), false);
+assert.equal(common.existsSync('tmp/file1'), false);
+assert.equal(common.existsSync('tmp/file2'), false);
+assert.equal(common.existsSync('tmp/file1.js'), false);
+assert.equal(common.existsSync('tmp/file2.js'), false);
 
 // recursive dir removal
 shell.mkdir('-p', 'tmp/a/b/c');
 shell.mkdir('-p', 'tmp/b');
 shell.mkdir('-p', 'tmp/c');
 shell.mkdir('-p', 'tmp/.hidden');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
-assert.equal(fs.existsSync('tmp/b'), true);
-assert.equal(fs.existsSync('tmp/c'), true);
-assert.equal(fs.existsSync('tmp/.hidden'), true);
+assert.equal(common.existsSync('tmp/a/b/c'), true);
+assert.equal(common.existsSync('tmp/b'), true);
+assert.equal(common.existsSync('tmp/c'), true);
+assert.equal(common.existsSync('tmp/.hidden'), true);
 result = shell.rm('-rf', 'tmp/*');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
@@ -135,10 +136,10 @@ shell.mkdir('-p', 'tmp/a/b/c');
 shell.mkdir('-p', 'tmp/b');
 shell.mkdir('-p', 'tmp/c');
 shell.mkdir('-p', 'tmp/.hidden');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
-assert.equal(fs.existsSync('tmp/b'), true);
-assert.equal(fs.existsSync('tmp/c'), true);
-assert.equal(fs.existsSync('tmp/.hidden'), true);
+assert.equal(common.existsSync('tmp/a/b/c'), true);
+assert.equal(common.existsSync('tmp/b'), true);
+assert.equal(common.existsSync('tmp/c'), true);
+assert.equal(common.existsSync('tmp/.hidden'), true);
 result = shell.rm('-rf', 'tmp/*', 'tmp/.*');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
@@ -150,10 +151,10 @@ shell.mkdir('-p', 'tmp/a/b/c');
 shell.mkdir('-p', 'tmp/b');
 shell.mkdir('-p', 'tmp/c');
 shell.mkdir('-p', 'tmp/.hidden');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
-assert.equal(fs.existsSync('tmp/b'), true);
-assert.equal(fs.existsSync('tmp/c'), true);
-assert.equal(fs.existsSync('tmp/.hidden'), true);
+assert.equal(common.existsSync('tmp/a/b/c'), true);
+assert.equal(common.existsSync('tmp/b'), true);
+assert.equal(common.existsSync('tmp/c'), true);
+assert.equal(common.existsSync('tmp/.hidden'), true);
 result = shell.rm('-rf', ['tmp/*', 'tmp/.*']);
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
@@ -165,7 +166,7 @@ shell.mkdir('-p', 'tmp/readonly');
 shell.ShellString('asdf').to('tmp/readonly/file1');
 fs.chmodSync('tmp/readonly/file1', '0444'); // -r--r--r--
 result = shell.rm('tmp/readonly/file1');
-assert.equal(fs.existsSync('tmp/readonly/file1'), true); // bash's rm always asks before removing read-only files
+assert.equal(common.existsSync('tmp/readonly/file1'), true); // bash's rm always asks before removing read-only files
                                                          // here we just assume "no"
 
 // removal of a read-only file (forced)
@@ -173,7 +174,7 @@ shell.mkdir('-p', 'tmp/readonly');
 shell.ShellString('asdf').to('tmp/readonly/file2');
 fs.chmodSync('tmp/readonly/file2', '0444'); // -r--r--r--
 result = shell.rm('-f', 'tmp/readonly/file2');
-assert.equal(fs.existsSync('tmp/readonly/file2'), false);
+assert.equal(common.existsSync('tmp/readonly/file2'), false);
 
 // removal of a tree containing read-only files (unforced)
 shell.mkdir('-p', 'tmp/tree2');
@@ -181,8 +182,8 @@ shell.ShellString('asdf').to('tmp/tree2/file1');
 shell.ShellString('asdf').to('tmp/tree2/file2');
 fs.chmodSync('tmp/tree2/file1', '0444'); // -r--r--r--
 result = shell.rm('-r', 'tmp/tree2');
-assert.equal(fs.existsSync('tmp/tree2/file1'), true);
-assert.equal(fs.existsSync('tmp/tree2/file2'), false);
+assert.equal(common.existsSync('tmp/tree2/file1'), true);
+assert.equal(common.existsSync('tmp/tree2/file2'), false);
 
 // removal of a tree containing read-only files (forced)
 shell.mkdir('-p', 'tmp/tree');
@@ -190,7 +191,7 @@ shell.ShellString('asdf').to('tmp/tree/file1');
 shell.ShellString('asdf').to('tmp/tree/file2');
 fs.chmodSync('tmp/tree/file1', '0444'); // -r--r--r--
 result = shell.rm('-rf', 'tmp/tree');
-assert.equal(fs.existsSync('tmp/tree'), false);
+assert.equal(common.existsSync('tmp/tree'), false);
 
 // removal of a sub-tree containing read-only and hidden files - rm('dir/*')
 shell.mkdir('-p', 'tmp/tree3');
@@ -216,7 +217,7 @@ fs.chmodSync('tmp/tree4/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree4/subtree/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree4/.hidden/file', '0444'); // -r--r--r--
 result = shell.rm('-rf', 'tmp/tree4'); // erase dir contents
-assert.equal(fs.existsSync('tmp/tree4'), false);
+assert.equal(common.existsSync('tmp/tree4'), false);
 
 // remove symbolic link to a dir
 result = shell.rm('-rf', 'tmp');
@@ -225,8 +226,8 @@ shell.cp('-R', 'resources/rm', 'tmp');
 result = shell.rm('-f', 'tmp/rm/link_to_a_dir');
 assert.equal(shell.error(), null);
 assert.equal(result.code, 0);
-assert.equal(fs.existsSync('tmp/rm/link_to_a_dir'), false);
-assert.equal(fs.existsSync('tmp/rm/a_dir'), true);
+assert.equal(common.existsSync('tmp/rm/link_to_a_dir'), false);
+assert.equal(common.existsSync('tmp/rm/a_dir'), true);
 
 // remove broken symbolic link
 if (process.platform !== 'win32') {
@@ -238,7 +239,7 @@ if (process.platform !== 'win32') {
   assert.equal(shell.error(), null);
   assert.equal(result.code, 0);
   assert.ok(!shell.test('-L', 'tmp/rm/fake.lnk'));
-  assert.equal(fs.existsSync('tmp/rm/fake.lnk'), false);
+  assert.equal(common.existsSync('tmp/rm/fake.lnk'), false);
 }
 
 shell.exit(123);

--- a/test/sed.js
+++ b/test/sed.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 shell.config.silent = true;
 
@@ -27,7 +27,7 @@ result = shell.sed(/asdf/g, 'nada'); // too few args
 assert.ok(shell.error());
 assert.equal(result.code, 1);
 
-assert.equal(fs.existsSync('asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('asdfasdf'), false); // sanity check
 result = shell.sed(/asdf/g, 'nada', 'asdfasdf'); // no such file
 assert.ok(shell.error());
 assert.equal(result.code, 2);
@@ -35,8 +35,8 @@ assert.equal(result.stderr, 'sed: no such file or directory: asdfasdf');
 
 // if at least one file is missing, this should be an error
 shell.cp('-f', 'resources/file1', 'tmp/file1');
-assert.equal(fs.existsSync('asdfasdf'), false); // sanity check
-assert.equal(fs.existsSync('tmp/file1'), true); // sanity check
+assert.equal(common.existsSync('asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('tmp/file1'), true); // sanity check
 result = shell.sed(/asdf/g, 'nada', 'tmp/file1', 'asdfasdf');
 assert.ok(shell.error());
 assert.equal(result.code, 2);

--- a/test/sort.js
+++ b/test/sort.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 shell.config.silent = true;
 
@@ -26,7 +26,7 @@ result = shell.sort();
 assert.ok(shell.error());
 assert.ok(result.code);
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 result = shell.sort('/adsfasdf'); // file does not exist
 assert.ok(shell.error());
 assert.ok(result.code);

--- a/test/tail.js
+++ b/test/tail.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 shell.config.silent = true;
 
@@ -18,7 +18,7 @@ result = shell.tail();
 assert.ok(shell.error());
 assert.equal(result.code, 1);
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 result = shell.tail('/adsfasdf'); // file does not exist
 assert.ok(shell.error());
 assert.equal(result.code, 1);

--- a/test/tempdir.js
+++ b/test/tempdir.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 shell.config.silent = true;
 
@@ -14,6 +14,6 @@ shell.mkdir('tmp');
 
 var tmp = shell.tempdir();
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync(tmp), true);
+assert.equal(common.existsSync(tmp), true);
 
 shell.exit(123);

--- a/test/to.js
+++ b/test/to.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 shell.config.silent = true;
 
@@ -19,7 +19,7 @@ assert.ok(typeof str.to === 'undefined');
 shell.ShellString('hello world').to();
 assert.ok(shell.error());
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 shell.ShellString('hello world').to('/asdfasdf/file');
 assert.ok(shell.error());
 
@@ -39,7 +39,7 @@ assert.equal(result, 'hello world');
 
 // With a glob
 shell.ShellString('goodbye').to('tmp/t*1');
-assert.equal(fs.existsSync('tmp/t*1'), false, 'globs are not interpreted literally');
+assert.equal(common.existsSync('tmp/t*1'), false, 'globs are not interpreted literally');
 result = shell.cat('tmp/to1');
 assert.equal(shell.error(), null);
 assert.equal(result, 'goodbye');

--- a/test/toEnd.js
+++ b/test/toEnd.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 shell.config.silent = true;
 
@@ -19,17 +19,17 @@ assert.ok(typeof str.toEnd === 'undefined');
 shell.ShellString('hello world').toEnd();
 assert.ok(shell.error());
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 assert.ok(shell.error());
 //
 // Valids
 //
 
 var result;
-assert.equal(fs.existsSync('tmp/toEnd1'), false); // Check file toEnd() creates does not already exist
-assert.equal(fs.existsSync('tmp/toEnd2'), false);
+assert.equal(common.existsSync('tmp/toEnd1'), false); // Check file toEnd() creates does not already exist
+assert.equal(common.existsSync('tmp/toEnd2'), false);
 shell.ShellString('hello ').toEnd('tmp/toEnd1');
-assert.equal(fs.existsSync('tmp/toEnd1'), true); // Check that file was created
+assert.equal(common.existsSync('tmp/toEnd1'), true); // Check that file was created
 shell.ShellString('world').toEnd('tmp/toEnd1').toEnd('tmp/toEnd2'); // Write some more to the file
 result = shell.cat('tmp/toEnd1');
 assert.equal(shell.error(), null);
@@ -41,7 +41,7 @@ assert.equal(result, 'world'); // Check that the result is what we expect
 // With a glob
 shell.ShellString('good').to('tmp/toE*1');
 shell.ShellString('bye').toEnd('tmp/toE*1');
-assert.equal(fs.existsSync('tmp/toE*1'), false, 'globs are not interpreted literally');
+assert.equal(common.existsSync('tmp/toE*1'), false, 'globs are not interpreted literally');
 result = shell.cat('tmp/toEnd1');
 assert.equal(shell.error(), null);
 assert.equal(result, 'goodbye');

--- a/test/touch.js
+++ b/test/touch.js
@@ -1,4 +1,5 @@
 var shell = require('..');
+var common = require('../src/common');
 var assert = require('assert');
 var fs = require('fs');
 var crypto = require('crypto');
@@ -30,13 +31,13 @@ assert.equal(result.code, 0);
 // creates new files
 testFile = tmpFile();
 result = shell.touch(testFile);
-assert(fs.existsSync(testFile));
+assert(common.existsSync(testFile));
 
 // does not create a file if told not to
 testFile = tmpFile(true);
 result = shell.touch('-c', testFile);
 assert.equal(result.code, 0);
-assert.ok(!fs.existsSync(testFile));
+assert.ok(!common.existsSync(testFile));
 
 // handles globs correctly
 result = shell.touch('tmp/file.txt');
@@ -100,8 +101,8 @@ testFile2 = tmpFile(true);
 shell.rm('-f', testFile, testFile2);
 result = shell.touch(testFile, testFile2);
 assert.equal(result.code, 0);
-assert(fs.existsSync(testFile));
-assert(fs.existsSync(testFile2));
+assert(common.existsSync(testFile));
+assert(common.existsSync(testFile2));
 
 // file array
 testFile = tmpFile(true);
@@ -109,15 +110,15 @@ testFile2 = tmpFile(true);
 shell.rm('-f', testFile, testFile2);
 result = shell.touch([testFile, testFile2]);
 assert.equal(result.code, 0);
-assert(fs.existsSync(testFile));
-assert(fs.existsSync(testFile2));
+assert(common.existsSync(testFile));
+assert(common.existsSync(testFile2));
 
 // touching broken link creates a new file
 if (process.platform !== 'win32') {
   result = shell.touch('resources/badlink');
   assert.equal(result.code, 0);
   assert.ok(!shell.error());
-  assert.ok(fs.existsSync('resources/not_existed_file'));
+  assert.ok(common.existsSync('resources/not_existed_file'));
   shell.rm('resources/not_existed_file');
 }
 

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 shell.config.silent = true;
 
@@ -18,7 +18,7 @@ result = shell.uniq();
 assert.ok(shell.error());
 assert.ok(result.code);
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(common.existsSync('/asdfasdf'), false); // sanity check
 result = shell.sort('/adsfasdf'); // file does not exist
 assert.ok(shell.error());
 assert.ok(result.code);

--- a/test/which.js
+++ b/test/which.js
@@ -1,7 +1,7 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
-var fs = require('fs');
 
 shell.config.silent = true;
 
@@ -27,7 +27,7 @@ var node = shell.which('node');
 assert.equal(node.code, 0);
 assert.ok(!node.stderr);
 assert.ok(!shell.error());
-assert.ok(fs.existsSync(node + ''));
+assert.ok(common.existsSync(node + ''));
 
 if (process.platform === 'win32') {
   // This should be equivalent on Windows


### PR DESCRIPTION
Because fs.existsSync is deprecated. This internally uses `fs.statSync()` instead, wrapped in a try-catch.