### PR TITLE
fix: echo supports -e option properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,10 @@ Searches for `command` in the system's PATH. On Windows, this uses the
 Returns string containing the absolute path to the command.
 
 
-### echo(string [, string ...])
+### echo([options,] string [, string ...])
+Available options:
+
++ `-e`: interpret backslash escapes (default)
 
 Examples:
 

--- a/src/echo.js
+++ b/src/echo.js
@@ -5,7 +5,10 @@ common.register('echo', _echo, {
 });
 
 //@
-//@ ### echo(string [, string ...])
+//@ ### echo([options,] string [, string ...])
+//@ Available options:
+//@
+//@ + `-e`: interpret backslash escapes (default)
 //@
 //@ Examples:
 //@
@@ -19,6 +22,12 @@ common.register('echo', _echo, {
 function _echo(opts, messages) {
   // allow strings starting with '-', see issue #20
   messages = [].slice.call(arguments, opts ? 0 : 1);
+
+  if (messages[0] === '-e') {
+    // ignore -e
+    messages.shift();
+  }
+
   console.log.apply(console, messages);
   return messages.join(' ');
 }

--- a/test/echo.js
+++ b/test/echo.js
@@ -33,15 +33,21 @@ child.exec(JSON.stringify(process.execPath) + ' ' + file, function (err, stdout)
     assert.equal(stderr2, '');
 
     // simple test with silent(true)
-    shell.mkdir('-p', 'tmp');
-    file = 'tmp/tempscript' + Math.random() + '.js';
     script = 'require(\'../../global.js\'); config.silent=true; echo(555);';
     shell.ShellString(script).to(file);
     child.exec(JSON.stringify(process.execPath) + ' ' + file, function (err3, stdout3) {
       assert.equal(stdout3, '555\n');
 
-      theEnd();
+      script = "require('../../global.js'); echo('-e', '\\tmessage');";
+      shell.ShellString(script).to(file);
+      child.exec(JSON.stringify(process.execPath) + ' ' + file, function (err4, stdout4) {
+        assert.equal(stdout4, '\tmessage\n');
+
+        theEnd();
+      });
     });
+
+    // simple test with silent(true)
   });
 });
 


### PR DESCRIPTION
Fixes #510 

The only real difference in behavior is that `echo('-e', message)` won't print the literal `-e` (since Bash's `echo -e` wouldn't).