### PR TITLE
feat: new alternative to exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,30 @@ Notable exceptions:
 + There is no "quiet" option since default behavior is to run silent.
 
 
+### cmd(command [, arguments...] [, options] [, callback])
+Available options (all `false` by default):
+
++ `silent`: Do not echo program output to console.
++ and any option available to NodeJS's
+  [child_process.spawnSync()](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options)
+
+Examples:
+
+```javascript
+var version = cmd('node', '--version', {silent:true}).stdout;
+
+cmd('git', 'checkout', 'master', '--', 'file.js');
+```
+
+An alternative for [exec()](#execcommand--options--callback), with better
+security around globbing, comamnd injection, and variable expansion. This is
+guaranteed to only run one external command, and won't handle special
+characters in unexpected and unsafe ways.
+
+By default, this performs globbing on all platforms (but you can disable
+this for extra security using `set('-f')`).
+
+
 ### cp([options,] source [, source ...], dest)
 ### cp([options,] source_array, dest)
 Available options:

--- a/commands.js
+++ b/commands.js
@@ -2,6 +2,7 @@ module.exports = [
   'cat',
   'cd',
   'chmod',
+  'cmd',
   'cp',
   'dirs',
   'echo',

--- a/src/child.js
+++ b/src/child.js
@@ -1,0 +1,45 @@
+var childProcess = require('child_process');
+var fs = require('fs');
+
+var stdoutFile = process.argv[2];
+var stderrFile = process.argv[3];
+var cmd = process.argv[4];
+var argString = process.argv[5];
+var optString = process.argv[6];
+var pipe = process.argv[7];
+
+var opts = JSON.parse(optString);
+var args = JSON.parse(argString);
+
+var c = childProcess.spawn(cmd, args, opts);
+
+// Wait to exit until all other work has been finished, like closing IO streams
+function delayedExit(code) {
+  setTimeout(function () {
+    process.exit(code); // let streams close before ending
+  }, 0);
+}
+
+c.on('error', function () {
+  delayedExit(127);
+});
+
+c.on('exit', function (code) {
+  delayedExit(code);
+});
+
+var stdoutStream = fs.createWriteStream(stdoutFile);
+var stderrStream = fs.createWriteStream(stderrFile);
+c.stdout.pipe(stdoutStream, { end: false });
+c.stderr.pipe(stderrStream, { end: false });
+
+if (!opts.silent) {
+  c.stdout.pipe(process.stdout);
+  c.stderr.pipe(process.stderr);
+}
+
+c.stdout.on('end', stdoutStream.end);
+c.stderr.on('end', stderrStream.end);
+
+// Handle piped input
+if (pipe) c.stdin.end(pipe);

--- a/src/child.js
+++ b/src/child.js
@@ -13,19 +13,12 @@ var args = JSON.parse(argString);
 
 var c = childProcess.spawn(cmd, args, opts);
 
-// Wait to exit until all other work has been finished, like closing IO streams
-function delayedExit(code) {
-  setTimeout(function () {
-    process.exit(code); // let streams close before ending
-  }, 0);
-}
-
 c.on('error', function () {
-  delayedExit(127);
+  process.exitCode = 127;
 });
 
 c.on('exit', function (code) {
-  delayedExit(code);
+  process.exitCode = code;
 });
 
 var stdoutStream = fs.createWriteStream(stdoutFile);

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -1,0 +1,136 @@
+var common = require('./common');
+var _tempDir = require('./tempdir');
+var path = require('path');
+var fs = require('fs');
+var child = require('child_process');
+
+common.register('cmd', _cmd, {
+  unix: false,
+  canReceivePipe: true,
+  wrapOutput: false,
+});
+
+// Similar to shell.exec(), this is a hack so that we can get concurrent output.
+function cmdSync(cmd, args, opts, pipe) {
+  var tempDir = _tempDir();
+  var stdoutFile = path.join(tempDir, common.randomFileName());
+  var stderrFile = path.join(tempDir, common.randomFileName());
+
+  opts = common.extend({
+    silent: common.config.silent,
+    cwd: process.cwd(),
+  }, opts);
+
+  if (common.existsSync(stdoutFile)) common.unlinkSync(stdoutFile);
+  if (common.existsSync(stderrFile)) common.unlinkSync(stderrFile);
+
+  // resolve to an absolute path, so if we cd in the child process, it's a no-op
+  opts.cwd = path.resolve(opts.cwd);
+
+  var optString = JSON.stringify(opts);
+
+  function cleanUpFiles() {
+    try { common.unlinkSync(stdoutFile); } catch (e2) {}
+    try { common.unlinkSync(stderrFile); } catch (e2) {}
+  }
+
+  opts.stdio = [0, 1, 2];
+
+  var proc;
+  try {
+    proc = child.spawnSync(process.execPath, [
+      path.join(__dirname, 'child.js'),
+      stdoutFile,
+      stderrFile,
+      cmd,
+      JSON.stringify(args),
+      optString,
+      pipe,
+    ], opts);
+  } catch (e) {
+    // Clean up immediately if we have an exception
+    cleanUpFiles();
+    throw e;
+  }
+
+  var stdout = fs.readFileSync(stdoutFile, 'utf8');
+  var stderr = fs.readFileSync(stderrFile, 'utf8');
+  var code = proc.status;
+
+  // Clean up files (we can delay this to improve performance)
+  setTimeout(cleanUpFiles, 0);
+
+  if (code !== 0) {
+    common.error(stderr, code, true);
+  }
+  return new common.ShellString(stdout, stderr, code);
+} // cmdSync()
+
+//@
+//@ ### cmd(command [, arguments...] [, options] [, callback])
+//@ Available options (all `false` by default):
+//@
+//@ + `silent`: Do not echo program output to console.
+//@ + and any option available to NodeJS's
+//@   [child_process.spawnSync()](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options)
+//@
+//@ Examples:
+//@
+//@ ```javascript
+//@ var version = cmd('node', '--version', {silent:true}).stdout;
+//@
+//@ cmd('git', 'checkout', 'master', '--', 'file.js');
+//@ ```
+//@
+//@ An alternative for [exec()](#execcommand--options--callback), with better
+//@ security around globbing, comamnd injection, and variable expansion. This is
+//@ guaranteed to only run one external command, and won't handle special
+//@ characters in unexpected and unsafe ways.
+//@
+//@ By default, this performs globbing on all platforms (but you can disable
+//@ this for extra security using `set('-f')`).
+function _cmd() {
+  var args = [].slice.call(arguments, 0);
+  var command;
+  var cmdArgs = [];
+  var options = {};
+  if (args.length < 1 || typeof args[0] !== 'string') {
+    common.error('must specify a command to run');
+  } else if (args.length === 1) {
+    command = args[0]; // just this command, no args, no options
+  } else {
+    command = args[0];
+    var lastArg = args[args.length - 1];
+    cmdArgs = typeof lastArg === 'string' ? args.slice(1) : args.slice(1, args.length - 1);
+    options = typeof lastArg === 'string' ? {} : lastArg;
+  }
+
+  // Perform globbing, unless it's disabled
+  if (!common.config.noglob) {
+    cmdArgs = common.expand(cmdArgs);
+  }
+
+  var pipe = common.readFromPipe();
+
+  options = common.extend({
+    silent: common.config.silent,
+  }, options);
+
+  // If we're explicitly told to not offer real-time output, use a more
+  // efficient function
+  if (options.realtimeOutput === false) {
+    var result = child.spawnSync(command, cmdArgs, options);
+    if (!options.silent) {
+      process.stdout.write(result.stdout);
+      process.stderr.write(result.stderr);
+    }
+    return new common.ShellString(result.stdout, result.stderr, result.status);
+  } else {
+    try {
+      return cmdSync(command, cmdArgs, options, pipe);
+    } catch (e) {
+      common.error('internal error');
+    }
+  }
+}
+module.exports = _cmd;

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -39,7 +39,7 @@ function cmdSync(cmd, args, opts, pipe) {
 
   var proc;
   try {
-    proc = child.spawnSync(process.execPath, [
+    proc = child.spawnSync(common.nodeBinPath, [
       path.join(__dirname, 'child.js'),
       stdoutFile,
       stderrFile,

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -130,7 +130,7 @@ function _cmd() {
     // common.state.stderr = result.stderr;
     // common.state.code = result.status;
     // return stdout;
-    return new common.ShellString(result.stdout, result.stderr, result.status);
+    return new common.ShellString(result.stdout.toString(), result.stderr.toString(), result.status);
   } else {
     try {
       return cmdSync(command, cmdArgs, options, pipe);

--- a/src/common.js
+++ b/src/common.js
@@ -80,6 +80,10 @@ function convertErrorOutput(msg) {
 }
 exports.convertErrorOutput = convertErrorOutput;
 
+// TODO(nate): make this compatible with electron
+// The path to the NodeJS binary. This is mainly used for exec() and cmd()
+exports.nodeBinPath = process.execPath;
+
 // Shows error message. Throws if config.fatal is true
 function error(msg, _code, options) {
   // Validate input

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,0 +1,122 @@
+var shell = require('..');
+
+var assert = require('assert');
+var path = require('path');
+var os = require('os');
+
+shell.config.silent = true;
+
+//
+// Invalids
+//
+
+shell.cmd();
+assert.ok(shell.error());
+
+var result = shell.cmd('asdfasdf'); // could not find command
+assert.notEqual(result.code, 0);
+
+// Test 'fatal' mode for cmd, temporarily overriding process.exit
+var oldFatal = shell.config.fatal;
+
+shell.config.fatal = true;
+
+assert.throws(function () {
+  shell.cmd('asdfasdf'); // could not find command
+}, /cmd: internal error/);
+
+shell.config.fatal = oldFatal;
+
+//
+// Valids
+//
+
+//
+// sync
+//
+
+// check if stdout goes to output
+result = shell.cmd(process.execPath, '-e', 'console.log(1234);');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+assert.equal(result.stdout, '1234\n');
+
+// check if stderr goes to output
+result = shell.cmd(process.execPath, '-e', 'console.error(1234);');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+assert.equal(result.stdout, '');
+assert.equal(result.stderr, '1234\n');
+
+// check if stdout + stderr go to output
+result = shell.cmd(process.execPath, '-e', 'console.error(1234); console.log(666);');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+assert.equal(result.stdout, '666\n');
+assert.equal(result.stderr, '1234\n');
+
+// check exit code
+result = shell.cmd(process.execPath, '-e', 'process.exit(12);');
+assert.ok(shell.error());
+assert.equal(result.code, 12);
+
+// interaction with cd
+shell.cd('resources/external');
+result = shell.cmd(process.execPath, 'node_script.js');
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+assert.equal(result.stdout, 'node_script_1234\n');
+shell.cd('../..');
+
+// set cwd
+var cmdString = process.platform === 'win32' ? 'cd' : 'pwd';
+result = shell.cmd(cmdString, { cwd: '..' });
+assert.equal(shell.error(), null);
+assert.equal(result.code, 0);
+assert.equal(result.stdout, path.resolve('..') + os.EOL);
+
+// supports globbing by default
+result = shell.cmd('echo', 'resources/*.txt');
+assert.equal(result.stdout, 'resources/a.txt resources/file1.txt resources/file2.txt\n');
+assert.equal(result.stderr, '');
+assert.ok(!shell.error());
+
+// globbing can be disabled
+shell.set('-f');
+result = shell.cmd('echo', 'resources/*.txt');
+assert.equal(result.stdout, 'resources/*.txt\n');
+assert.equal(result.stderr, '');
+assert.ok(!shell.error());
+shell.set('+f');
+
+// cmd returns a ShellString
+result = shell.cmd('echo', 'foo');
+assert.equal(typeof result, 'object');
+assert.ok(result instanceof String);
+assert.equal(typeof result.stdout, 'string');
+assert.strictEqual(result.toString(), result.stdout);
+
+// TODO(nate): make it exactly equivalent to stderr, unless stderr === ''
+// shell.error() contains the stderr of external command in the case of an error
+result = shell.cmd(process.execPath, '-e', 'console.error(1234); process.exit(1);');
+assert.equal(shell.error(), 'cmd: ' + result.stderr);
+assert.equal(result.code, 1);
+assert.equal(result.stdout, '');
+assert.equal(result.stderr, '1234\n');
+
+// option: realtimeOutput === false
+result = shell.cmd(process.execPath, '-e', 'console.error(1234); console.log(5678);', {
+  realtimeOutput: false
+});
+assert.ok(!shell.error());
+assert.equal(result.code, 0);
+assert.equal(result.stdout, '5678\n');
+assert.equal(result.stderr, '1234\n');
+
+// cmd works, even if it's piped while in silent mode
+result = shell.ShellString('foo bar baz').cmd('cat', { silent: true });
+assert.equal(typeof result, 'object');
+assert.ok(result instanceof String);
+assert.equal(result.stdout, 'foo bar baz');
+
+shell.exit(123);

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,4 +1,5 @@
 var shell = require('..');
+var common = require('../src/common');
 
 var assert = require('assert');
 var path = require('path');
@@ -36,33 +37,33 @@ shell.config.fatal = oldFatal;
 //
 
 // check if stdout goes to output
-result = shell.cmd(process.execPath, '-e', 'console.log(1234);');
+result = shell.cmd(common.nodeBinPath, '-e', 'console.log(1234);');
 assert.ok(!shell.error());
 assert.equal(result.code, 0);
 assert.equal(result.stdout, '1234\n');
 
 // check if stderr goes to output
-result = shell.cmd(process.execPath, '-e', 'console.error(1234);');
+result = shell.cmd(common.nodeBinPath, '-e', 'console.error(1234);');
 assert.ok(!shell.error());
 assert.equal(result.code, 0);
 assert.equal(result.stdout, '');
 assert.equal(result.stderr, '1234\n');
 
 // check if stdout + stderr go to output
-result = shell.cmd(process.execPath, '-e', 'console.error(1234); console.log(666);');
+result = shell.cmd(common.nodeBinPath, '-e', 'console.error(1234); console.log(666);');
 assert.ok(!shell.error());
 assert.equal(result.code, 0);
 assert.equal(result.stdout, '666\n');
 assert.equal(result.stderr, '1234\n');
 
 // check exit code
-result = shell.cmd(process.execPath, '-e', 'process.exit(12);');
+result = shell.cmd(common.nodeBinPath, '-e', 'process.exit(12);');
 assert.ok(shell.error());
 assert.equal(result.code, 12);
 
 // interaction with cd
 shell.cd('resources/external');
-result = shell.cmd(process.execPath, 'node_script.js');
+result = shell.cmd(common.nodeBinPath, 'node_script.js');
 assert.ok(!shell.error());
 assert.equal(result.code, 0);
 assert.equal(result.stdout, 'node_script_1234\n');
@@ -97,14 +98,14 @@ assert.strictEqual(result.toString(), result.stdout);
 
 // TODO(nate): make it exactly equivalent to stderr, unless stderr === ''
 // shell.error() contains the stderr of external command in the case of an error
-result = shell.cmd(process.execPath, '-e', 'console.error(1234); process.exit(1);');
+result = shell.cmd(common.nodeBinPath, '-e', 'console.error(1234); process.exit(1);');
 assert.equal(shell.error(), 'cmd: ' + result.stderr);
 assert.equal(result.code, 1);
 assert.equal(result.stdout, '');
 assert.equal(result.stderr, '1234\n');
 
 // option: realtimeOutput === false
-result = shell.cmd(process.execPath, '-e', 'console.error(1234); console.log(5678);', {
+result = shell.cmd(common.nodeBinPath, '-e', 'console.error(1234); console.log(5678);', {
   realtimeOutput: false
 });
 assert.ok(!shell.error());

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,5 +1,4 @@
 import path from 'path';
-import os from 'os';
 
 import test from 'ava';
 
@@ -86,11 +85,11 @@ test('set cwd', t => {
   const result = shell.cmd('shx', 'pwd', { cwd: '..' });
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.stdout, path.resolve('..') + os.EOL);
+  t.is(result.stdout, `${path.resolve('..')}\n`);
 });
 
 test('supports globbing by default', t => {
-  const result = shell.cmd('echo', 'resources/*.txt');
+  const result = shell.cmd('shx', 'echo', 'resources/*.txt');
   t.is(result.stdout, 'resources/a.txt resources/file1.txt resources/file2.txt\n');
   t.is(result.stderr, '');
   t.falsy(shell.error());
@@ -98,7 +97,7 @@ test('supports globbing by default', t => {
 
 test('globbing can be disabled', t => {
   shell.set('-f');
-  const result = shell.cmd('echo', 'resources/*.txt');
+  const result = shell.cmd('shx', 'echo', 'resources/*.txt');
   t.is(result.stdout, 'resources/*.txt\n');
   t.is(result.stderr, '');
   t.falsy(shell.error());
@@ -106,7 +105,7 @@ test('globbing can be disabled', t => {
 });
 
 test('cmd returns a ShellString', t => {
-  const result = shell.cmd('echo', 'foo');
+  const result = shell.cmd('shx', 'echo', 'foo');
   t.is(typeof result, 'object');
   t.truthy(result instanceof String);
   t.is(typeof result.stdout, 'string');
@@ -136,7 +135,7 @@ test('option: realtimeOutput === false', t => {
 });
 
 test('cmd works, even if it\'s piped while in silent mode', t => {
-  const result = shell.ShellString('foo bar baz').cmd('cat', { silent: true });
+  const result = shell.ShellString('foo bar baz').cmd('shx', 'cat', { silent: true });
   t.is(typeof result, 'object');
   t.truthy(result instanceof String);
   t.is(result.stdout, 'foo bar baz');

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -23,7 +23,7 @@ shell.config.fatal = true;
 
 assert.throws(function () {
   shell.cmd('asdfasdf'); // could not find command
-}, /cmd: internal error/);
+}, 'cmd: must specify command');
 
 shell.config.fatal = oldFatal;
 
@@ -37,20 +37,20 @@ shell.config.fatal = oldFatal;
 
 // check if stdout goes to output
 result = shell.cmd(process.execPath, '-e', 'console.log(1234);');
-assert.equal(shell.error(), null);
+assert.ok(!shell.error());
 assert.equal(result.code, 0);
 assert.equal(result.stdout, '1234\n');
 
 // check if stderr goes to output
 result = shell.cmd(process.execPath, '-e', 'console.error(1234);');
-assert.equal(shell.error(), null);
+assert.ok(!shell.error());
 assert.equal(result.code, 0);
 assert.equal(result.stdout, '');
 assert.equal(result.stderr, '1234\n');
 
 // check if stdout + stderr go to output
 result = shell.cmd(process.execPath, '-e', 'console.error(1234); console.log(666);');
-assert.equal(shell.error(), null);
+assert.ok(!shell.error());
 assert.equal(result.code, 0);
 assert.equal(result.stdout, '666\n');
 assert.equal(result.stderr, '1234\n');
@@ -63,15 +63,14 @@ assert.equal(result.code, 12);
 // interaction with cd
 shell.cd('resources/external');
 result = shell.cmd(process.execPath, 'node_script.js');
-assert.equal(shell.error(), null);
+assert.ok(!shell.error());
 assert.equal(result.code, 0);
 assert.equal(result.stdout, 'node_script_1234\n');
 shell.cd('../..');
 
 // set cwd
-var cmdString = process.platform === 'win32' ? 'cd' : 'pwd';
-result = shell.cmd(cmdString, { cwd: '..' });
-assert.equal(shell.error(), null);
+result = shell.cmd('shx', 'pwd', { cwd: '..' });
+assert.ok(!shell.error());
 assert.equal(result.code, 0);
 assert.equal(result.stdout, path.resolve('..') + os.EOL);
 


### PR DESCRIPTION
Add a new command to launch external shell commands, providing a less vulnerable
alternative to exec(), with cross-platform globbing.

I'd love community input on the design of the new API, if this is an agreeable name, etc. This implementation would work well with shelljs-exec-proxy (see nfischer/shelljs-exec-proxy#2), which might be a better API alternative for Node v6+ users.

I believe this, in conjunction with `set('-f')`, should solve all the relevant security flaws surrounding command injection and unexpected globbing. Globbing is enabled by default in this implementation, for the sake of providing a consistent API across all commands.

This relies on a JS-based implementation of globbing, which is an improvement on `exec()`, which inconsistently provides globbing on unix but not on windows.

Fixes #143
Fixes #495
Fixes #103 

I believe this should also help with #175, #5, shelljs/shx#68, and probably some others.
