### PR TITLE
Fix: Remove default glob from shell.test (fixes #529)

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -13,6 +13,7 @@ common.register('test', _test, {
     'S': 'socket',
   },
   wrapOutput: false,
+  allowGlobbing: false,
 });
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -65,6 +65,12 @@ result = shell.test('-L', 'resources/file1');
 assert.equal(shell.error(), null);
 assert.equal(result, false);
 
+// regression #529
+result = shell.test('-f', 'resources/**/*.js');
+assert.equal(shell.error(), null);
+assert.equal(result, false);
+
+
 // link
 // Windows is weird with links so skip these tests
 if (common.platform !== 'win') {


### PR DESCRIPTION
Regression from #492 