### PR TITLE
New: `nodepath` option for the path

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-config-airbnb-base": "^3.0.0",
     "eslint-plugin-import": "^1.11.1",
     "coffee-script": "^1.10.0",
+    "sinon": "^1.17.6",
     "shelljs-changelog": "^0.2.0",
     "shelljs-release": "^0.2.0",
     "travis-check-changes": "^0.2.0"

--- a/src/common.js
+++ b/src/common.js
@@ -4,10 +4,22 @@
 
 var os = require('os');
 var fs = require('fs');
+var path = require('path');
 var glob = require('glob');
 var shell = require('..');
 
 var shellMethods = Object.create(shell);
+var PATH_IDENTIFIER = 'PATH';
+
+// windows calls it's path 'Path' usually, but this is not guaranteed.
+if (process.platform === 'win32') {
+  PATH_IDENTIFIER = 'Path';
+  Object.keys(process.env).forEach(function (e) {
+    if (e.match(/^PATH$/i)) {
+      PATH_IDENTIFIER = e;
+    }
+  });
+}
 
 // Module globals
 var config = {
@@ -16,7 +28,8 @@ var config = {
   verbose: false,
   noglob: false,
   globOptions: {},
-  maxdepth: 255
+  maxdepth: 255,
+  nodepath: false,
 };
 exports.config = config;
 
@@ -401,3 +414,15 @@ function _register(name, implementation, wrapOptions) {
   }
 }
 exports.register = _register;
+
+exports.getProcessEnv = function () {
+  var env = objectAssign({}, process.env);
+
+  if (config.nodepath) {
+    env[PATH_IDENTIFIER] += path.delimiter + path.join(process.cwd(), 'node_modules', '.bin');
+  }
+
+  return env;
+};
+
+exports.PATH_IDENTIFIER = PATH_IDENTIFIER;

--- a/src/exec.js
+++ b/src/exec.js
@@ -29,7 +29,7 @@ function execSync(cmd, opts, pipe) {
   opts = common.extend({
     silent: common.config.silent,
     cwd: _pwd().toString(),
-    env: process.env,
+    env: common.getProcessEnv(),
     maxBuffer: DEFAULT_MAXBUFFER_SIZE
   }, opts);
 
@@ -171,7 +171,7 @@ function execAsync(cmd, opts, pipe, callback) {
   opts = common.extend({
     silent: common.config.silent,
     cwd: _pwd().toString(),
-    env: process.env,
+    env: common.getProcessEnv(),
     maxBuffer: DEFAULT_MAXBUFFER_SIZE
   }, opts);
 

--- a/src/which.js
+++ b/src/which.js
@@ -40,7 +40,7 @@ function checkPath(pathName) {
 function _which(options, cmd) {
   if (!cmd) common.error('must specify command');
 
-  var pathEnv = process.env.path || process.env.Path || process.env.PATH;
+  var pathEnv = common.getProcessEnv()[common.PATH_IDENTIFIER];
   var pathArray = splitPath(pathEnv);
   var where = null;
 

--- a/test/which.js
+++ b/test/which.js
@@ -2,6 +2,9 @@ var shell = require('..');
 
 var assert = require('assert');
 var fs = require('fs');
+var path = require('path');
+var sinon = require('sinon');
+var sandbox = sinon.sandbox.create();
 
 shell.config.silent = true;
 
@@ -37,5 +40,32 @@ if (process.platform === 'win32') {
   // already been checked.
   assert.equal(node + '', nodeExe + '');
 }
+
+/*
+ Tests for nodepath
+ */
+var cwd = path.resolve(process.cwd(), '..');
+
+function stubProcessData() {
+  sandbox.stub(process.env, 'PATH', '');
+  sandbox.stub(process, 'cwd', function () { return cwd; }); // test are ran from test folder
+}
+
+// fails since nodepath is not set
+stubProcessData();
+result = shell.which('eslint');
+assert.ok(!shell.error());
+assert.ok(!result);
+sandbox.restore();
+
+// pass
+shell.config.nodepath = true;
+stubProcessData();
+result = shell.which('eslint');
+assert.equal(result.code, 0);
+assert.ok(!result.stderr);
+assert.ok(!shell.error());
+sandbox.restore();
+shell.config.nodepath = false; // set it back to default
 
 shell.exit(123);


### PR DESCRIPTION
This what i am thinking for `nodepath` config option. This works as i have tried it. 
Its getting difficult to test since when you run `npm test` to run the unit test. NPM already adds the `./node_modules/.bin` to the $PATH. 

I will work on the tests but I wanted to know whether I am heading in the right direction.
