### PR TITLE
chore: remove v0.10 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: c++
 sudo: false
 env:
-  - NODE_VERSION="0.10"
   - NODE_VERSION="0.11"
   - NODE_VERSION="0.12"
   - NODE_VERSION="iojs-v1"
@@ -11,10 +10,6 @@ env:
   - NODE_VERSION="5"
   - NODE_VERSION="6"
   - NODE_VERSION="7"
-
-matrix:
-  allow_failures:
-    - NODE_VERSION="0.10"
 
 # keep this blank to make sure there are no before_install steps
 before_install:


### PR DESCRIPTION
This version of Node was already unsupported as of ShellJS v0.7