### PR TITLE
Safely exit by throwing an error

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -348,8 +348,7 @@ function wrap(cmd, fn, options) {
       if (!state.error) {
         // If state.error hasn't been set it's an error thrown by Node, not us - probably a bug...
         console.error('ShellJS: internal error');
-        console.error(e.stack || e);
-        process.exit(1);
+        throw e;
       }
       if (config.fatal) throw e;
     }

--- a/src/common.js
+++ b/src/common.js
@@ -347,7 +347,7 @@ function wrap(cmd, fn, options) {
     } catch (e) {
       if (!state.error) {
         // If state.error hasn't been set it's an error thrown by Node, not us - probably a bug...
-        e.message = 'ShellJS Internal Error: ' + e.message;
+        e.name = 'ShellJSInternalError';
         throw e;
       }
       if (config.fatal) throw e;

--- a/src/common.js
+++ b/src/common.js
@@ -347,7 +347,7 @@ function wrap(cmd, fn, options) {
     } catch (e) {
       if (!state.error) {
         // If state.error hasn't been set it's an error thrown by Node, not us - probably a bug...
-        console.error('ShellJS: internal error');
+        e.message = 'ShellJS Internal Error: ' + e.message;
         throw e;
       }
       if (config.fatal) throw e;


### PR DESCRIPTION
Fixes #483.

Instead of exiting the process with `process.exit(1)`, simply throw an error. This way, the error can be caught by Node itself. If the error is not caught, the error is still printed, and the process exits with a `1`.