### PR TITLE
Get pipe tests running on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "coffee-script": "^1.10.0",
     "shelljs-changelog": "^0.2.0",
     "shelljs-release": "^0.2.0",
+    "shx": "^0.2.0",
     "travis-check-changes": "^0.2.0"
   },
   "optionalDependencies": {},

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -50,18 +50,25 @@ assert.equal(shell.error(), null);
 assert.equal(result.toString(), shell.cat('resources/uniq/pipeSorted').toString());
 
 // Synchronous exec
+var findCommand;
 if (process.platform === 'win32') {
+  // On Windows, we use the FIND command. FIND is semantically similar
+  // to POSIX’s grep(1) except it only matches string literals. Also,
+  // FIND requires the first argument, the search string, to be
+  // wrapped in double quotes when accessed via GetCommandLine().
+  // https://technet.microsoft.com/en-us/library/bb490906.aspx
+
+  // Get the full path to FIND. If we just exec('find'), Windows will
+  // try to run ./find.js with Windows Script Host.
+  findCommand = '"' + shell.which('FIND') + '"';
+
   // Ensure the user does not have the wrong version of FIND. I.e.,
   // require the following to return error.
-  result = shell.exec('CD..&FIND . -name no');
+  result = shell.exec(findCommand + ' . -name no');
   if (!shell.error()) {
     console.error('Warning: Cannot verify piped exec: Found POSIX-like find(1) in PATH. This test assumes a Windows environment with its FIND command (fix your PATH, exit cygwin/mingw32/MSYS2).');
   } else {
-    // “CD..” is to avoid Windows running test/find.js with Windows
-    // Script Host. I tried using regex to remove ‘.’ from PATH but
-    // apparently exec sources the OS’s environment when executing which
-    // ends up re-adding ‘.’ to PATH.
-    result = shell.cat('resources/grep/file').exec('CD..&FIND "alph"');
+    result = shell.cat('resources/grep/file').exec(findCommand + ' "alph"');
     assert.ok(!shell.error());
     assert.equal(result, 'alphaaaaaaabeta\r\nalphbeta\r\n');
   }
@@ -79,14 +86,12 @@ if (process.platform === 'win32') {
 if (process.platform === 'win32') {
   // Ensure the user does not have the wrong version of FIND. I.e.,
   // require the following to return error.
-  result = shell.exec('CD..&FIND . -name no');
+  result = shell.exec(findCommand + ' . -name no');
   if (!shell.error()) {
     console.error('Warning: Cannot verify piped exec: Found POSIX-like find(1) in PATH. This test assumes a Windows environment with its FIND command (fix your PATH, exit cygwin/mingw32/MSYS2).');
     shell.exit(123);
   } else {
-    // “CD..” is to avoid Windows running test/find.js with Windows
-    // Script Host.
-    shell.cat('resources/grep/file').exec('CD..&FIND "alph"', function (code, stdout) {
+    shell.cat('resources/grep/file').exec(findCommand + ' "alph"', function (code, stdout) {
       assert.equal(code, 0);
       assert.equal(stdout, 'alphaaaaaaabeta\r\nalphbeta\r\n');
       shell.exit(123);

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -49,63 +49,16 @@ result = shell.sort('resources/uniq/pipe').uniq('-c').sort('-n');
 assert.equal(shell.error(), null);
 assert.equal(result.toString(), shell.cat('resources/uniq/pipeSorted').toString());
 
-// Synchronous exec
-var findCommand;
-if (process.platform === 'win32') {
-  // On Windows, we use the FIND command. FIND is semantically similar
-  // to POSIX’s grep(1) except it only matches string literals. Also,
-  // FIND requires the first argument, the search string, to be
-  // wrapped in double quotes when accessed via GetCommandLine().
-  // https://technet.microsoft.com/en-us/library/bb490906.aspx
-
-  // Get the full path to FIND. If we just exec('find'), Windows will
-  // try to run ./find.js with Windows Script Host.
-  findCommand = '"' + shell.which('FIND') + '"';
-
-  // Ensure the user does not have the wrong version of FIND. I.e.,
-  // require the following to return error.
-  result = shell.exec(findCommand + ' . -name no');
-  if (!shell.error()) {
-    console.error('Warning: Cannot verify piped exec: Found POSIX-like find(1) in PATH. This test assumes a Windows environment with its FIND command (fix your PATH, exit cygwin/mingw32/MSYS2).');
-  } else {
-    result = shell.cat('resources/grep/file').exec(findCommand + ' "alph"');
-    assert.ok(!shell.error());
-    assert.equal(result, 'alphaaaaaaabeta\r\nalphbeta\r\n');
-  }
-} else {
-  if (shell.which('grep').stdout) {
-    result = shell.cat('resources/grep/file').exec("grep 'alpha*beta'");
-    assert.ok(!shell.error());
-    assert.equal(result, 'alphaaaaaaabeta\nalphbeta\n');
-  } else {
-    console.error('Warning: Cannot verify piped exec');
-  }
-}
+// Synchronous exec. To support Windows, the arguments must be passed
+// using double quotes because node, following win32 convention,
+// passes single quotes through to process.argv verbatim.
+result = shell.cat('resources/grep/file').exec('shx grep "alpha*beta"');
+assert.ok(!shell.error());
+assert.equal(result, 'alphaaaaaaabeta\nalphbeta\n');
 
 // Async exec
-if (process.platform === 'win32') {
-  // Ensure the user does not have the wrong version of FIND. I.e.,
-  // require the following to return error.
-  result = shell.exec(findCommand + ' . -name no');
-  if (!shell.error()) {
-    console.error('Warning: Cannot verify piped exec: Found POSIX-like find(1) in PATH. This test assumes a Windows environment with its FIND command (fix your PATH, exit cygwin/mingw32/MSYS2).');
-    shell.exit(123);
-  } else {
-    shell.cat('resources/grep/file').exec(findCommand + ' "alph"', function (code, stdout) {
-      assert.equal(code, 0);
-      assert.equal(stdout, 'alphaaaaaaabeta\r\nalphbeta\r\n');
-      shell.exit(123);
-    });
-  }
-} else {
-  if (shell.which('grep').stdout) {
-    shell.cat('resources/grep/file').exec("grep 'alpha*beta'", function (code, stdout) {
-      assert.equal(code, 0);
-      assert.equal(stdout, 'alphaaaaaaabeta\nalphbeta\n');
-      shell.exit(123);
-    });
-  } else {
-    console.error('Warning: Cannot verify piped exec');
-    shell.exit(123);
-  }
-}
+shell.cat('resources/grep/file').exec('shx grep "alpha*beta"', function (code, stdout) {
+  assert.equal(code, 0);
+  assert.equal(stdout, 'alphaaaaaaabeta\nalphbeta\n');
+  shell.exit(123);
+});

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -51,8 +51,6 @@ assert.equal(result.toString(), shell.cat('resources/uniq/pipeSorted').toString(
 
 // Synchronous exec
 if (process.platform === 'win32') {
-  // Windows-specific
-
   // Ensure the user does not have the wrong version of FIND. I.e.,
   // require the following to return error.
   result = shell.exec('CD..&FIND . -name no');
@@ -68,7 +66,6 @@ if (process.platform === 'win32') {
     assert.equal(result, 'alphaaaaaaabeta\r\nalphbeta\r\n');
   }
 } else {
-  // unix-specific
   if (shell.which('grep').stdout) {
     result = shell.cat('resources/grep/file').exec("grep 'alpha*beta'");
     assert.ok(!shell.error());
@@ -80,8 +77,6 @@ if (process.platform === 'win32') {
 
 // Async exec
 if (process.platform === 'win32') {
-  // Windows-specified
-
   // Ensure the user does not have the wrong version of FIND. I.e.,
   // require the following to return error.
   result = shell.exec('CD..&FIND . -name no');
@@ -98,7 +93,6 @@ if (process.platform === 'win32') {
     });
   }
 } else {
-  // unix-specific
   if (shell.which('grep').stdout) {
     shell.cat('resources/grep/file').exec("grep 'alpha*beta'", function (code, stdout) {
       assert.equal(code, 0);


### PR DESCRIPTION
I used the FIND command which ships with Windows as something to
pass data through.

The test checks that a POSIX-like find(1) exists and skips the tests
if this condition is true because Windows-provided FIND is incompatible
with find(1).