### PR TITLE
Turn off Electron asar archive support.

### DIFF
--- a/src/rm.js
+++ b/src/rm.js
@@ -105,6 +105,11 @@ function isWriteable(file) {
 //@
 //@ Removes files.
 function _rm(options, files) {
+  // Switch Electron asar support off
+  // Prevents unexpected behaviour when attempting to remove an asar archive
+  var noAsar = process.noAsar;
+  process.noAsar = true;
+
   if (!files) common.error('no paths given');
 
   // Convert to array
@@ -141,6 +146,8 @@ function _rm(options, files) {
       common.unlinkSync(file);
     }
   }); // forEach(file)
+
+  process.noAsar = noAsar;
   return '';
 } // rm
 module.exports = _rm;


### PR DESCRIPTION
ShellJS fails to remove asar archives when run in Electron due to
Electron fs patches that treat asar archives as virtual directories.
See issue #618 .
To overcome this, we set process.noAsar to true.