### PR TITLE
fix: allow non-normalized paths as input to mkdir

### DIFF
--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -75,7 +75,7 @@ function _mkdir(options, dirs) {
 
     try {
       if (options.fullpath) {
-        mkdirSyncRecursive(dir);
+        mkdirSyncRecursive(path.resolve(dir));
       } else {
         fs.mkdirSync(dir, parseInt('0777', 8));
       }

--- a/test/cp.js
+++ b/test/cp.js
@@ -259,7 +259,6 @@ test(
 );
 
 test('recursive, everything exists, no force flag', t => {
-  shell.cp('-R', 'resources/cp', t.context.tmp);
   const result = shell.cp('-R', 'resources/cp', t.context.tmp);
   t.falsy(shell.error()); // crash test only
   t.falsy(result.stderr);
@@ -646,4 +645,11 @@ test('Test with recursive option and symlinks.', t => {
     t.falsy(shell.test('-L', 'foo.lnk'));
     t.falsy(shell.test('-L', 'sym.lnk'));
   });
+});
+
+test('recursive, with a non-normalized path', t => {
+  const result = shell.cp('-R', 'resources/../resources/./cp', t.context.tmp);
+  t.falsy(shell.error()); // crash test only
+  t.falsy(result.stderr);
+  t.is(result.code, 0);
 });

--- a/test/ls.js
+++ b/test/ls.js
@@ -466,3 +466,13 @@ test('Check stderr field', t => {
   t.truthy(shell.error());
   t.is('ls: no such file or directory: /asdfasdf', result.stderr);
 });
+
+test('non-normalized paths are still ok with -R', t => {
+  const result = shell.ls('-R', 'resources/./ls/../ls');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.truthy(result.indexOf('a_dir') > -1);
+  t.truthy(result.indexOf('a_dir/b_dir') > -1);
+  t.truthy(result.indexOf('a_dir/b_dir/z') > -1);
+  t.is(result.length, 9);
+});

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -147,3 +147,10 @@ test('globbed dir', t => {
   t.truthy(fs.existsSync(`${t.context.tmp}/mydir`));
   t.falsy(fs.existsSync(`${t.context.tmp}/m*ir`)); // doesn't create literal name
 });
+
+test('non-normalized paths are still ok with -p', t => {
+  const result = shell.mkdir('-p', `${t.context.tmp}/asdf/../asdf/./`);
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.truthy(fs.existsSync(`${t.context.tmp}/asdf`));
+});

--- a/test/rm.js
+++ b/test/rm.js
@@ -282,3 +282,12 @@ test('remove broken symbolic link', t => {
     t.falsy(fs.existsSync(`${t.context.tmp}/rm/fake.lnk`));
   }
 });
+
+test('recursive dir removal, for non-normalized path', t => {
+  shell.mkdir('-p', `${t.context.tmp}/a/b/c`);
+  t.truthy(fs.existsSync(`${t.context.tmp}/a/b/c`));
+  const result = shell.rm('-rf', `${t.context.tmp}/a/.././a`);
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.falsy(fs.existsSync(`${t.context.tmp}/a`));
+});


### PR DESCRIPTION
Adds tests to make sure that non-normalized paths (i.e. path/to/./dir) are
valid for a few commands, including mkdir() which previously failed when given
the -p flag.

Fixes #634