### PR TITLE
chore: set up test coverage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
-ava-test/resources/
-ava-test/tmp/
+.nyc_output/
+coverage/
+make.js
+node_modules/
 test/resources/
 test/tmp/
-node_modules/
-make.js

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 npm-debug.log*
 node_modules
 tmp
+coverage/
+.nyc_output/
 
 # Linux
 *~

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "scripts": {
     "posttest": "npm run lint",
-    "test": "ava --serial test/*.js",
+    "test": "nyc --reporter=text --reporter=lcov ava --serial test/*.js",
     "gendocs": "node scripts/generate-docs",
     "lint": "eslint .",
     "after-travis": "travis-check-changes",
@@ -57,6 +57,7 @@
     "eslint": "^2.0.0",
     "eslint-config-airbnb-base": "^3.0.0",
     "eslint-plugin-import": "^1.11.1",
+    "nyc": "^10.0.0",
     "shelljs-changelog": "^0.2.0",
     "shelljs-release": "^0.2.0",
     "shx": "^0.2.0",


### PR DESCRIPTION
Use `nyc` for test coverage and ignore all nyc-related files in git & eslint.
This increases testing time (~35sec -> ~60sec on my 4-core machine).

Fixes #347