### PR TITLE
refactor: add config.reset() and .resetForTesting()

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,32 @@ config.globOptions = {nodir: true};
 
 Use this value for calls to `glob.sync()` instead of the default options.
 
+### config.reset()
+
+Example:
+
+```javascript
+var shell = require('shelljs');
+// Make changes to shell.config, and do stuff...
+/* ... */
+shell.config.reset(); // reset to original state
+// Do more stuff, but with original settings
+/* ... */
+```
+
+Reset shell.config to the defaults:
+
+```javascript
+{
+  fatal: false,
+  globOptions: {},
+  maxdepth: 255,
+  noglob: false,
+  silent: false,
+  verbose: false,
+}
+```
+
 ## Team
 
 | [![Nate Fischer](https://avatars.githubusercontent.com/u/5801521?s=130)](https://github.com/nfischer) | [![Ari Porad](https://avatars1.githubusercontent.com/u/1817508?v=3&s=130)](http://github.com/ariporad) |

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "posttest": "npm run lint",
     "test": "nyc --reporter=text --reporter=lcov ava --serial test/*.js",
+    "test-no-coverage": "ava --serial test/*.js",
     "gendocs": "node scripts/generate-docs",
     "lint": "eslint .",
     "after-travis": "travis-check-changes",

--- a/shell.js
+++ b/shell.js
@@ -123,3 +123,30 @@ exports.config = common.config;
 //@ ```
 //@
 //@ Use this value for calls to `glob.sync()` instead of the default options.
+
+//@
+//@ ### config.reset()
+//@
+//@ Example:
+//@
+//@ ```javascript
+//@ var shell = require('shelljs');
+//@ // Make changes to shell.config, and do stuff...
+//@ /* ... */
+//@ shell.config.reset(); // reset to original state
+//@ // Do more stuff, but with original settings
+//@ /* ... */
+//@ ```
+//@
+//@ Reset shell.config to the defaults:
+//@
+//@ ```javascript
+//@ {
+//@   fatal: false,
+//@   globOptions: {},
+//@   maxdepth: 255,
+//@   noglob: false,
+//@   silent: false,
+//@   verbose: false,
+//@ }
+//@ ```

--- a/src/common.js
+++ b/src/common.js
@@ -9,15 +9,42 @@ var shell = require('..');
 
 var shellMethods = Object.create(shell);
 
+// objectAssign(target_obj, source_obj1 [, source_obj2 ...])
+// "Ponyfill" for Object.assign
+//    objectAssign({A:1}, {b:2}, {c:3}) returns {A:1, b:2, c:3}
+var objectAssign = typeof Object.assign === 'function' ?
+  Object.assign :
+  function objectAssign(target) {
+    var sources = [].slice.call(arguments, 1);
+    sources.forEach(function (source) {
+      Object.keys(source).forEach(function (key) {
+        target[key] = source[key];
+      });
+    });
+
+    return target;
+  };
+exports.extend = objectAssign;
+
 // Module globals
-var config = {
-  silent: false,
+var DEFAULT_CONFIG = {
   fatal: false,
-  verbose: false,
-  noglob: false,
   globOptions: {},
-  maxdepth: 255
+  maxdepth: 255,
+  noglob: false,
+  silent: false,
+  verbose: false,
 };
+var config = {
+  reset: function () {
+    objectAssign(this, DEFAULT_CONFIG);
+  },
+  resetForTesting: function () {
+    objectAssign(this, DEFAULT_CONFIG);
+    this.silent = true;
+  },
+};
+config.reset();
 exports.config = config;
 
 var state = {
@@ -249,23 +276,6 @@ function randomFileName() {
   return 'shelljs_' + randomHash(20);
 }
 exports.randomFileName = randomFileName;
-
-// objectAssign(target_obj, source_obj1 [, source_obj2 ...])
-// "Ponyfill" for Object.assign
-//    objectAssign({A:1}, {b:2}, {c:3}) returns {A:1, b:2, c:3}
-var objectAssign = typeof Object.assign === 'function' ?
-  Object.assign :
-  function objectAssign(target) {
-    var sources = [].slice.call(arguments, 1);
-    sources.forEach(function (source) {
-      Object.keys(source).forEach(function (key) {
-        target[key] = source[key];
-      });
-    });
-
-    return target;
-  };
-exports.extend = objectAssign;
 
 // Common wrapper for all Unix-like commands that performs glob expansion,
 // command-logging, and other nice things

--- a/test/cd.js
+++ b/test/cd.js
@@ -11,7 +11,7 @@ const cur = shell.pwd().toString();
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   process.chdir(cur);
   shell.mkdir(t.context.tmp);
 });

--- a/test/cp.js
+++ b/test/cp.js
@@ -11,7 +11,7 @@ const CWD = process.cwd();
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.mkdir(t.context.tmp);
 });
 

--- a/test/dirs.js
+++ b/test/dirs.js
@@ -5,7 +5,7 @@ import test from 'ava';
 import shell from '..';
 
 test.beforeEach(() => {
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.pushd('resources/pushd');
   shell.pushd('a');
 });

--- a/test/find.js
+++ b/test/find.js
@@ -5,7 +5,7 @@ import shell from '..';
 const CWD = process.cwd();
 
 test.beforeEach(() => {
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   process.chdir(CWD);
 });
 

--- a/test/global.js
+++ b/test/global.js
@@ -8,7 +8,7 @@ import utils from './utils/utils';
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  config.silent = true;
+  config.resetForTesting();
   mkdir(t.context.tmp);
 });
 

--- a/test/grep.js
+++ b/test/grep.js
@@ -7,7 +7,7 @@ import utils from './utils/utils';
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.cp('-r', 'resources', t.context.tmp);
 });
 

--- a/test/ln.js
+++ b/test/ln.js
@@ -10,7 +10,7 @@ const CWD = process.cwd();
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.cp('-r', 'resources', t.context.tmp);
   process.chdir(CWD);
 });

--- a/test/ls.js
+++ b/test/ls.js
@@ -9,7 +9,7 @@ const CWD = process.cwd();
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.mkdir(t.context.tmp);
 });
 

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -7,7 +7,7 @@ import utils from './utils/utils';
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.mkdir(t.context.tmp);
 });
 

--- a/test/mv.js
+++ b/test/mv.js
@@ -10,7 +10,7 @@ const numLines = utils.numLines;
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.cp('-r', 'resources', t.context.tmp);
   shell.cd(t.context.tmp);
 });

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -36,7 +36,7 @@ function fooImplementation(options, arg) {
 }
 
 test.beforeEach(() => {
-  shell.config.silent = true;
+  shell.config.resetForTesting();
 });
 
 

--- a/test/popd.js
+++ b/test/popd.js
@@ -12,7 +12,7 @@ function reset() {
 }
 
 test.beforeEach(() => {
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   reset();
 });
 

--- a/test/pushd.js
+++ b/test/pushd.js
@@ -12,7 +12,7 @@ function reset() {
 }
 
 test.beforeEach(() => {
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   reset();
 });
 

--- a/test/pwd.js
+++ b/test/pwd.js
@@ -9,7 +9,7 @@ const cur = process.cwd();
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.mkdir(t.context.tmp);
 });
 

--- a/test/rm.js
+++ b/test/rm.js
@@ -8,7 +8,7 @@ import utils from './utils/utils';
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.cp('-r', 'resources', t.context.tmp);
 });
 

--- a/test/sed.js
+++ b/test/sed.js
@@ -7,7 +7,7 @@ import utils from './utils/utils';
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.cp('-r', 'resources', t.context.tmp);
 });
 

--- a/test/set.js
+++ b/test/set.js
@@ -8,7 +8,7 @@ const uncaughtErrorExitCode = 1;
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.cp('-r', 'resources', t.context.tmp);
 });
 

--- a/test/to.js
+++ b/test/to.js
@@ -7,7 +7,7 @@ import utils from './utils/utils';
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.mkdir(t.context.tmp);
 });
 

--- a/test/toEnd.js
+++ b/test/toEnd.js
@@ -7,7 +7,7 @@ import utils from './utils/utils';
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.mkdir(t.context.tmp);
 });
 

--- a/test/touch.js
+++ b/test/touch.js
@@ -8,7 +8,7 @@ import utils from './utils/utils';
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  shell.config.silent = true;
+  shell.config.resetForTesting();
   shell.mkdir(t.context.tmp);
 });
 


### PR DESCRIPTION
This adds `.reset()` and `.resetForTesting()` to `shell.config` and use `.resetForTesting()` as a standard set-up for unit tests.

This also adds `npm run test-no-coverage`, since testing with coverage every time gets pretty slow.

`.reset()` is implicitly tested by checking default values for `shell.config`. `.resetForTesting()` is relied upon by all unit tests.