### PR TITLE
chore(lint): Enforce a trailing comma for multi-line

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   },
   "extends": "airbnb-base/legacy",
   "rules": {
-    "comma-dangle": 0,
+    "comma-dangle": [2, "always-multiline"],
     "global-require": 0,
     "vars-on-top": 0,
     "spaced-comment": [2, "always", { "markers": ["@", "@include"], "exceptions": ["@", "@commands"] }],

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -21,12 +21,12 @@ var PERMS = (function (base) {
     SETGID: parseInt('02000', 8),
     SETUID: parseInt('04000', 8),
 
-    TYPE_MASK: parseInt('0770000', 8)
+    TYPE_MASK: parseInt('0770000', 8),
   };
 }({
   EXEC: 1,
   WRITE: 2,
-  READ: 4
+  READ: 4,
 }));
 
 common.register('chmod', _chmod, {
@@ -73,7 +73,7 @@ function _chmod(options, mode, filePattern) {
   options = common.parseOptions(options, {
     'R': 'recursive',
     'c': 'changes',
-    'v': 'verbose'
+    'v': 'verbose',
   });
 
   filePattern = [].slice.call(arguments, 2);

--- a/src/common.js
+++ b/src/common.js
@@ -51,7 +51,7 @@ var state = {
   error: null,
   errorCode: 0,
   currentCmd: 'shell.js',
-  tempDir: null
+  tempDir: null,
 };
 exports.state = state;
 
@@ -106,7 +106,7 @@ function error(msg, _code, options) {
   if (!options.continue) {
     throw {
       msg: 'earlyExit',
-      retValue: (new ShellString('', state.error, state.errorCode))
+      retValue: (new ShellString('', state.error, state.errorCode)),
     };
   }
 }

--- a/src/dirs.js
+++ b/src/dirs.js
@@ -63,7 +63,7 @@ function _pushd(options, dir) {
   }
 
   options = common.parseOptions(options, {
-    'n': 'no-cd'
+    'n': 'no-cd',
   });
 
   var dirs = _actualDirStack();
@@ -129,7 +129,7 @@ function _popd(options, index) {
   }
 
   options = common.parseOptions(options, {
-    'n': 'no-cd'
+    'n': 'no-cd',
   });
 
   if (!_dirStack.length) {
@@ -172,7 +172,7 @@ function _dirs(options, index) {
   }
 
   options = common.parseOptions(options, {
-    'c': 'clear'
+    'c': 'clear',
   });
 
   if (options.clear) {

--- a/src/exec.js
+++ b/src/exec.js
@@ -30,7 +30,7 @@ function execSync(cmd, opts, pipe) {
     silent: common.config.silent,
     cwd: _pwd().toString(),
     env: process.env,
-    maxBuffer: DEFAULT_MAXBUFFER_SIZE
+    maxBuffer: DEFAULT_MAXBUFFER_SIZE,
   }, opts);
 
   var previousStdoutContent = '';
@@ -186,7 +186,7 @@ function execAsync(cmd, opts, pipe, callback) {
     silent: common.config.silent,
     cwd: _pwd().toString(),
     env: process.env,
-    maxBuffer: DEFAULT_MAXBUFFER_SIZE
+    maxBuffer: DEFAULT_MAXBUFFER_SIZE,
   }, opts);
 
   var c = child.exec(cmd, opts, function (err) {
@@ -275,7 +275,7 @@ function _exec(command, options, callback) {
 
   options = common.extend({
     silent: common.config.silent,
-    async: false
+    async: false,
   }, options);
 
   try {

--- a/src/set.js
+++ b/src/set.js
@@ -34,7 +34,7 @@ function _set(options) {
   options = common.parseOptions(options, {
     'e': 'fatal',
     'v': 'verbose',
-    'f': 'noglob'
+    'f': 'noglob',
   });
 
   if (negate) {


### PR DESCRIPTION
Multi-line lists and objects should have a trailing comma. This keeps things stylistically consistent, while still having good compatibility.