### PR TITLE
Fix find ENOENT

### DIFF
--- a/src/find.js
+++ b/src/find.js
@@ -40,9 +40,16 @@ function _find(options, paths) {
   // to get the base dir in the output, we need instead ls('-R', 'dir/*') for every directory
 
   paths.forEach(function (file) {
+    var stat;
+    try {
+      stat = fs.statSync(file);
+    } catch (e) {
+      common.error('no such file or directory: ' + file);
+    }
+
     pushFile(file);
 
-    if (fs.statSync(file).isDirectory()) {
+    if (stat.isDirectory()) {
       _ls({ recursive: true, all: true }, file).forEach(function (subfile) {
         pushFile(path.join(file, subfile));
       });

--- a/test/find.js
+++ b/test/find.js
@@ -60,3 +60,9 @@ test('multiple paths - array', t => {
   t.truthy(result.indexOf('resources/find/dir2/a_dir1') > -1);
   t.is(result.length, 6);
 });
+
+test('nonexistent path', t => {
+  const result = shell.find('resources/find/nonexistent');
+  t.is(shell.error(), 'find: no such file or directory: resources/find/nonexistent');
+  t.is(result.code, 1);
+});


### PR DESCRIPTION
Fixes #653 

Fixes `find` so that it returns a shell error if passed a non-existent path.