### PR TITLE
feature: add -a option for which command

### DIFF
--- a/test/which.js
+++ b/test/which.js
@@ -46,9 +46,15 @@ test('Windows can search with or without a .exe extension', t => {
   }
 });
 
-test('Search all of matched binaries', t => {
+test('Search all of matched binaries shoud return an array', t => {
   const result = shell.which('-a', 'node');
   t.falsy(shell.error());
   t.truthy(result);
   t.truthy(result.length);
+});
+
+test('Search all for not exist command should return an empty array', t => {
+  const notExist = '6ef25c13209cb28ae465852508cc3a8f3dcdc71bc7bcf8c38379ba38me';
+  const result = shell.which('-a', notExist);
+  t.truthy(result.length === 0)
 });

--- a/test/which.js
+++ b/test/which.js
@@ -46,15 +46,27 @@ test('Windows can search with or without a .exe extension', t => {
   }
 });
 
-test('Search all of matched binaries shoud return an array', t => {
-  const result = shell.which('-a', 'node');
+test('Searching with -a flag returns an array', t => {
+  const commandName = 'node'; //Should be an existing command
+  const result = shell.which('-a', commandName);
   t.falsy(shell.error());
   t.truthy(result);
-  t.truthy(result.length);
+  t.not(result.length, 0);
 });
 
-test('Search all for not exist command should return an empty array', t => {
+test('Searching with -a flag for not existing command returns an empty array', t => {
   const notExist = '6ef25c13209cb28ae465852508cc3a8f3dcdc71bc7bcf8c38379ba38me';
   const result = shell.which('-a', notExist);
-  t.truthy(result.length === 0)
+  t.falsy(shell.error());
+  t.is(result.length, 0)
+});
+
+test('Searching with -a flag returns an array with first item equals to the regular search', t => {
+  const commandName = 'node'; //Should be an existing command
+  const resultForWhich = shell.which(commandName);
+  const resultForWhichA = shell.which('-a', commandName);
+  t.falsy(shell.error());
+  t.truthy(resultForWhich);
+  t.truthy(resultForWhichA);
+  t.is(resultForWhich.toString(), resultForWhichA[0].toString());
 });

--- a/test/which.js
+++ b/test/which.js
@@ -45,3 +45,10 @@ test('Windows can search with or without a .exe extension', t => {
     t.is(node.toString(), nodeExe.toString());
   }
 });
+
+test('Search all of matched binaries', t => {
+  const result = shell.which('-a', 'node');
+  t.falsy(shell.error());
+  t.truthy(result);
+  t.truthy(result.length);
+});

--- a/test/which.js
+++ b/test/which.js
@@ -47,7 +47,7 @@ test('Windows can search with or without a .exe extension', t => {
 });
 
 test('Searching with -a flag returns an array', t => {
-  const commandName = 'node'; //Should be an existing command
+  const commandName = 'node'; // Should be an existing command
   const result = shell.which('-a', commandName);
   t.falsy(shell.error());
   t.truthy(result);
@@ -58,11 +58,11 @@ test('Searching with -a flag for not existing command returns an empty array', t
   const notExist = '6ef25c13209cb28ae465852508cc3a8f3dcdc71bc7bcf8c38379ba38me';
   const result = shell.which('-a', notExist);
   t.falsy(shell.error());
-  t.is(result.length, 0)
+  t.is(result.length, 0);
 });
 
 test('Searching with -a flag returns an array with first item equals to the regular search', t => {
-  const commandName = 'node'; //Should be an existing command
+  const commandName = 'node'; // Should be an existing command
   const resultForWhich = shell.which(commandName);
   const resultForWhichA = shell.which('-a', commandName);
   t.falsy(shell.error());


### PR DESCRIPTION
With a `-a` option it will return an array of all matched binaries. Stdout is formatted as needed (joined with `\n` all binaries and `\n` is added to the end).
I've tested it on Mac OSX and Windows.