### PR TITLE
docs: clean up RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,14 @@
 # Release steps
 
 1. Ensure master passes CI tests
-2. `npm run gendocs`
-3. Bump version, create tags, push, and release:
+2. Bump version, create tags, push, and release:
   - `$ npm run <release:major|release:minor|release:patch>`
   - `major` - breaking API changes
   - `minor` - backwards-compatible features
   - `patch` - backwards-compatible bug fixes
-4. Update CHANGELOG.md
+3. Update `CHANGELOG.md`
   - `$ npm run changelog`
+  - Manually verify that the changelog makes sense
   - `$ git push`
-5. Generate the documentup website by visiting
-  [http://documentup.com/shelljs/shelljs/__recompile] in your browser
+4. Generate the documentup website by visiting
+  http://documentup.com/shelljs/shelljs/__recompile in your browser


### PR DESCRIPTION
Miscellaneous changes.

`npm run gendocs` is actually done as part of the CI, so it isn't necessary to run it manually for a release.