### PR TITLE
test: don't count hard-to-test lines for coverage

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -73,6 +73,7 @@ exports.platform = platform;
 var pipeMethods = [];
 
 function log() {
+  /* istanbul ignore next */
   if (!config.silent) {
     console.error.apply(console, arguments);
   }
@@ -259,6 +260,7 @@ function unlinkSync(file) {
     fs.unlinkSync(file);
   } catch (e) {
     // Try to override file permission
+    /* istanbul ignore next */
     if (e.code === 'EPERM') {
       fs.chmodSync(file, '0666');
       fs.unlinkSync(file);
@@ -364,6 +366,7 @@ function wrap(cmd, fn, options) {
 
           retValue = fn.apply(this, args);
         } catch (e) {
+          /* istanbul ignore else */
           if (e.msg === 'earlyExit') {
             retValue = e.retValue;
           } else {
@@ -372,6 +375,7 @@ function wrap(cmd, fn, options) {
         }
       }
     } catch (e) {
+      /* istanbul ignore next */
       if (!state.error) {
         // If state.error hasn't been set it's an error thrown by Node, not us - probably a bug...
         console.error('ShellJS: internal error');

--- a/src/cp.js
+++ b/src/cp.js
@@ -54,12 +54,14 @@ function copyFileSync(srcFile, destFile, options) {
     try {
       fdr = fs.openSync(srcFile, 'r');
     } catch (e) {
+      /* istanbul ignore next */
       common.error('copyFileSync: could not read src file (' + srcFile + ')');
     }
 
     try {
       fdw = fs.openSync(destFile, 'w');
     } catch (e) {
+      /* istanbul ignore next */
       common.error('copyFileSync: could not write to dest file (code=' + e.code + '):' + destFile);
     }
 
@@ -243,6 +245,7 @@ function _cp(options, sources, dest) {
           fs.statSync(path.dirname(dest));
           cpdirSyncRecursive(src, newDest, 0, { no_force: options.no_force, followsymlink: options.followsymlink });
         } catch (e) {
+          /* istanbul ignore next */
           common.error("cannot create directory '" + dest + "': No such file or directory");
         }
       }

--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -83,6 +83,7 @@ function _mkdir(options, dirs) {
       if (e.code === 'EACCES') {
         common.error('cannot create directory ' + dir + ': Permission denied');
       } else {
+        /* istanbul ignore next */
         throw e;
       }
     }

--- a/src/mv.js
+++ b/src/mv.js
@@ -38,6 +38,7 @@ function _mv(options, sources, dest) {
   } else if (typeof sources === 'string') {
     sources = [sources];
   } else {
+    // TODO(nate): figure out if we actually need this line
     common.error('invalid arguments');
   }
 
@@ -82,9 +83,12 @@ function _mv(options, sources, dest) {
     try {
       fs.renameSync(src, thisDest);
     } catch (e) {
-      if (e.code === 'EXDEV') { // external partition
-        // if either of these fails, the appropriate error message will bubble
-        // up to the top level automatically
+      /* istanbul ignore next */
+      if (e.code === 'EXDEV') {
+        // If we're trying to `mv` to an external partition, we'll actually need
+        // to perform a copy and then clean up the original file. If either the
+        // copy or the rm fails with an exception, we should allow this
+        // exception to pass up to the top level.
         cp('-r', src, thisDest);
         rm('-rf', src);
       }

--- a/src/rm.js
+++ b/src/rm.js
@@ -34,7 +34,10 @@ function rmdirSyncRecursive(dir, force) {
         try {
           common.unlinkSync(file);
         } catch (e) {
-          common.error('could not remove file (code ' + e.code + '): ' + file, { continue: true });
+          /* istanbul ignore next */
+          common.error('could not remove file (code ' + e.code + '): ' + file, {
+            continue: true,
+          });
         }
       }
     }
@@ -55,6 +58,7 @@ function rmdirSyncRecursive(dir, force) {
         if (fs.existsSync(dir)) throw { code: 'EAGAIN' };
         break;
       } catch (er) {
+        /* istanbul ignore next */
         // In addition to error codes, also check if the directory still exists and loop again if true
         if (process.platform === 'win32' && (er.code === 'ENOTEMPTY' || er.code === 'EBUSY' || er.code === 'EPERM' || er.code === 'EAGAIN')) {
           if (Date.now() - start > 1000) throw er;

--- a/src/tempdir.js
+++ b/src/tempdir.js
@@ -19,6 +19,7 @@ function writeableDir(dir) {
     common.unlinkSync(testFile);
     return dir;
   } catch (e) {
+    /* istanbul ignore next */
     return false;
   }
 }

--- a/src/test.js
+++ b/src/test.js
@@ -72,10 +72,13 @@ function _test(options, path) {
 
   if (options.file) return stats.isFile();
 
+  /* istanbul ignore next */
   if (options.pipe) return stats.isFIFO();
 
+  /* istanbul ignore next */
   if (options.socket) return stats.isSocket();
 
+  /* istanbul ignore next */
   return false; // fallback
 } // test
 module.exports = _test;

--- a/src/to.js
+++ b/src/to.js
@@ -30,6 +30,7 @@ function _to(options, file) {
     fs.writeFileSync(file, this.stdout || this.toString(), 'utf8');
     return this;
   } catch (e) {
+    /* istanbul ignore next */
     common.error('could not write to file (code ' + e.code + '): ' + file, { continue: true });
   }
 }

--- a/src/toEnd.js
+++ b/src/toEnd.js
@@ -29,6 +29,7 @@ function _toEnd(options, file) {
     fs.appendFileSync(file, this.stdout || this.toString(), 'utf8');
     return this;
   } catch (e) {
+    /* istanbul ignore next */
     common.error('could not append to file (code ' + e.code + '): ' + file, { continue: true });
   }
 }


### PR DESCRIPTION
No change in logic.

Add `/* istanbul ignore next */` lines for hard-to-test lines so that
they don't count against us during code coverage.

I've also adjusted comments that I found confusing, and changed some
formatting.

Partial fix for #671