### PR TITLE
test: add misc. tests to improve coverage

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -6,6 +6,11 @@ import utils from './utils/utils';
 
 shell.config.silent = true;
 
+test.beforeEach(() => {
+  common.state.error = null;
+  common.state.errorCode = 0;
+});
+
 //
 // Invalids
 //
@@ -20,6 +25,26 @@ test('should be a list', t => {
   t.throws(() => {
     common.expand('resources');
   }, TypeError);
+});
+
+test('parseOptions (invalid option in options object)', t => {
+  t.throws(() => {
+    common.parseOptions({ q: 'some string value' }, {
+      R: 'recursive',
+      f: 'force',
+      r: 'reverse',
+    });
+  });
+});
+
+test('parseOptions (invalid type)', t => {
+  t.throws(() => {
+    common.parseOptions(12, {
+      R: 'recursive',
+      f: 'force',
+      r: 'reverse',
+    });
+  });
 });
 
 //

--- a/test/mv.js
+++ b/test/mv.js
@@ -91,6 +91,15 @@ test('-n is no-force/no-clobber', t => {
   t.is(result.stderr, 'mv: dest file already exists: file2');
 });
 
+test('-n option with a directory as the destination', t => {
+  shell.cp('file1', 'cp'); // copy it so we're sure it's already there
+  const result = shell.mv('-n', 'file1', 'cp');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  // TODO(nate): make this an equals comparison once issue #681 is resolved
+  t.regex(result.stderr, /mv: dest file already exists: cp.file1/);
+});
+
 test('-f is the default behavior', t => {
   const result = shell.mv('file1', 'file2'); // dest already exists (but that's ok)
   t.falsy(shell.error());
@@ -153,19 +162,13 @@ test('one source', t => {
 });
 
 test('two sources', t => {
-  shell.rm('-rf', 't');
-  shell.mkdir('-p', 't');
-  let result = shell.mv('file1', 'file2', 't');
+  const result = shell.mv('file1', 'file2', 'cp');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.falsy(fs.existsSync('file1'));
   t.falsy(fs.existsSync('file2'));
-  t.truthy(fs.existsSync('t/file1'));
-  t.truthy(fs.existsSync('t/file2'));
-  result = shell.mv('t/*', '.'); // revert
-  t.is(result.code, 0);
-  t.truthy(fs.existsSync('file1'));
-  t.truthy(fs.existsSync('file2'));
+  t.truthy(fs.existsSync('cp/file1'));
+  t.truthy(fs.existsSync('cp/file2'));
 });
 
 test('two sources, array style', t => {

--- a/test/rm.js
+++ b/test/rm.js
@@ -35,6 +35,13 @@ test('file does not exist', t => {
   t.is(result.stderr, 'rm: no such file or directory: asdfasdf');
 });
 
+test('cannot delete a directoy without recursive flag', t => {
+  const result = shell.rm(`${t.context.tmp}/rm`);
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, 'rm: path is a directory');
+});
+
 test('only an option', t => {
   const result = shell.rm('-f');
   t.truthy(shell.error());

--- a/test/toEnd.js
+++ b/test/toEnd.js
@@ -30,6 +30,12 @@ test('missing file argument', t => {
   t.truthy(shell.error());
 });
 
+test('cannot write to a non-existent directory', t => {
+  t.falsy(fs.existsSync('/asdfasdf')); // sanity check
+  shell.ShellString('hello world').toEnd('/asdfasdf/file');
+  t.truthy(shell.error());
+});
+
 //
 // Valids
 //


### PR DESCRIPTION
No change in production logic.

This adds missing tests to improve test coverage. This does not change
ShellJS behavior at all--all test cases are testing already-working
functionality.

One test case has been renamed for clarity.

For the "omit directory if missing recursive flag" case, we were
actually already testing that in another case, but we were testing
multiple things in that test case. It's better to test this one error
condition explicitly in its own case.

When adding real tests for `parseOptions()`, we need to explicitly clear
`common.state.error` because we're testing an internal function, not a
wrapped command.

Partial fix for #671