### PR TITLE
refactor(parseOptions): better handle errors

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -195,11 +195,12 @@ function parseOptions(opt, map, errorOptions) {
   });
 
   if (!opt) return options; // defaults
+  var hasErrorOpts = typeof errorOptions === 'object';
 
   var optionName;
   if (typeof opt === 'string') {
     if (opt[0] !== '-') {
-      return options;
+      error("Must start the options string with a '-'");
     }
 
     // e.g. chars = ['R', 'f']
@@ -213,10 +214,10 @@ function parseOptions(opt, map, errorOptions) {
         } else {
           options[optionName] = true;
         }
-      } else if (typeof errorOptions === 'object') {
-        error('option not recognized: ' + c, errorOptions);
       } else {
-        error('option not recognized: ' + c);
+        error('option not recognized: ' + c, hasErrorOpts
+          ? errorOptions
+          : undefined);
       }
     });
   } else if (typeof opt === 'object') {
@@ -226,16 +227,16 @@ function parseOptions(opt, map, errorOptions) {
       if (c in map) {
         optionName = map[c];
         options[optionName] = opt[key]; // assign the given value
-      } else if (typeof errorOptions === 'object') {
-        error('option not recognized: ' + c, errorOptions);
       } else {
-        error('option not recognized: ' + c);
+        error('option not recognized: ' + c, hasErrorOpts
+          ? errorOptions
+          : undefined);
       }
     });
-  } else if (typeof errorOptions === 'object') {
-    error('options must be strings or key-value pairs', errorOptions);
   } else {
-    error('options must be strings or key-value pairs');
+    error('options must be strings or key-value pairs', hasErrorOpts
+        ? errorOptions
+        : undefined);
   }
   return options;
 }

--- a/src/common.js
+++ b/src/common.js
@@ -72,6 +72,12 @@ exports.platform = platform;
 // This is populated by calls to commonl.wrap()
 var pipeMethods = [];
 
+// Reliably test if something is any sort of javascript object
+function isObject(a) {
+  return typeof a === 'object' && a !== null;
+}
+exports.isObject = isObject;
+
 function log() {
   /* istanbul ignore next */
   if (!config.silent) {
@@ -103,9 +109,9 @@ function error(msg, _code, options) {
     silent: false,
   };
 
-  if (typeof _code === 'number' && typeof options === 'object') {
+  if (typeof _code === 'number' && isObject(options)) {
     options.code = _code;
-  } else if (typeof _code === 'object') { // no 'code'
+  } else if (isObject(_code)) { // no 'code'
     options = _code;
   } else if (typeof _code === 'number') { // no 'options'
     options = { code: _code };
@@ -185,11 +191,11 @@ exports.getUserHome = getUserHome;
 //   parseOptions({'-r': 'string-value'}, {'r':'reference', 'b':'bob'});
 function parseOptions(opt, map, errorOptions) {
   // Validate input
-  if (typeof opt !== 'string' && !(opt instanceof Object)) {
+  if (typeof opt !== 'string' && !isObject(opt)) {
     throw new Error('options must be strings or key-value pairs');
-  } else if (!(map instanceof Object)) {
+  } else if (!isObject(map)) {
     throw new Error('parseOptions() internal error: map must be an object');
-  } else if (errorOptions && !(errorOptions instanceof Object)) {
+  } else if (errorOptions && !isObject(errorOptions)) {
     throw new Error('parseOptions() internal error: errorOptions must be object');
   }
 
@@ -224,7 +230,7 @@ function parseOptions(opt, map, errorOptions) {
         error('option not recognized: ' + c, errorOptions || {});
       }
     });
-  } else { // opt instanceof Option
+  } else { // opt is an Object
     Object.keys(opt).forEach(function (key) {
       // key is a string of the form '-r', '-d', etc.
       var c = key[1];
@@ -327,7 +333,7 @@ function wrap(cmd, fn, options) {
       if (options.unix === false) { // this branch is for exec()
         retValue = fn.apply(this, args);
       } else { // and this branch is for everything else
-        if (args[0] instanceof Object && args[0].constructor.name === 'Object') {
+        if (isObject(args[0]) && args[0].constructor.name === 'Object') {
           // a no-op, allowing the syntax `touch({'-r': file}, ...)`
         } else if (args.length === 0 || typeof args[0] !== 'string' || args[0].length <= 1 || args[0][0] !== '-') {
           args.unshift(''); // only add dummy option if '-option' not already present
@@ -347,7 +353,7 @@ function wrap(cmd, fn, options) {
 
         // Convert ShellStrings (basically just String objects) to regular strings
         args = args.map(function (arg) {
-          if (arg instanceof Object && arg.constructor.name === 'String') {
+          if (isObject(arg) && arg.constructor.name === 'String') {
             return arg.toString();
           }
           return arg;
@@ -370,7 +376,7 @@ function wrap(cmd, fn, options) {
 
         try {
           // parse options if options are provided
-          if (typeof options.cmdOptions === 'object') {
+          if (isObject(options.cmdOptions)) {
             args[0] = parseOptions(args[0], options.cmdOptions);
           }
 

--- a/src/common.js
+++ b/src/common.js
@@ -186,11 +186,11 @@ exports.getUserHome = getUserHome;
 function parseOptions(opt, map, errorOptions) {
   // Validate input
   if (typeof opt !== 'string' && !(opt instanceof Object)) {
-    error('options must be strings or key-value pairs');
+    throw new Error('options must be strings or key-value pairs');
   } else if (!(map instanceof Object)) {
-    error('parseOptions() internal error: map must be an object');
+    throw new Error('parseOptions() internal error: map must be an object');
   } else if (errorOptions && !(errorOptions instanceof Object)) {
-    error('parseOptions() internal error: errorOptions must be object');
+    throw new Error('parseOptions() internal error: errorOptions must be object');
   }
 
   // All options are false by default

--- a/test/common.js
+++ b/test/common.js
@@ -40,9 +40,45 @@ test('parseOptions (invalid option in options object)', t => {
 test('parseOptions (without a hyphen in the string)', t => {
   t.throws(() => {
     common.parseOptions('f', {
-      R: 'recursive',
       f: 'force',
-      r: 'reverse',
+    });
+  });
+});
+
+test('parseOptions (opt is not a string/object)', t => {
+  t.throws(() => {
+    common.parseOptions(1, {
+      f: 'force',
+    });
+  });
+});
+
+test('parseOptions (map is not an object)', t => {
+  t.throws(() => {
+    common.parseOptions('-f', 27);
+  });
+});
+
+test('parseOptions (errorOptions is not an object)', t => {
+  t.throws(() => {
+    common.parseOptions('-f', {
+      f: 'force',
+    }, 'not a valid errorOptions');
+  });
+});
+
+test('parseOptions (unrecognized string option)', t => {
+  t.throws(() => {
+    common.parseOptions('-z', {
+      f: 'force',
+    });
+  });
+});
+
+test('parseOptions (unrecognized option in Object)', t => {
+  t.throws(() => {
+    common.parseOptions({ '-c': 7 }, {
+      f: 'force',
     });
   });
 });

--- a/test/common.js
+++ b/test/common.js
@@ -37,6 +37,16 @@ test('parseOptions (invalid option in options object)', t => {
   });
 });
 
+test('parseOptions (without a hyphen in the string)', t => {
+  t.throws(() => {
+    common.parseOptions('f', {
+      R: 'recursive',
+      f: 'force',
+      r: 'reverse',
+    });
+  });
+});
+
 test('parseOptions (invalid type)', t => {
   t.throws(() => {
     common.parseOptions(12, {


### PR DESCRIPTION
For the case where `parseOptions()` is passed a string that does not
start with a hyphen, we should reject this string instead of returning
the same value. This has no change on any other test cases, and should
not affect any commands since we are careful about what input we pass to
`parseOptions()`

This also adjust how we were handling error cases in the function. We
were previously using two different calls to `common.error()`, one for
if `errorOptions` is passed, and one without. This hurts readability,
because it reads like "if we have errorOptions, then this is an error,
and if we don't then it's also an error," instead of the more
appropriate, "we reached an error case and should use errorOptions if
it's available, otherwise we should signal an error without using it."

We now reject invalid input at the top of the function. These are regular
`Error`s instead of calls to `common.error()` because they represent misuse
of an internal function.

Added test cases bring this function to 100% test coverage.

Partial fix for #671