### PR TITLE
Modified glob pattern. Fixes #666

### DIFF
--- a/src/ls.js
+++ b/src/ls.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var common = require('./common');
 var glob = require('glob');
 
-var globPatternRecursive = path.sep + '**' + path.sep + '*';
+var globPatternRecursive = path.sep + '**';
 
 common.register('ls', _ls, {
   cmdOptions: {
@@ -86,7 +86,10 @@ function _ls(options, paths) {
         // use glob, because it's simple
         glob.sync(p + globPatternRecursive, { dot: options.all, follow: options.link })
           .forEach(function (item) {
-            pushFile(item, path.relative(p, item));
+            // Glob pattern returns the directory itself and needs to be filtered out.
+            if (path.relative(p, item)) {
+              pushFile(item, path.relative(p, item));
+            }
           });
       } else if (options.all) {
         // use fs.readdirSync, because it's fast

--- a/test/ls.js
+++ b/test/ls.js
@@ -292,7 +292,19 @@ test('-RA flag, path given', t => {
   t.is(result.length, 14);
 });
 
-test('-RAL flag, path given', t => {
+test('-RA flag, symlinks are not followed', t => {
+  const result = shell.ls('-RA', 'resources/rm');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.truthy(result.indexOf('a_dir') > -1);
+  t.truthy(result.indexOf('a_dir/a_file') > -1);
+  t.truthy(result.indexOf('link_to_a_dir') > -1);
+  t.is(result.indexOf('link_to_a_dir/a_file'), -1);
+  t.truthy(result.indexOf('fake.lnk') > -1);
+  t.is(result.length, 4);
+});
+
+test('-RAL flag, follows symlinks', t => {
   if (process.platform !== 'win32') {
     const result = shell.ls('-RAL', 'resources/rm');
     t.falsy(shell.error());


### PR DESCRIPTION
### Rebase of #669

This PR continues #665 and fixes #666.

From `node-glob` repo:

>Note that symlinked directories are not crawled as part of a **, though their contents may match against subsequent portions of the pattern. This prevents infinite loops and duplicates and the like.

Therefore, the current pattern (`/**/*`) takes the first level of files inside symlinked directories. This PR changes it to `/**` which does not follow symlinks.

Now both `ls` and `find` only show the symlink directory as a single entry. `ls -RL` follows it.