### PR TITLE
Fix cp overwriting identical files

### DIFF
--- a/src/cp.js
+++ b/src/cp.js
@@ -267,7 +267,7 @@ function _cp(options, sources, dest) {
       if (path.relative(src, thisDest) === '') {
         // a file cannot be copied to itself, but we want to continue copying other files,
         // so save the error for later
-        identicalFiles.push([thisDest, src]);
+        identicalFiles.push("'" + thisDest + "' and '" + src + "' are the same file");
         return;
       }
 
@@ -277,11 +277,9 @@ function _cp(options, sources, dest) {
 
   if (identicalFiles.length > 0) {
     // if any of the copies were identical, print an error for each and then exit
-    identicalFiles.forEach(function (files, i) {
-      var thisDest = files[0];
-      var src = files[1];
+    identicalFiles.forEach(function (err, i) {
       var cont = i < identicalFiles.length - 1; // exit on the last file
-      common.error(thisDest + ' and ' + src + ' are identical (not copied).', { continue: cont });
+      common.error(err, { continue: cont });
     });
   }
 

--- a/src/cp.js
+++ b/src/cp.js
@@ -213,7 +213,6 @@ function _cp(options, sources, dest) {
 
   var destExists = fs.existsSync(dest);
   var destStat = destExists && fs.statSync(dest);
-  var identicalFiles = [];
 
   // Dest is not existing dir, but multiple sources given
   if ((!destExists || !destStat.isDirectory()) && sources.length > 1) {
@@ -265,23 +264,14 @@ function _cp(options, sources, dest) {
       }
 
       if (path.relative(src, thisDest) === '') {
-        // a file cannot be copied to itself, but we want to continue copying other files,
-        // so save the error for later
-        identicalFiles.push("'" + thisDest + "' and '" + src + "' are the same file");
+        // a file cannot be copied to itself, but we want to continue copying other files
+        common.error("'" + thisDest + "' and '" + src + "' are the same file", { continue: true });
         return;
       }
 
       copyFileSync(src, thisDest, options);
     }
   }); // forEach(src)
-
-  if (identicalFiles.length > 0) {
-    // if any of the copies were identical, print an error for each and then exit
-    identicalFiles.forEach(function (err, i) {
-      var cont = i < identicalFiles.length - 1; // exit on the last file
-      common.error(err, { continue: cont });
-    });
-  }
 
   return new common.ShellString('', common.state.error, common.state.errorCode);
 }

--- a/test/cp.js
+++ b/test/cp.js
@@ -693,7 +693,7 @@ test('copy file to same location', t => {
   const result = shell.cp('resources/file1', 'resources');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, 'cp: resources/file1 and resources/file1 are identical (not copied).');
+  t.is(result.stderr, "cp: 'resources/file1' and 'resources/file1' are the same file");
 });
 
 test('copy mutliple files to same location', t => {
@@ -702,7 +702,7 @@ test('copy mutliple files to same location', t => {
   t.is(result.code, 1);
   t.is(
     result.stderr,
-    'cp: resources/file1 and resources/file1 are identical (not copied).\n' +
-    'cp: resources/file2 and resources/file2 are identical (not copied).'
+    "cp: 'resources/file1' and 'resources/file1' are the same file\n" +
+    "cp: 'resources/file2' and 'resources/file2' are the same file"
   );
 });

--- a/test/cp.js
+++ b/test/cp.js
@@ -688,3 +688,21 @@ test('recursive, with a non-normalized path', t => {
   t.falsy(result.stderr);
   t.is(result.code, 0);
 });
+
+test('copy file to same location', t => {
+  const result = shell.cp('resources/file1', 'resources');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, 'cp: resources/file1 and resources/file1 are identical (not copied).');
+});
+
+test('copy mutliple files to same location', t => {
+  const result = shell.cp('resources/file1', 'resources/file2', 'resources');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(
+    result.stderr,
+    'cp: resources/file1 and resources/file1 are identical (not copied).\n' +
+    'cp: resources/file2 and resources/file2 are identical (not copied).'
+  );
+});

--- a/test/cp.js
+++ b/test/cp.js
@@ -689,7 +689,14 @@ test('recursive, with a non-normalized path', t => {
   t.is(result.code, 0);
 });
 
-test('copy file to same location', t => {
+test('copy file to same path', t => {
+  const result = shell.cp('resources/file1', 'resources/file1');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, "cp: 'resources/file1' and 'resources/file1' are the same file");
+});
+
+test('copy file to same directory', t => {
   const result = shell.cp('resources/file1', 'resources');
   t.truthy(shell.error());
   t.is(result.code, 1);


### PR DESCRIPTION
If `cp` is passed a destination that is location of a source file, in effect, copying a file to itself, the source file will become empty. This prevents this situation form happening by verifying that the destination is a different location than the source.

Fixes #678 