### PR TITLE
chore: add codecov script to appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,3 +24,6 @@ build: off
 
 test_script:
   - npm test
+
+on_success:
+  - npm run codecov -- -f coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lint": "eslint .",
     "after-travis": "travis-check-changes",
     "changelog": "shelljs-changelog",
+    "codecov": "codecov",
     "release:major": "shelljs-release major",
     "release:minor": "shelljs-release minor",
     "release:patch": "shelljs-release patch"


### PR DESCRIPTION
Invoke codecov on appveyor builds too, so that we can get coverage for
Windows-specific lines of code.

Partial fix for #671