### PR TITLE
Remove contents of symlink to dir with rm -rf

### DIFF
--- a/src/rm.js
+++ b/src/rm.js
@@ -1,5 +1,6 @@
 var common = require('./common');
 var fs = require('fs');
+var path = require('path');
 
 common.register('rm', _rm, {
   cmdOptions: {
@@ -17,7 +18,7 @@ common.register('rm', _rm, {
 //
 // Licensed under the MIT License
 // http://www.opensource.org/licenses/mit-license.php
-function rmdirSyncRecursive(dir, force) {
+function rmdirSyncRecursive(dir, force, fromSymlink) {
   var files;
 
   files = fs.readdirSync(dir);
@@ -42,6 +43,10 @@ function rmdirSyncRecursive(dir, force) {
       }
     }
   }
+
+  // if was directory was referenced through a symbolic link,
+  // do not remove the directory itself
+  if (fromSymlink) return;
 
   // Now that we know everything in the sub-tree has been deleted, we can delete the main directory.
   // Huzzah for the shopkeep.
@@ -91,6 +96,60 @@ function isWriteable(file) {
   return writePermission;
 }
 
+function handleFile(file, options) {
+  if (options.force || isWriteable(file)) {
+    // -f was passed, or file is writable, so it can be removed
+    common.unlinkSync(file);
+  } else {
+    common.error('permission denied: ' + file, { continue: true });
+  }
+}
+
+function handleDirectory(file, options) {
+  if (options.recursive) {
+    // -r was passed, so directory can be removed
+    rmdirSyncRecursive(file, options.force);
+  } else {
+    common.error('path is a directory', { continue: true });
+  }
+}
+
+function handleSymbolicLink(file, options) {
+  var stats;
+  try {
+    stats = fs.statSync(file);
+  } catch (e) {
+    // symlink is bad, so just remove it
+    common.unlinkSync(file);
+    return;
+  }
+
+  if (stats.isFile()) {
+    common.unlinkSync(file);
+  } else if (stats.isDirectory()) {
+    if (file[file.length - 1] === '/') {
+      // trailing separator, so remove the contents, not the link
+      if (options.recursive) {
+        // -r was passed, so directory can be removed
+        var link = file.slice(0, -1); // remove the '/' character for readlinkSync
+        var dir = fs.readlinkSync(link);
+        var dirpath = path.resolve(path.dirname(link), dir);
+        var fromSymlink = true;
+        rmdirSyncRecursive(dirpath, options.force, fromSymlink);
+      } else {
+        common.error('path is a directory', { continue: true });
+      }
+    } else {
+      // no trailing separator, so remove the link
+      common.unlinkSync(file);
+    }
+  }
+}
+
+function handleFIFO(file) {
+  common.unlinkSync(file);
+}
+
 //@
 //@ ### rm([options,] file [, file ...])
 //@ ### rm([options,] file_array)
@@ -115,9 +174,12 @@ function _rm(options, files) {
   files = [].slice.call(arguments, 1);
 
   files.forEach(function (file) {
-    var stats;
+    var lstats;
     try {
-      stats = fs.lstatSync(file); // test for existence
+      var filepath = (file[file.length - 1] === '/')
+        ? file.slice(0, -1) // remove the '/' so lstatSync can detect symlinks
+        : file;
+      lstats = fs.lstatSync(filepath); // test for existence
     } catch (e) {
       // Path does not exist, no force flag given
       if (!options.force) {
@@ -127,22 +189,14 @@ function _rm(options, files) {
     }
 
     // If here, path exists
-    if (stats.isFile()) {
-      if (options.force || isWriteable(file)) {
-        // -f was passed, or file is writable, so it can be removed
-        common.unlinkSync(file);
-      } else {
-        common.error('permission denied: ' + file, { continue: true });
-      }
-    } else if (stats.isDirectory()) {
-      if (options.recursive) {
-        // -r was passed, so directory can be removed
-        rmdirSyncRecursive(file, options.force);
-      } else {
-        common.error('path is a directory', { continue: true });
-      }
-    } else if (stats.isSymbolicLink() || stats.isFIFO()) {
-      common.unlinkSync(file);
+    if (lstats.isFile()) {
+      handleFile(file, options);
+    } else if (lstats.isDirectory()) {
+      handleDirectory(file, options);
+    } else if (lstats.isSymbolicLink()) {
+      handleSymbolicLink(file, options);
+    } else if (lstats.isFIFO()) {
+      handleFIFO(file);
     }
   }); // forEach(file)
   return '';

--- a/src/rm.js
+++ b/src/rm.js
@@ -1,6 +1,5 @@
 var common = require('./common');
 var fs = require('fs');
-var path = require('path');
 
 common.register('rm', _rm, {
   cmdOptions: {
@@ -131,11 +130,8 @@ function handleSymbolicLink(file, options) {
       // trailing separator, so remove the contents, not the link
       if (options.recursive) {
         // -r was passed, so directory can be removed
-        var link = file.slice(0, -1); // remove the '/' character for readlinkSync
-        var dir = fs.readlinkSync(link);
-        var dirpath = path.resolve(path.dirname(link), dir);
         var fromSymlink = true;
-        rmdirSyncRecursive(dirpath, options.force, fromSymlink);
+        rmdirSyncRecursive(file, options.force, fromSymlink);
       } else {
         common.error('path is a directory', { continue: true });
       }

--- a/src/rm.js
+++ b/src/rm.js
@@ -45,7 +45,7 @@ function rmdirSyncRecursive(dir, force, fromSymlink) {
   }
 
   // if was directory was referenced through a symbolic link,
-  // do not remove the directory itself
+  // the contents should be removed, but not the directory itself
   if (fromSymlink) return;
 
   // Now that we know everything in the sub-tree has been deleted, we can delete the main directory.
@@ -119,7 +119,7 @@ function handleSymbolicLink(file, options) {
   try {
     stats = fs.statSync(file);
   } catch (e) {
-    // symlink is bad, so just remove it
+    // symlink is broken, so remove the symlink itself
     common.unlinkSync(file);
     return;
   }

--- a/test/rm.js
+++ b/test/rm.js
@@ -150,7 +150,7 @@ test('recursive dir removal', t => {
   t.is(result.code, 0);
   const contents = fs.readdirSync(t.context.tmp);
   t.is(contents.length, 1);
-  t.is(contents[0], '.hidden'); // shouldn't remove hiddden if no .* given
+  t.is(contents[0], '.hidden'); // shouldn't remove hidden if no .* given
 });
 
 test('recursive dir removal #2', t => {

--- a/test/rm.js
+++ b/test/rm.js
@@ -267,8 +267,7 @@ test('remove symbolic link to a dir', t => {
   t.truthy(fs.existsSync(`${t.context.tmp}/rm/a_dir`));
 });
 
-// TODO(nfischer): fix this behavior in rm
-test.skip('rm -rf on a symbolic link to a dir deletes its contents', t => {
+test('rm -rf on a symbolic link to a dir deletes its contents', t => {
   const result = shell.rm('-rf', `${t.context.tmp}/rm/link_to_a_dir/`);
   t.falsy(shell.error());
   t.is(result.code, 0);

--- a/test/rm.js
+++ b/test/rm.js
@@ -268,14 +268,16 @@ test('remove symbolic link to a dir', t => {
 });
 
 test('rm -rf on a symbolic link to a dir deletes its contents', t => {
-  const result = shell.rm('-rf', `${t.context.tmp}/rm/link_to_a_dir/`);
-  t.falsy(shell.error());
-  t.is(result.code, 0);
+  if (process.platform !== 'win32') {
+    const result = shell.rm('-rf', `${t.context.tmp}/rm/link_to_a_dir/`);
+    t.falsy(shell.error());
+    t.is(result.code, 0);
 
-  // Both the link and original dir should remain, but contents are deleted
-  t.truthy(fs.existsSync(`${t.context.tmp}/rm/link_to_a_dir`));
-  t.truthy(fs.existsSync(`${t.context.tmp}/rm/a_dir`));
-  t.falsy(fs.existsSync(`${t.context.tmp}/rm/a_dir/a_file`));
+    // Both the link and original dir should remain, but contents are deleted
+    t.truthy(fs.existsSync(`${t.context.tmp}/rm/link_to_a_dir`));
+    t.truthy(fs.existsSync(`${t.context.tmp}/rm/a_dir`));
+    t.falsy(fs.existsSync(`${t.context.tmp}/rm/a_dir/a_file`));
+  }
 });
 
 test('remove broken symbolic link', t => {


### PR DESCRIPTION
Fix the behavior of `rm` such that:

1. `rm('-rf', 'link_to_dir/')` deletes contents of real dir, but keeps dir and symlink
2. `rm('-rf', 'link_to_dir')` deletes the symlink itself

Fixes #587 