### PR TITLE
fix(grep, sed, sort, uniq): Split only on newline characters

### DIFF
--- a/src/grep.js
+++ b/src/grep.js
@@ -47,12 +47,12 @@ function _grep(options, regex, files) {
     }
 
     var contents = file === '-' ? pipe : fs.readFileSync(file, 'utf8');
-    var lines = contents.split('\n');
     if (options.nameOnly) {
       if (contents.match(regex)) {
         grep.push(file);
       }
     } else {
+      var lines = contents.split('\n');
       lines.forEach(function (line) {
         var matched = line.match(regex);
         if ((options.inverse && !matched) || (!options.inverse && matched)) {

--- a/src/grep.js
+++ b/src/grep.js
@@ -47,7 +47,7 @@ function _grep(options, regex, files) {
     }
 
     var contents = file === '-' ? pipe : fs.readFileSync(file, 'utf8');
-    var lines = contents.split(/\r*\n/);
+    var lines = contents.split('\n');
     if (options.nameOnly) {
       if (contents.match(regex)) {
         grep.push(file);

--- a/src/sed.js
+++ b/src/sed.js
@@ -69,7 +69,7 @@ function _sed(options, regex, replacement, files) {
     }
 
     var contents = file === '-' ? pipe : fs.readFileSync(file, 'utf8');
-    var lines = contents.split(/\r*\n/);
+    var lines = contents.split('\n');
     var result = lines.map(function (line) {
       return line.replace(regex, replacement);
     }).join('\n');

--- a/src/sort.js
+++ b/src/sort.js
@@ -75,7 +75,7 @@ function _sort(options, files) {
     }
 
     var contents = file === '-' ? pipe : fs.readFileSync(file, 'utf8');
-    lines = lines.concat(contents.trimRight().split(/\r*\n/));
+    lines = lines.concat(contents.trimRight().split('\n'));
   });
 
   var sorted;

--- a/src/sort.js
+++ b/src/sort.js
@@ -67,19 +67,17 @@ function _sort(options, files) {
     files.unshift('-');
   }
 
-  var lines = [];
-  files.forEach(function (file) {
+  var lines = files.reduce(function (accum, file) {
     if (!fs.existsSync(file) && file !== '-') {
       // exit upon any sort of error
       common.error('no such file or directory: ' + file);
     }
 
     var contents = file === '-' ? pipe : fs.readFileSync(file, 'utf8');
-    lines = lines.concat(contents.trimRight().split('\n'));
-  });
+    return accum.concat(contents.trimRight().split('\n'));
+  }, []);
 
-  var sorted;
-  sorted = lines.sort(options.numerical ? numericalCmp : unixCmp);
+  var sorted = lines.sort(options.numerical ? numericalCmp : unixCmp);
 
   if (options.reverse) {
     sorted = sorted.reverse();

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -44,7 +44,7 @@ function _uniq(options, input, output) {
 
   var lines = (input ? fs.readFileSync(input, 'utf8') : pipe).
               trimRight().
-              split(/\r*\n/);
+              split('\n');
 
   var compare = function (a, b) {
     return options.ignoreCase ?


### PR DESCRIPTION
Splits and joins on newlines only.

Fixes #645 .