### PR TITLE
Echo test mocks

### DIFF
--- a/src/echo.js
+++ b/src/echo.js
@@ -33,9 +33,9 @@ function _echo(opts) {
   try {
     options = common.parseOptions(messages[0], {
       'e': 'escapes',
-      'n': 'no_newline'
+      'n': 'no_newline',
     }, {
-      silent: true
+      silent: true,
     });
 
     // Allow null to be echoed

--- a/test/echo.js
+++ b/test/echo.js
@@ -51,17 +51,6 @@ test("using null as an explicit argument doesn't crash the function", t => {
   t.is(stderr, '');
 });
 
-test.skip('simple test with silent(true)', t => {
-  // already using shell.config.silent = true
-  const result = shell.echo(555);
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
-  t.falsy(shell.error());
-  t.is(result.code, 0);
-  t.is(stdout, '555\n');
-  t.is(stderr, '');
-});
-
 test('-e option', t => {
   const result = shell.echo('-e', '\tmessage');
   const stdout = mocks.stdout();

--- a/test/echo.js
+++ b/test/echo.js
@@ -2,18 +2,18 @@ import test from 'ava';
 
 import shell from '..';
 import utils from './utils/utils';
-import mocks from './utils/mocks';
+import Mocks from './utils/mocks';
 
 shell.config.silent = true;
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  mocks.init();
+  t.context.mocks = new Mocks();
 });
 
 test.afterEach.always(t => {
   shell.rm('-rf', t.context.tmp);
-  mocks.restore();
+  t.context.mocks.restore();
 });
 
 //
@@ -22,8 +22,8 @@ test.afterEach.always(t => {
 
 test('simple test with defaults', t => {
   const result = shell.echo('hello', 'world');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'hello world\n');
@@ -33,8 +33,8 @@ test('simple test with defaults', t => {
 test('allow arguments to begin with a hyphen', t => {
   // see issue #20
   const result = shell.echo('-asdf', '111');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 1);
   t.is(stdout, '-asdf 111\n');
@@ -43,8 +43,8 @@ test('allow arguments to begin with a hyphen', t => {
 
 test("using null as an explicit argument doesn't crash the function", t => {
   const result = shell.echo(null);
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'null\n');
@@ -54,8 +54,8 @@ test("using null as an explicit argument doesn't crash the function", t => {
 test.skip('simple test with silent(true)', t => {
   // already using shell.config.silent = true
   const result = shell.echo(555);
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, '555\n');
@@ -64,8 +64,8 @@ test.skip('simple test with silent(true)', t => {
 
 test('-e option', t => {
   const result = shell.echo('-e', '\tmessage');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, '\tmessage\n');
@@ -83,8 +83,8 @@ test('piping to a file', t => {
   t.falsy(shell.error());
   t.is(resultB.code, 0);
   const result = shell.cat(tmp);
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(stdout, 'A\nB\n');
   t.is(stderr, '');
@@ -93,8 +93,8 @@ test('piping to a file', t => {
 
 test('-n option', t => {
   const result = shell.echo('-n', 'message');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'message');
@@ -103,8 +103,8 @@ test('-n option', t => {
 
 test('-ne option', t => {
   const result = shell.echo('-ne', 'message');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'message');
@@ -113,8 +113,8 @@ test('-ne option', t => {
 
 test('-en option', t => {
   const result = shell.echo('-en', 'message');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'message');
@@ -123,8 +123,8 @@ test('-en option', t => {
 
 test('-en option with escaped characters', t => {
   const result = shell.echo('-en', '\tmessage\n');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, '\tmessage\n');
@@ -142,8 +142,8 @@ test('piping to a file with -n', t => {
   t.falsy(shell.error());
   t.is(resultB.code, 0);
   const result = shell.cat(tmp);
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(stdout, 'AB');
   t.is(stderr, '');
@@ -152,8 +152,8 @@ test('piping to a file with -n', t => {
 
 test('stderr with unrecognized options is empty', t => {
   const result = shell.echo('-asdf');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = t.context.mocks.stdout();
+  const stderr = t.context.mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 1);
   t.falsy(result.stderr);

--- a/test/echo.js
+++ b/test/echo.js
@@ -2,18 +2,18 @@ import test from 'ava';
 
 import shell from '..';
 import utils from './utils/utils';
-import Mocks from './utils/mocks';
+import mocks from './utils/mocks';
 
 shell.config.silent = true;
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  t.context.mocks = new Mocks();
+  mocks.init();
 });
 
 test.afterEach.always(t => {
   shell.rm('-rf', t.context.tmp);
-  t.context.mocks.restore();
+  mocks.restore();
 });
 
 //
@@ -22,8 +22,8 @@ test.afterEach.always(t => {
 
 test('simple test with defaults', t => {
   const result = shell.echo('hello', 'world');
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'hello world\n');
@@ -33,8 +33,8 @@ test('simple test with defaults', t => {
 test('allow arguments to begin with a hyphen', t => {
   // see issue #20
   const result = shell.echo('-asdf', '111');
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 1);
   t.is(stdout, '-asdf 111\n');
@@ -43,8 +43,8 @@ test('allow arguments to begin with a hyphen', t => {
 
 test("using null as an explicit argument doesn't crash the function", t => {
   const result = shell.echo(null);
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'null\n');
@@ -54,8 +54,8 @@ test("using null as an explicit argument doesn't crash the function", t => {
 test.skip('simple test with silent(true)', t => {
   // already using shell.config.silent = true
   const result = shell.echo(555);
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, '555\n');
@@ -64,8 +64,8 @@ test.skip('simple test with silent(true)', t => {
 
 test('-e option', t => {
   const result = shell.echo('-e', '\tmessage');
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, '\tmessage\n');
@@ -83,8 +83,8 @@ test('piping to a file', t => {
   t.falsy(shell.error());
   t.is(resultB.code, 0);
   const result = shell.cat(tmp);
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(stdout, 'A\nB\n');
   t.is(stderr, '');
@@ -93,8 +93,8 @@ test('piping to a file', t => {
 
 test('-n option', t => {
   const result = shell.echo('-n', 'message');
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'message');
@@ -103,8 +103,8 @@ test('-n option', t => {
 
 test('-ne option', t => {
   const result = shell.echo('-ne', 'message');
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'message');
@@ -113,8 +113,8 @@ test('-ne option', t => {
 
 test('-en option', t => {
   const result = shell.echo('-en', 'message');
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'message');
@@ -123,8 +123,8 @@ test('-en option', t => {
 
 test('-en option with escaped characters', t => {
   const result = shell.echo('-en', '\tmessage\n');
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, '\tmessage\n');
@@ -142,8 +142,8 @@ test('piping to a file with -n', t => {
   t.falsy(shell.error());
   t.is(resultB.code, 0);
   const result = shell.cat(tmp);
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(stdout, 'AB');
   t.is(stderr, '');
@@ -152,8 +152,8 @@ test('piping to a file with -n', t => {
 
 test('stderr with unrecognized options is empty', t => {
   const result = shell.echo('-asdf');
-  const stdout = t.context.mocks.stdout();
-  const stderr = t.context.mocks.stderr();
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
   t.falsy(shell.error());
   t.is(result.code, 1);
   t.falsy(result.stderr);

--- a/test/echo.js
+++ b/test/echo.js
@@ -2,137 +2,161 @@ import test from 'ava';
 
 import shell from '..';
 import utils from './utils/utils';
+import mocks from './utils/mocks';
 
 shell.config.silent = true;
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
+  mocks.init();
 });
 
 test.afterEach.always(t => {
   shell.rm('-rf', t.context.tmp);
+  mocks.restore();
 });
 
 //
 // Valids
 //
 
-test.cb('simple test with defaults', t => {
-  const script = 'require(\'../global.js\'); echo("hello", "world");';
-  utils.runScript(script, (err, stdout, stderr) => {
-    t.falsy(err);
-    t.is(stdout, 'hello world\n');
-    t.is(stderr, '');
-    t.end();
-  });
+test('simple test with defaults', t => {
+  const result = shell.echo('hello', 'world');
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(stdout, 'hello world\n');
+  t.is(stderr, '');
 });
 
-test.cb('allow arguments to begin with a hyphen', t => {
+test('allow arguments to begin with a hyphen', t => {
   // see issue #20
-  const script = 'require(\'../global.js\'); echo("-asdf", "111");';
-  utils.runScript(script, (err, stdout, stderr) => {
-    t.falsy(err);
-    t.is(stdout, '-asdf 111\n');
-    t.is(stderr, '');
-    t.end();
-  });
+  const result = shell.echo('-asdf', '111');
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(result.code, 1);
+  t.is(stdout, '-asdf 111\n');
+  t.is(stderr, '');
 });
 
-test.cb("using null as an explicit argument doesn't crash the function", t => {
-  const script = 'require(\'../global.js\'); echo(null);';
-  utils.runScript(script, (err, stdout, stderr) => {
-    t.falsy(err);
-    t.is(stdout, 'null\n');
-    t.is(stderr, '');
-    t.end();
-  });
+test("using null as an explicit argument doesn't crash the function", t => {
+  const result = shell.echo(null);
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(stdout, 'null\n');
+  t.is(stderr, '');
 });
 
-test.cb('simple test with silent(true)', t => {
-  const script = 'require(\'../global.js\'); config.silent=true; echo(555);';
-  utils.runScript(script, (err, stdout) => {
-    t.falsy(err);
-    t.is(stdout, '555\n');
-    t.end();
-  });
+test.skip('simple test with silent(true)', t => {
+  // already using shell.config.silent = true
+  const result = shell.echo(555);
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(stdout, '555\n');
+  t.is(stderr, '');
 });
 
-test.cb('-e option', t => {
-  const script = "require('../global.js'); echo('-e', '\\tmessage');";
-  utils.runScript(script, (err, stdout) => {
-    t.falsy(err);
-    t.is(stdout, '\tmessage\n');
-    t.end();
-  });
+test('-e option', t => {
+  const result = shell.echo('-e', '\tmessage');
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(stdout, '\tmessage\n');
+  t.is(stderr, '');
 });
 
-test.cb('piping to a file', t => {
+test('piping to a file', t => {
   // see issue #476
   shell.mkdir(t.context.tmp);
   const tmp = `${t.context.tmp}/echo.txt`;
-  const script = `require('../global.js'); echo('A').toEnd('${tmp}'); echo('B').toEnd('${tmp}');`;
-  utils.runScript(script, (err, stdout) => {
-    const result = shell.cat(tmp);
-    t.falsy(err);
-    t.is(stdout, 'A\nB\n');
-    t.is(result.toString(), 'A\nB\n');
-    t.end();
-  });
+  const resultA = shell.echo('A').toEnd(tmp);
+  t.falsy(shell.error());
+  t.is(resultA.code, 0);
+  const resultB = shell.echo('B').toEnd(tmp);
+  t.falsy(shell.error());
+  t.is(resultB.code, 0);
+  const result = shell.cat(tmp);
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(stdout, 'A\nB\n');
+  t.is(stderr, '');
+  t.is(result.toString(), 'A\nB\n');
 });
 
-test.cb('-n option', t => {
-  const script = "require('../global.js'); echo('-n', 'message');";
-  utils.runScript(script, (err, stdout) => {
-    t.falsy(err);
-    t.is(stdout, 'message');
-    t.end();
-  });
+test('-n option', t => {
+  const result = shell.echo('-n', 'message');
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(stdout, 'message');
+  t.is(stderr, '');
 });
 
-test.cb('-ne option', t => {
-  const script = "require('../global.js'); echo('-ne', 'message');";
-  utils.runScript(script, (err, stdout) => {
-    t.falsy(err);
-    t.is(stdout, 'message');
-    t.end();
-  });
+test('-ne option', t => {
+  const result = shell.echo('-ne', 'message');
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(stdout, 'message');
+  t.is(stderr, '');
 });
 
-test.cb('-en option', t => {
-  const script = "require('../global.js'); echo('-en', 'message');";
-  utils.runScript(script, (err, stdout) => {
-    t.falsy(err);
-    t.is(stdout, 'message');
-    t.end();
-  });
+test('-en option', t => {
+  const result = shell.echo('-en', 'message');
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(stdout, 'message');
+  t.is(stderr, '');
 });
 
-test.cb('-en option with escaped characters', t => {
-  const script = "require('../global.js'); echo('-en', '\\tmessage\\n');";
-  utils.runScript(script, (err, stdout) => {
-    t.falsy(err);
-    t.is(stdout, '\tmessage\n');
-    t.end();
-  });
+test('-en option with escaped characters', t => {
+  const result = shell.echo('-en', '\tmessage\n');
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(stdout, '\tmessage\n');
+  t.is(stderr, '');
 });
 
-test.cb('piping to a file with -n', t => {
+test('piping to a file with -n', t => {
   // see issue #476
   shell.mkdir(t.context.tmp);
   const tmp = `${t.context.tmp}/echo.txt`;
-  const script = `require('../global.js'); echo('-n', 'A').toEnd('${tmp}'); echo('-n', 'B').toEnd('${tmp}');`;
-  utils.runScript(script, (err, stdout) => {
-    const result = shell.cat(tmp);
-    t.falsy(err);
-    t.is(stdout, 'AB');
-    t.is(result.toString(), 'AB');
-    t.end();
-  });
+  const resultA = shell.echo('-n', 'A').toEnd(tmp);
+  t.falsy(shell.error());
+  t.is(resultA.code, 0);
+  const resultB = shell.echo('-n', 'B').toEnd(tmp);
+  t.falsy(shell.error());
+  t.is(resultB.code, 0);
+  const result = shell.cat(tmp);
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(stdout, 'AB');
+  t.is(stderr, '');
+  t.is(result.toString(), 'AB');
 });
 
 test('stderr with unrecognized options is empty', t => {
-  // TODO: console output here needs to be muted
   const result = shell.echo('-asdf');
+  const stdout = mocks.stdout();
+  const stderr = mocks.stderr();
+  t.falsy(shell.error());
+  t.is(result.code, 1);
   t.falsy(result.stderr);
-  t.is(result.stdout, '-asdf\n');
+  t.is(stdout, '-asdf\n');
+  t.is(stderr, '');
 });

--- a/test/utils/mocks.js
+++ b/test/utils/mocks.js
@@ -1,8 +1,3 @@
-const _processStdoutWrite = process.stdout.write;
-const _processStderrWrite = process.stderr.write;
-const _stdout = [];
-const _stderr = [];
-
 function addToString(str, val) {
   if (Buffer.isBuffer(val)) {
     return str + val.toString();
@@ -21,6 +16,13 @@ function wrapWrite(target) {
   };
 }
 
+const _processStdoutWrite = process.stdout.write;
+const _processStderrWrite = process.stderr.write;
+const _stdout = [];
+const _stderr = [];
+const _stdoutWrite = wrapWrite(_stdout);
+const _stderrWrite = wrapWrite(_stderr);
+
 exports.stdout = function stdout() {
   return joinData(_stdout);
 };
@@ -30,8 +32,8 @@ exports.stderr = function stderr() {
 };
 
 exports.init = function init() {
-  process.stdout.write = wrapWrite(_stdout);
-  process.stderr.write = wrapWrite(_stderr);
+  process.stdout.write = _stdoutWrite;
+  process.stderr.write = _stderrWrite;
 };
 
 exports.restore = function restore() {

--- a/test/utils/mocks.js
+++ b/test/utils/mocks.js
@@ -1,0 +1,72 @@
+/* eslint-disable prefer-rest-params */
+
+let stdoutValue = '';
+let stderrValue = '';
+let stdinValue = null;
+
+const oldConsoleLog = console.log;
+const oldConsoleError = console.error;
+const oldStdoutWrite = process.stdout.write;
+const oldProcessExit = process.exit;
+
+function consoleLog() {                // mock console.log
+  const msgs = [].slice.call(arguments);
+  stdoutValue += msgs.join(' ') + '\n';
+}
+
+function consoleError() {              // mock console.error
+  const msgs = [].slice.call(arguments);
+  stderrValue += msgs.join(' ') + '\n';
+}
+
+function stdoutWrite(msg) {            // mock process.stdout.write
+  stdoutValue += msg;
+  return true;
+}
+
+function processExit(retCode) {        // mock process.exit
+  const e = new Error('process.exit was called');
+  e.code = retCode || 0;
+  throw e;
+}
+
+function resetValues() {
+  stdoutValue = '';
+  stderrValue = '';
+}
+
+function stdout() {
+  return stdoutValue;
+}
+exports.stdout = stdout;
+
+function stderr() {
+  return stderrValue;
+}
+exports.stderr = stderr;
+
+function stdin(val) {
+  // If called with no arg, return the mocked stdin. Otherwise set stdin to that
+  // arg
+  if (val === undefined) return stdinValue;
+  stdinValue = val;
+  return null;
+}
+exports.stdin = stdin;
+
+function init() {
+  resetValues();
+  console.log = consoleLog;
+  console.error = consoleError;
+  process.stdout.write = stdoutWrite;
+  process.exit = processExit;
+}
+exports.init = init;
+
+function restore() {
+  console.log = oldConsoleLog;
+  console.error = oldConsoleError;
+  process.stdout.write = oldStdoutWrite;
+  process.exit = oldProcessExit;
+}
+exports.restore = restore;

--- a/test/utils/mocks.js
+++ b/test/utils/mocks.js
@@ -1,4 +1,5 @@
-/* eslint-disable prefer-rest-params */
+/* eslint-disable prefer-rest-params, strict */
+'use strict';
 
 let stdoutValue = '';
 let stderrValue = '';


### PR DESCRIPTION
Fixes #622 

Adds mocks for `process.stdout.write` and `process.stderr.write` that allows the written values to be extracted. This way, we can inspect the output of `echo` without actually outputting to stdout.