### PR TITLE
Properly handle directories as arguments

### DIFF
--- a/src/cat.js
+++ b/src/cat.js
@@ -30,6 +30,8 @@ function _cat(options, files) {
   files.forEach(function (file) {
     if (!fs.existsSync(file)) {
       common.error('no such file or directory: ' + file);
+    } else if (fs.statSync(file).isDirectory()) {
+      common.error(file + ': Is a directory');
     }
 
     cat += fs.readFileSync(file, 'utf8');

--- a/src/head.js
+++ b/src/head.js
@@ -75,6 +75,11 @@ function _head(options, files) {
     if (!fs.existsSync(file) && file !== '-') {
       common.error('no such file or directory: ' + file, { continue: true });
       return;
+    } else if (fs.statSync(file).isDirectory()) {
+      common.error("error reading '" + file + "': Is a directory", {
+        continue: true,
+      });
+      return;
     }
 
     var contents;

--- a/src/head.js
+++ b/src/head.js
@@ -72,14 +72,16 @@ function _head(options, files) {
 
   var shouldAppendNewline = false;
   files.forEach(function (file) {
-    if (!fs.existsSync(file) && file !== '-') {
-      common.error('no such file or directory: ' + file, { continue: true });
-      return;
-    } else if (fs.statSync(file).isDirectory()) {
-      common.error("error reading '" + file + "': Is a directory", {
-        continue: true,
-      });
-      return;
+    if (file !== '-') {
+      if (!fs.existsSync(file)) {
+        common.error('no such file or directory: ' + file, { continue: true });
+        return;
+      } else if (fs.statSync(file).isDirectory()) {
+        common.error("error reading '" + file + "': Is a directory", {
+          continue: true,
+        });
+        return;
+      }
     }
 
     var contents;

--- a/src/sort.js
+++ b/src/sort.js
@@ -72,6 +72,11 @@ function _sort(options, files) {
     if (!fs.existsSync(file) && file !== '-') {
       // exit upon any sort of error
       common.error('no such file or directory: ' + file);
+    } else if (fs.statSync(file).isDirectory()) {
+      common.error('read failed: ' + file + ': Is a directory', {
+        continue: true,
+      });
+      return;
     }
 
     var contents = file === '-' ? pipe : fs.readFileSync(file, 'utf8');

--- a/src/sort.js
+++ b/src/sort.js
@@ -69,14 +69,16 @@ function _sort(options, files) {
 
   var lines = [];
   files.forEach(function (file) {
-    if (!fs.existsSync(file) && file !== '-') {
-      // exit upon any sort of error
-      common.error('no such file or directory: ' + file);
-    } else if (fs.statSync(file).isDirectory()) {
-      common.error('read failed: ' + file + ': Is a directory', {
-        continue: true,
-      });
-      return;
+    if (file !== '-') {
+      if (!fs.existsSync(file)) {
+        common.error('no such file or directory: ' + file, { continue: true });
+        return;
+      } else if (fs.statSync(file).isDirectory()) {
+        common.error('read failed: ' + file + ': Is a directory', {
+          continue: true,
+        });
+        return;
+      }
     }
 
     var contents = file === '-' ? pipe : fs.readFileSync(file, 'utf8');

--- a/src/tail.js
+++ b/src/tail.js
@@ -49,6 +49,11 @@ function _tail(options, files) {
     if (!fs.existsSync(file) && file !== '-') {
       common.error('no such file or directory: ' + file, { continue: true });
       return;
+    } else if (fs.statSync(file).isDirectory()) {
+      common.error("error reading '" + file + "': Is a directory", {
+        continue: true,
+      });
+      return;
     }
 
     var contents = file === '-' ? pipe : fs.readFileSync(file, 'utf8');

--- a/src/tail.js
+++ b/src/tail.js
@@ -46,14 +46,16 @@ function _tail(options, files) {
 
   var shouldAppendNewline = false;
   files.forEach(function (file) {
-    if (!fs.existsSync(file) && file !== '-') {
-      common.error('no such file or directory: ' + file, { continue: true });
-      return;
-    } else if (fs.statSync(file).isDirectory()) {
-      common.error("error reading '" + file + "': Is a directory", {
-        continue: true,
-      });
-      return;
+    if (file !== '-') {
+      if (!fs.existsSync(file)) {
+        common.error('no such file or directory: ' + file, { continue: true });
+        return;
+      } else if (fs.statSync(file).isDirectory()) {
+        common.error("error reading '" + file + "': Is a directory", {
+          continue: true,
+        });
+        return;
+      }
     }
 
     var contents = file === '-' ? pipe : fs.readFileSync(file, 'utf8');

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -40,7 +40,18 @@ function _uniq(options, input, output) {
   // Check if this is coming from a pipe
   var pipe = common.readFromPipe();
 
-  if (!input && !pipe) common.error('no input given');
+  if (!pipe) {
+    if (!input) common.error('no input given');
+
+    if (!fs.existsSync(input)) {
+      common.error(input + ': No such file or directory');
+    } else if (fs.statSync(input).isDirectory()) {
+      common.error("error reading '" + input + "'");
+    }
+  }
+  if (output && fs.existsSync(output) && fs.statSync(output).isDirectory()) {
+    common.error(output + ': Is a directory');
+  }
 
   var lines = (input ? fs.readFileSync(input, 'utf8') : pipe).
               trimRight().

--- a/test/cat.js
+++ b/test/cat.js
@@ -25,6 +25,13 @@ test('nonexistent file', t => {
   t.is(result.stderr, 'cat: no such file or directory: /asdfasdf');
 });
 
+test('directory', t => {
+  const result = shell.cat('resources/cat');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, 'cat: resources/cat: Is a directory');
+});
+
 //
 // Valids
 //

--- a/test/head.js
+++ b/test/head.js
@@ -18,9 +18,18 @@ test('no args', t => {
 
 test('file does not exist', t => {
   t.falsy(fs.existsSync('/asdfasdf')); // sanity check
-  const result = shell.head('/adsfasdf'); // file does not exist
+  const result = shell.head('/asdfasdf'); // file does not exist
   t.truthy(shell.error());
   t.is(result.code, 1);
+  t.is(result.stderr, 'head: no such file or directory: /asdfasdf');
+});
+
+test('directory', t => {
+  t.truthy(fs.statSync('resources/').isDirectory()); // sanity check
+  const result = shell.head('resources/');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, "head: error reading 'resources/': Is a directory");
 });
 
 //

--- a/test/sort.js
+++ b/test/sort.js
@@ -25,9 +25,17 @@ test('no args', t => {
 
 test('file does not exist', t => {
   t.falsy(fs.existsSync('/asdfasdf')); // sanity check
-  const result = shell.sort('/adsfasdf');
+  const result = shell.sort('/asdfasdf');
   t.truthy(shell.error());
   t.truthy(result.code);
+});
+
+test('directory', t => {
+  t.truthy(fs.statSync('resources/').isDirectory()); // sanity check
+  const result = shell.sort('resources/');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, 'sort: read failed: resources/: Is a directory');
 });
 
 //

--- a/test/tail.js
+++ b/test/tail.js
@@ -18,9 +18,17 @@ test('no args', t => {
 
 test('file does not exist', t => {
   t.falsy(fs.existsSync('/asdfasdf')); // sanity check
-  const result = shell.tail('/adsfasdf');
+  const result = shell.tail('/asdfasdf');
   t.truthy(shell.error());
   t.is(result.code, 1);
+});
+
+test('directory', t => {
+  t.truthy(fs.statSync('resources/').isDirectory()); // sanity check
+  const result = shell.tail('resources/');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, "tail: error reading 'resources/': Is a directory");
 });
 
 //

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -18,9 +18,32 @@ test('no args', t => {
 
 test('file does not exist', t => {
   t.falsy(fs.existsSync('/asdfasdf')); // sanity check
-  const result = shell.sort('/adsfasdf');
+  const result = shell.uniq('/asdfasdf');
   t.truthy(shell.error());
   t.truthy(result.code);
+});
+
+test('directory', t => {
+  t.truthy(fs.statSync('resources/').isDirectory()); // sanity check
+  const result = shell.uniq('resources/');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, "uniq: error reading 'resources/'");
+});
+
+test('output directory', t => {
+  t.truthy(fs.statSync('resources/').isDirectory()); // sanity check
+  const result = shell.uniq('resources/file1.txt', 'resources/');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, 'uniq: resources/: Is a directory');
+});
+
+test('file does not exist with output directory', t => {
+  t.falsy(fs.existsSync('/asdfasdf')); // sanity check
+  const result = shell.uniq('/asdfasdf', 'resources/');
+  t.is(result.code, 1);
+  t.truthy(shell.error());
 });
 
 //


### PR DESCRIPTION
We previously did not handle directories very well for many of our commands (would immediately error out). This fixes that.

 * `cat()`: did not handle directories as inputs, now it gracefully errors
 * `head()`: same thing. It also had a typo in a test.
 * `sort()`: same thing. It had the same typo.
 * `tail()`: same bug, and same typo.
 * `uniq()`: did not handle directories as inputs. Did not handle directories as outputs. Did not handle non-existent inputs (this slipped through because of a test typo). All are treated as errors.

Fixes #707 