### PR TITLE
fix(mkdir): improve error handling around files

### DIFF
--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -57,9 +57,11 @@ function _mkdir(options, dirs) {
 
   dirs.forEach(function (dir) {
     try {
-      fs.lstatSync(dir);
+      var stat = fs.lstatSync(dir);
       if (!options.fullpath) {
         common.error('path already exists: ' + dir, { continue: true });
+      } else if (stat.isFile()) {
+        common.error('cannot create directory ' + dir + ': File exists', { continue: true });
       }
       return; // skip dir
     } catch (e) {
@@ -80,12 +82,16 @@ function _mkdir(options, dirs) {
         fs.mkdirSync(dir, parseInt('0777', 8));
       }
     } catch (e) {
+      var reason;
       if (e.code === 'EACCES') {
-        common.error('cannot create directory ' + dir + ': Permission denied');
+        reason = 'Permission denied';
+      } else if (e.code === 'ENOTDIR') {
+        reason = 'Not a directory';
       } else {
         /* istanbul ignore next */
         throw e;
       }
+      common.error('cannot create directory ' + dir + ': ' + reason, { continue: true });
     }
   });
   return '';

--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -85,7 +85,7 @@ function _mkdir(options, dirs) {
       var reason;
       if (e.code === 'EACCES') {
         reason = 'Permission denied';
-      } else if (e.code === 'ENOTDIR') {
+      } else if (e.code === 'ENOTDIR' || e.code === 'ENOENT') {
         reason = 'Not a directory';
       } else {
         /* istanbul ignore next */

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -55,6 +55,34 @@ test('root path does not exist', t => {
   t.falsy(fs.existsSync('/asdfasdf/foobar'));
 });
 
+test('try to overwrite file', t => {
+  t.truthy(fs.statSync('resources/file1').isFile());
+  const result = shell.mkdir('resources/file1');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, 'mkdir: path already exists: resources/file1');
+  t.truthy(fs.statSync('resources/file1').isFile());
+});
+
+test('try to overwrite file, with -p', t => {
+  t.truthy(fs.statSync('resources/file1').isFile());
+  const result = shell.mkdir('-p', 'resources/file1');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, 'mkdir: cannot create directory resources/file1: File exists');
+  t.truthy(fs.statSync('resources/file1').isFile());
+});
+
+test('try to make a subdirectory of a file', t => {
+  t.truthy(fs.statSync('resources/file1').isFile());
+  const result = shell.mkdir('resources/file1/subdir');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stderr, 'mkdir: cannot create directory resources/file1/subdir: Not a directory');
+  t.truthy(fs.statSync('resources/file1').isFile());
+  t.falsy(fs.existsSync('resources/file1/subdir'));
+});
+
 test('Check for invalid permissions', t => {
   if (process.platform !== 'win32') {
     // This test case only works on unix, but should work on Windows as well


### PR DESCRIPTION
In particular, this fixes:

 - if we try to overwrite a file with a mkdir
 - if we try to create a subdirectory of a file
 - adds `continue: true` in spots where we missed it

Fixes #720