### PR TITLE
Deprecate common.getUserHome, advise using os.homedir instead

### DIFF
--- a/src/cd.js
+++ b/src/cd.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var os = require('os');
 var common = require('./common');
 
 common.register('cd', _cd, {});
@@ -8,7 +9,7 @@ common.register('cd', _cd, {});
 //@ Changes to directory `dir` for the duration of the script. Changes to home
 //@ directory if no argument is supplied.
 function _cd(options, dir) {
-  if (!dir) dir = common.getUserHome();
+  if (!dir) dir = os.homedir();
 
   if (dir === '-') {
     if (!process.env.OLDPWD) {

--- a/src/common.js
+++ b/src/common.js
@@ -4,7 +4,6 @@
 
 var os = require('os');
 var fs = require('fs');
-var util = require('util');
 var glob = require('glob');
 var shell = require('..');
 
@@ -157,24 +156,6 @@ function ShellString(stdout, stderr, code) {
 }
 
 exports.ShellString = ShellString;
-
-// DEPRECATED: Use os.homedir instead
-//
-// Return the home directory in a platform-agnostic way, with consideration for
-// older versions of node
-function getUserHome() {
-  var result;
-  if (os.homedir) {
-    result = os.homedir(); // node 3+
-  } else {
-    result = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
-  }
-  return result;
-}
-exports.getUserHome = util.deprecate(
-  getUserHome,
-  'shelljs.common.getUserHome: Use os.homedir instead'
-);
 
 // Returns {'alice': true, 'bob': false} when passed a string and dictionary as follows:
 //   parseOptions('-a', {'a':'alice', 'b':'bob'});

--- a/src/common.js
+++ b/src/common.js
@@ -4,6 +4,7 @@
 
 var os = require('os');
 var fs = require('fs');
+var util = require('util');
 var glob = require('glob');
 var shell = require('..');
 
@@ -157,6 +158,8 @@ function ShellString(stdout, stderr, code) {
 
 exports.ShellString = ShellString;
 
+// DEPRECATED: Use os.homedir instead
+//
 // Return the home directory in a platform-agnostic way, with consideration for
 // older versions of node
 function getUserHome() {
@@ -168,7 +171,10 @@ function getUserHome() {
   }
   return result;
 }
-exports.getUserHome = getUserHome;
+exports.getUserHome = util.deprecate(
+  getUserHome,
+  'shelljs.common.getUserHome: Use os.homedir instead'
+);
 
 // Returns {'alice': true, 'bob': false} when passed a string and dictionary as follows:
 //   parseOptions('-a', {'a':'alice', 'b':'bob'});
@@ -347,7 +353,7 @@ function wrap(cmd, fn, options) {
         });
 
         // Expand the '~' if appropriate
-        var homeDir = getUserHome();
+        var homeDir = os.homedir();
         args = args.map(function (arg) {
           if (typeof arg === 'string' && arg.slice(0, 2) === '~/' || arg === '~') {
             return arg.replace(/^~/, homeDir);

--- a/test/cd.js
+++ b/test/cd.js
@@ -1,10 +1,10 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import test from 'ava';
 
 import shell from '..';
-import common from '../src/common';
 import utils from './utils/utils';
 
 const cur = shell.pwd().toString();
@@ -90,16 +90,16 @@ test('cd + other commands', t => {
 
 test('Tilde expansion', t => {
   shell.cd('~');
-  t.is(process.cwd(), common.getUserHome());
+  t.is(process.cwd(), os.homedir());
   shell.cd('..');
-  t.not(process.cwd(), common.getUserHome());
+  t.not(process.cwd(), os.homedir());
   shell.cd('~'); // Change back to home
-  t.is(process.cwd(), common.getUserHome());
+  t.is(process.cwd(), os.homedir());
 });
 
 test('Goes to home directory if no arguments are passed', t => {
   const result = shell.cd();
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(process.cwd(), common.getUserHome());
+  t.is(process.cwd(), os.homedir());
 });


### PR DESCRIPTION
Deprecates `common.getUserHome` and provides a warning about the deprecation. Also replaces all of the internal uses of `common.getUserHome` with `os.homedir`.

Fixes #683 