### PR TITLE
Copying fifos hangs.

### DIFF
--- a/src/cp.js
+++ b/src/cp.js
@@ -34,7 +34,9 @@ function copyFileSync(srcFile, destFile, options) {
     // If we're here, destFile probably doesn't exist, so just do a normal copy
   }
 
-  if (fs.lstatSync(srcFile).isSymbolicLink() && !options.followsymlink) {
+  var srcFileStat = fs.lstatSync(srcFile);
+
+  if (srcFileStat.isSymbolicLink() && !options.followsymlink) {
     try {
       fs.lstatSync(destFile);
       common.unlinkSync(destFile); // re-link it
@@ -44,7 +46,7 @@ function copyFileSync(srcFile, destFile, options) {
 
     var symlinkFull = fs.readlinkSync(srcFile);
     fs.symlinkSync(symlinkFull, destFile, isWindows ? 'junction' : null);
-  } else {
+  } else if (srcFileStat.isSymbolicLink() || srcFileStat.isFile() || srcFileStat.isCharacterDevice() || srcFileStat.isBlockDevice()) {
     var buf = common.buffer();
     var bufLength = buf.length;
     var bytesRead = bufLength;
@@ -76,6 +78,8 @@ function copyFileSync(srcFile, destFile, options) {
     fs.closeSync(fdw);
 
     fs.chmodSync(destFile, fs.statSync(srcFile).mode);
+  } else {
+    common.log('copyFileSync: skipping non-file (' + srcFile + ')');
   }
 }
 

--- a/src/cp.js
+++ b/src/cp.js
@@ -46,7 +46,9 @@ function copyFileSync(srcFile, destFile, options) {
 
     var symlinkFull = fs.readlinkSync(srcFile);
     fs.symlinkSync(symlinkFull, destFile, isWindows ? 'junction' : null);
-  } else if (srcFileStat.isSymbolicLink() || srcFileStat.isFile() || srcFileStat.isCharacterDevice() || srcFileStat.isBlockDevice()) {
+  } else if (srcFileStat.isSymbolicLink()) {
+    copyFileSync(fs.realpathSync(srcFile), destFile);
+  } else if (srcFileStat.isFile() || srcFileStat.isCharacterDevice() || srcFileStat.isBlockDevice()) {
     var buf = common.buffer();
     var bufLength = buf.length;
     var bytesRead = bufLength;

--- a/test/cp.js
+++ b/test/cp.js
@@ -755,3 +755,20 @@ test('should not overwrite recently created files (not give error no-force mode)
   // Ensure First file is copied
   t.is(shell.cat(`${t.context.tmp}/file1`).toString(), 'test1');
 });
+
+test('should not attempt to copy fifos', t => {
+  shell.mkdir(`${t.context.tmp}/dir`);
+  try {
+    shell.exec(`mkfifo ${t.context.tmp}/dir/fifo`);
+  } catch (e) {
+    console.warn('Exception trying to create fifo. Skipping fifo copy test.');
+    return;
+  }
+  shell.cp('resources/file1', `${t.context.tmp}/dir`);
+  t.truthy(fs.existsSync(`${t.context.tmp}/dir/fifo`));
+  const result = shell.cp('-r', `${t.context.tmp}/dir`, `${t.context.tmp}/cp`);
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(shell.cat(`${t.context.tmp}/cp/file1`).toString(), 'test1');
+  t.falsy(fs.existsSync(`${t.context.tmp}/cp/fifo`));
+});


### PR DESCRIPTION
shelljs' `cp` will hang if trying to copy a fifo.

This PR skips copying more non-file-like entities to avoid this issue.

I can't quite decide whether this fix is going to work for a symlink pointing to a fifo? :-s