### PR TITLE
test(head): improve coverage

### DIFF
--- a/src/head.js
+++ b/src/head.js
@@ -8,20 +8,14 @@ common.register('head', _head, {
   },
 });
 
-// This reads n or more lines, or the entire file, whichever is less.
+// Reads |numLines| lines or the entire file, whichever is less.
 function readSomeLines(file, numLines) {
   var buf = common.buffer();
   var bufLength = buf.length;
   var bytesRead = bufLength;
   var pos = 0;
-  var fdr = null;
 
-  try {
-    fdr = fs.openSync(file, 'r');
-  } catch (e) {
-    common.error('cannot read file: ' + file);
-  }
-
+  var fdr = fs.openSync(file, 'r');
   var numLinesRead = 0;
   var ret = '';
   while (bytesRead === bufLength && numLinesRead < numLines) {
@@ -35,6 +29,7 @@ function readSomeLines(file, numLines) {
   fs.closeSync(fdr);
   return ret;
 }
+
 //@
 //@ ### head([{'-n': \<num\>},] file [, file ...])
 //@ ### head([{'-n': \<num\>},] file_array)

--- a/test/head.js
+++ b/test/head.js
@@ -127,3 +127,10 @@ test('negative values (-num) are the same as (numLines - num)', t => {
   t.is(result.code, 0);
   t.is(result.toString(), 'file1 1\nfile1 2\nfile1 3\nfile1 4\n');
 });
+
+test('right-hand side of a pipe', t => {
+  const result = shell.cat('resources/head/file1.txt').head();
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.toString(), topOfFile1.slice(0, 10).join('\n') + '\n');
+});


### PR DESCRIPTION
This adds a test for `head()` on the right-hand side of a pipe. This also
removes the try-catch surrounding `fs.openSync()`, because it was unreachable
code. `fs.existsSync()` guarantees that the file exists, and `fs.openSync()`
only throws if the file does not exist, according to official documentation.

I see 100% line coverage for `src/head.js` when running:

```sh
$ nyc --reporter=text --reporter=lcov ava --serial test/head.js`
```

Fixes #741