### PR TITLE
test(exec): add tests for coverage

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -78,6 +78,7 @@ function execSync(cmd, opts, pipe) {
 
   fs.writeFileSync(scriptFile, script);
 
+  /* istanbul ignore else */
   if (opts.silent) {
     opts.stdio = 'ignore';
   } else {
@@ -137,6 +138,7 @@ function execAsync(cmd, opts, pipe, callback) {
         callback(0, stdout, stderr);
       } else if (err.code === undefined) {
         // See issue #536
+        /* istanbul ignore next */
         callback(1, stdout, stderr);
       } else {
         callback(err.code, stdout, stderr);

--- a/test/exec.js
+++ b/test/exec.js
@@ -201,7 +201,7 @@ test.cb('callback as 3rd argument (silent:true)', t => {
 });
 
 test.cb('command that fails', t => {
-  shell.exec(`shx cp onlyOneCpArgument.txt`, { silent: true }, (code, stdout, stderr) => {
+  shell.exec('shx cp onlyOneCpArgument.txt', { silent: true }, (code, stdout, stderr) => {
     t.is(code, 1);
     t.is(stdout, '');
     t.is(stderr, 'cp: missing <source> and/or <dest>\n');

--- a/test/exec.js
+++ b/test/exec.js
@@ -199,3 +199,12 @@ test.cb('callback as 3rd argument (silent:true)', t => {
     t.end();
   });
 });
+
+test.cb('command that fails', t => {
+  shell.exec(`shx cp onlyOneCpArgument.txt`, { silent: true }, (code, stdout, stderr) => {
+    t.is(code, 1);
+    t.is(stdout, '');
+    t.is(stderr, 'cp: missing <source> and/or <dest>\n');
+    t.end();
+  });
+});


### PR DESCRIPTION
No logic change.

This adds one test to cover some missing lines, and adds some `istanbul ignore`
directives.

I see 100% line coverage for `src/exec.js` when running:

```sh
$ nyc --reporter=text --reporter=lcov ava --serial test/exec.js`
```

Fixes #742