### PR TITLE
chore: add skipOnWin and skipOnUnix test helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
+    "chalk": "^1.1.3",
     "codecov": "^1.0.1",
     "coffee-script": "^1.10.0",
     "eslint": "^2.0.0",

--- a/test/chmod.js
+++ b/test/chmod.js
@@ -32,7 +32,7 @@ test('invalid permissions', t => {
 });
 
 test('Basic usage with octal codes', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('755', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
@@ -45,11 +45,11 @@ test('Basic usage with octal codes', t => {
       fs.statSync(`${TMP}/chmod/file1`).mode & BITMASK,
       parseInt('644', 8)
     );
-  }
+  });
 });
 
 test('symbolic mode', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('o+x', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
@@ -58,11 +58,11 @@ test('symbolic mode', t => {
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
-  }
+  });
 });
 
 test('symbolic mode, without group', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('+x', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
@@ -71,11 +71,11 @@ test('symbolic mode, without group', t => {
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
-  }
+  });
 });
 
 test('Test setuid', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('u+s', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
@@ -102,11 +102,11 @@ test('Test setuid', t => {
     );
     result = shell.chmod('u-s', `${TMP}/chmod/c`);
     t.is(result.code, 0);
-  }
+  });
 });
 
 test('Test setgid', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('g+s', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
@@ -119,11 +119,11 @@ test('Test setgid', t => {
       fs.statSync(`${TMP}/chmod/file1`).mode & BITMASK,
       parseInt('644', 8)
     );
-  }
+  });
 });
 
 test('Test sticky bit', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('+t', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
@@ -137,11 +137,11 @@ test('Test sticky bit', t => {
       parseInt('644', 8)
     );
     t.is(fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('1000', 8), 0);
-  }
+  });
 });
 
 test('Test directories', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('a-w', `${TMP}/chmod/b/a/b`);
     t.is(result.code, 0);
     t.is(
@@ -150,11 +150,11 @@ test('Test directories', t => {
     );
     result = shell.chmod('755', `${TMP}/chmod/b/a/b`);
     t.is(result.code, 0);
-  }
+  });
 });
 
 test('Test recursion', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('-R', 'a+w', `${TMP}/chmod/b`);
     t.is(result.code, 0);
     t.is(
@@ -167,11 +167,11 @@ test('Test recursion', t => {
       fs.statSync(`${TMP}/chmod/b/a/b`).mode & BITMASK,
       parseInt('755', 8)
     );
-  }
+  });
 });
 
 test('Test symbolic links w/ recursion  - WARNING: *nix only', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     fs.symlinkSync(`${TMP}/chmod/b/a`, `${TMP}/chmod/a/b/c/link`, 'dir');
     let result = shell.chmod('-R', 'u-w', `${TMP}/chmod/a/b`);
     t.is(result.code, 0);
@@ -186,7 +186,7 @@ test('Test symbolic links w/ recursion  - WARNING: *nix only', t => {
     result = shell.chmod('-R', 'u+w', `${TMP}/chmod/a/b`);
     t.is(result.code, 0);
     fs.unlinkSync(`${TMP}/chmod/a/b/c/link`);
-  }
+  });
 });
 
 test('Test combinations', t => {
@@ -223,7 +223,7 @@ test('multiple symbolic modes #2', t => {
 });
 
 test('multiple symbolic modes #3', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('a-rwx,u+rwx', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
@@ -232,7 +232,7 @@ test('multiple symbolic modes #3', t => {
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
-  }
+  });
 });
 
 test('u+rw', t => {
@@ -249,7 +249,7 @@ test('u+rw', t => {
 });
 
 test('u+wx', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('000', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     result = shell.chmod('u+wx', `${TMP}/chmod/file1`);
@@ -260,11 +260,11 @@ test('u+wx', t => {
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
-  }
+  });
 });
 
 test('Multiple symbolic modes at once', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('000', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     result = shell.chmod('u+r,g+w,o+x', `${TMP}/chmod/file1`);
@@ -275,11 +275,11 @@ test('Multiple symbolic modes at once', t => {
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
-  }
+  });
 });
 
 test('u+rw,g+wx', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.chmod('000', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     result = shell.chmod('u+rw,g+wx', `${TMP}/chmod/file1`);
@@ -290,7 +290,7 @@ test('u+rw,g+wx', t => {
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
-  }
+  });
 });
 
 test('u-x,g+rw', t => {
@@ -337,7 +337,7 @@ test('Numeric modes', t => {
 });
 
 test('Make sure chmod succeeds for a variety of octal codes', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     t.is(
       fs.statSync(`${TMP}/chmod/xdir`).mode & parseInt('755', 8),
       parseInt('755', 8)
@@ -354,5 +354,5 @@ test('Make sure chmod succeeds for a variety of octal codes', t => {
       fs.statSync(`${TMP}/chmod/xdir/deep/file`).mode & parseInt('644', 8),
       parseInt('644', 8)
     );
-  }
+  });
 });

--- a/test/cp.js
+++ b/test/cp.js
@@ -307,7 +307,7 @@ test('recursive, everything exists, no force flag', t => {
 });
 
 test('-R implies to not follow links', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     shell.cp('-R', 'resources/cp/*', t.context.tmp);
     t.truthy(fs.lstatSync(`${t.context.tmp}/links/sym.lnk`).isSymbolicLink()); // this one is a link
     t.falsy((fs.lstatSync(`${t.context.tmp}/fakeLinks/sym.lnk`).isSymbolicLink())); // this one isn't
@@ -325,11 +325,11 @@ test('-R implies to not follow links', t => {
       shell.cat(`${t.context.tmp}/links/sym.lnk`).toString(),
       shell.cat(`${t.context.tmp}/fakeLinks/sym.lnk`).toString()
     );
-  }
+  });
 });
 
 test('Missing -R implies -L', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     // Recursive, everything exists, overwrite a real file *by following a link*
     // Because missing the -R implies -L.
     shell.cp('-R', 'resources/cp/*', t.context.tmp);
@@ -350,7 +350,7 @@ test('Missing -R implies -L', t => {
       shell.cat(`${t.context.tmp}/links/sym.lnk`).toString(),
       shell.cat(`${t.context.tmp}/fakeLinks/sym.lnk`).toString()
     );
-  }
+  });
 });
 
 test('recursive, everything exists, with force flag', t => {
@@ -411,7 +411,7 @@ test('recursive, with trailing slash, does the exact same', t => {
 test(
   'On Windows, permission bits are quite different so skip those tests for now',
   t => {
-    if (process.platform !== 'win32') {
+    utils.skipOnWin(t, () => {
       // preserve mode bits
       const execBit = parseInt('001', 8);
       t.is(fs.statSync('resources/cp-mode-bits/executable').mode & execBit, execBit);
@@ -420,7 +420,7 @@ test(
         fs.statSync('resources/cp-mode-bits/executable').mode,
         fs.statSync(`${t.context.tmp}/executable`).mode
       );
-    }
+    });
   }
 );
 
@@ -457,42 +457,42 @@ test('no-recursive will copy regular files only', t => {
 });
 
 test('-R implies -P', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     shell.cp('-R', 'resources/cp/links/sym.lnk', t.context.tmp);
     t.truthy(fs.lstatSync(`${t.context.tmp}/sym.lnk`).isSymbolicLink());
-  }
+  });
 });
 
 test('using -P explicitly works', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     shell.cp('-P', 'resources/cp/links/sym.lnk', t.context.tmp);
     t.truthy(fs.lstatSync(`${t.context.tmp}/sym.lnk`).isSymbolicLink());
-  }
+  });
 });
 
 test('using -PR on a link to a folder does not follow the link', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     shell.cp('-PR', 'resources/cp/symFolder', t.context.tmp);
     t.truthy(fs.lstatSync(`${t.context.tmp}/symFolder`).isSymbolicLink());
-  }
+  });
 });
 
 test('-L overrides -P for copying directory', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     shell.cp('-LPR', 'resources/cp/symFolder', t.context.tmp);
     t.falsy(fs.lstatSync(`${t.context.tmp}/symFolder`).isSymbolicLink());
     t.falsy(fs.lstatSync(`${t.context.tmp}/symFolder/sym.lnk`).isSymbolicLink());
-  }
+  });
 });
 
 test('Recursive, copies entire directory with no symlinks and -L option does not cause change in behavior', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     const result = shell.cp('-rL', 'resources/cp/dir_a', `${t.context.tmp}/dest`);
     t.falsy(shell.error());
     t.falsy(result.stderr);
     t.is(result.code, 0);
     t.truthy(fs.existsSync(`${t.context.tmp}/dest/z`));
-  }
+  });
 });
 
 test('-u flag won\'t overwrite newer files', t => {

--- a/test/exec.js
+++ b/test/exec.js
@@ -5,6 +5,7 @@ import util from 'util';
 import test from 'ava';
 
 import shell from '..';
+import utils from './utils/utils';
 
 const CWD = process.cwd();
 const ORIG_EXEC_PATH = shell.config.execPath;
@@ -138,7 +139,7 @@ test('check process.env works', t => {
 });
 
 test('set shell option (TODO: add tests for Windows)', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     let result = shell.exec('echo $0');
     t.falsy(shell.error());
     t.is(result.code, 0);
@@ -151,7 +152,7 @@ test('set shell option (TODO: add tests for Windows)', t => {
       t.is(result.code, 0);
       t.is(result.stdout, '/bin/bash\n');
     }
-  }
+  });
 });
 
 test('exec returns a ShellString', t => {

--- a/test/ls.js
+++ b/test/ls.js
@@ -305,7 +305,7 @@ test('-RA flag, symlinks are not followed', t => {
 });
 
 test('-RAL flag, follows symlinks', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     const result = shell.ls('-RAL', 'resources/rm');
     t.falsy(shell.error());
     t.is(result.code, 0);
@@ -315,17 +315,17 @@ test('-RAL flag, follows symlinks', t => {
     t.truthy(result.indexOf('link_to_a_dir/a_file') > -1);
     t.truthy(result.indexOf('fake.lnk') > -1);
     t.is(result.length, 5);
-  }
+  });
 });
 
 test('-L flag, path is symlink', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     const result = shell.ls('-L', 'resources/rm/link_to_a_dir');
     t.falsy(shell.error());
     t.is(result.code, 0);
     t.truthy(result.indexOf('a_file') > -1);
     t.is(result.length, 1);
-  }
+  });
 });
 
 test('-Rd works like -d', t => {
@@ -382,10 +382,10 @@ test('long option, single file', t => {
   t.is(result.nlink, 1);
   t.is(result.size, 5);
   t.truthy(result.mode); // check that these keys exist
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     t.truthy(result.uid);
     t.truthy(result.gid);
-  }
+  });
   t.truthy(result.mtime); // check that these keys exist
   t.truthy(result.atime); // check that these keys exist
   t.truthy(result.ctime); // check that these keys exist
@@ -401,10 +401,10 @@ test('long option, glob files', t => {
   t.is(result.nlink, 1);
   t.is(result.size, 5);
   t.truthy(result.mode); // check that these keys exist
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     t.truthy(result.uid);
     t.truthy(result.gid);
-  }
+  });
   t.truthy(result.mtime); // check that these keys exist
   t.truthy(result.atime); // check that these keys exist
   t.truthy(result.ctime); // check that these keys exist
@@ -423,10 +423,10 @@ test('long option, directory', t => {
   t.is(result.nlink, 1);
   t.is(result.size, 5);
   t.truthy(result.mode); // check that these keys exist
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     t.truthy(result.uid);
     t.truthy(result.gid);
-  }
+  });
   t.truthy(result.mtime); // check that these keys exist
   t.truthy(result.atime); // check that these keys exist
   t.truthy(result.ctime); // check that these keys exist
@@ -446,10 +446,10 @@ test('long option, directory, recursive (and windows converts slashes)', t => {
   t.is(typeof result.nlink, 'number'); // This can vary between the local machine and travis
   t.is(typeof result.size, 'number'); // This can vary between different file systems
   t.truthy(result.mode); // check that these keys exist
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     t.truthy(result.uid);
     t.truthy(result.gid);
-  }
+  });
   t.truthy(result.mtime); // check that these keys exist
   t.truthy(result.atime); // check that these keys exist
   t.truthy(result.ctime); // check that these keys exist

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -84,7 +84,7 @@ test('try to make a subdirectory of a file', t => {
 });
 
 test('Check for invalid permissions', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     // This test case only works on unix, but should work on Windows as well
     const dirName = 'nowritedir';
     shell.mkdir(dirName);
@@ -99,7 +99,7 @@ test('Check for invalid permissions', t => {
     t.truthy(shell.error());
     t.falsy(fs.existsSync(dirName + '/foo'));
     shell.rm('-rf', dirName); // clean up
-  }
+  });
 });
 
 //

--- a/test/rm.js
+++ b/test/rm.js
@@ -268,7 +268,7 @@ test('remove symbolic link to a dir', t => {
 });
 
 test('rm -rf on a symbolic link to a dir deletes its contents', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     const result = shell.rm('-rf', `${t.context.tmp}/rm/link_to_a_dir/`);
     t.falsy(shell.error());
     t.is(result.code, 0);
@@ -277,18 +277,18 @@ test('rm -rf on a symbolic link to a dir deletes its contents', t => {
     t.truthy(fs.existsSync(`${t.context.tmp}/rm/link_to_a_dir`));
     t.truthy(fs.existsSync(`${t.context.tmp}/rm/a_dir`));
     t.falsy(fs.existsSync(`${t.context.tmp}/rm/a_dir/a_file`));
-  }
+  });
 });
 
 test('remove broken symbolic link', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     t.truthy(shell.test('-L', `${t.context.tmp}/rm/fake.lnk`));
     const result = shell.rm(`${t.context.tmp}/rm/fake.lnk`);
     t.falsy(shell.error());
     t.is(result.code, 0);
     t.falsy(shell.test('-L', `${t.context.tmp}/rm/fake.lnk`));
     t.falsy(fs.existsSync(`${t.context.tmp}/rm/fake.lnk`));
-  }
+  });
 });
 
 test('recursive dir removal, for non-normalized path', t => {
@@ -301,10 +301,10 @@ test('recursive dir removal, for non-normalized path', t => {
 });
 
 test('remove fifo', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     const fifo = utils.mkfifo(t.context.tmp);
     const result = shell.rm(fifo);
     t.falsy(shell.error());
     t.is(result.code, 0);
-  }
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 
 import shell from '..';
+import utils from './utils/utils';
 
 shell.config.silent = true;
 
@@ -90,41 +91,41 @@ test('test command is not globbed', t => {
 
 // TODO(nate): figure out a way to test links on Windows
 test('-d option fails for a link', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     const result = shell.test('-d', 'resources/link');
     t.falsy(shell.error());
     t.falsy(result);
-  }
+  });
 });
 
 test('-f option succeeds for a link', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     const result = shell.test('-f', 'resources/link');
     t.falsy(shell.error());
     t.truthy(result);
-  }
+  });
 });
 
 test('-L option succeeds for a symlink', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     const result = shell.test('-L', 'resources/link');
     t.falsy(shell.error());
     t.truthy(result);
-  }
+  });
 });
 
 test('-L option works for broken symlinks', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     const result = shell.test('-L', 'resources/badlink');
     t.falsy(shell.error());
     t.truthy(result);
-  }
+  });
 });
 
 test('-L option fails for missing files', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     const result = shell.test('-L', 'resources/404');
     t.falsy(shell.error());
     t.falsy(result);
-  }
+  });
 });

--- a/test/touch.js
+++ b/test/touch.js
@@ -164,11 +164,11 @@ test('file array', t => {
 });
 
 test('touching broken link creates a new file', t => {
-  if (process.platform !== 'win32') {
+  utils.skipOnWin(t, () => {
     const result = shell.touch('resources/badlink');
     t.is(result.code, 0);
     t.falsy(shell.error());
     t.truthy(fs.existsSync('resources/not_existed_file'));
     shell.rm('resources/not_existed_file');
-  }
+  });
 });

--- a/test/utils/utils.js
+++ b/test/utils/utils.js
@@ -1,4 +1,7 @@
 const child = require('child_process');
+const path = require('path');
+
+const chalk = require('chalk');
 
 const common = require('../../src/common');
 
@@ -33,7 +36,11 @@ function runScript(script, cb) {
 exports.runScript = runScript;
 
 function sleep(time) {
-  child.execFileSync(common.config.execPath, ['resources/exec/slow.js', time.toString()]);
+  const testDirectoryPath = path.dirname(__dirname);
+  child.execFileSync(common.config.execPath, [
+    path.join(testDirectoryPath, 'resources', 'exec', 'slow.js'),
+    time.toString(),
+  ]);
 }
 exports.sleep = sleep;
 
@@ -46,3 +53,18 @@ function mkfifo(dir) {
   return null;
 }
 exports.mkfifo = mkfifo;
+
+function skipIfTrue(booleanValue, t, closure) {
+  if (booleanValue) {
+    console.warn(
+      chalk.yellow('Warning: skipping platform-dependent test ') +
+      chalk.bold.white(`'${t._test.title}'`)
+    );
+    t.truthy(true); // dummy assertion to satisfy ava v0.19+
+  } else {
+    closure();
+  }
+}
+
+exports.skipOnUnix = skipIfTrue.bind(module.exports, process.platform !== 'win32');
+exports.skipOnWin = skipIfTrue.bind(module.exports, process.platform === 'win32');

--- a/test/which.js
+++ b/test/which.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import test from 'ava';
 
 import shell from '..';
+import utils from './utils/utils';
 
 shell.config.silent = true;
 
@@ -35,7 +36,7 @@ test('basic usage', t => {
 });
 
 test('Windows can search with or without a .exe extension', t => {
-  if (process.platform === 'win32') {
+  utils.skipOnUnix(t, () => {
     // This should be equivalent on Windows
     const node = shell.which('node');
     const nodeExe = shell.which('node.exe');
@@ -43,7 +44,7 @@ test('Windows can search with or without a .exe extension', t => {
     // If the paths are equal, then this file *should* exist, since that's
     // already been checked.
     t.is(node.toString(), nodeExe.toString());
-  }
+  });
 });
 
 test('Searching with -a flag returns an array', t => {


### PR DESCRIPTION
This adds `skipOnWin` and `skipOnUnix` to help us manage our platform-dependent
tests. These methods give a nice warning message when we skip tests. We may also
consider adding warnings when running platform-dependent tests.

Part of the motivation for this is if we ever update to AVA v0.19. This version
requires at least one assertion per test case. While this could be disabled with
an AVA setting, we instead benefit from warnings for any case when we
unintentionally skip assertions.

This adds chalk as a dev dependency to enable colored messages.