### PR TITLE
Use Node's native spawnSync for execSync to improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,9 +307,7 @@ Not seeing the behavior you want? `exec()` runs everything through `sh`
 by default (or `cmd.exe` on Windows), which differs from `bash`. If you
 need bash-specific behavior, try out the `{shell: 'path/to/bash'}` option.
 
-**Note:** For long-lived processes, it's best to run `exec()` asynchronously as
-the current synchronous implementation uses a lot of CPU. This should be getting
-fixed soon.
+**Note:** You should consider to run `exec()` asynchronously for long-lived processes.
 
 
 ### find(path [, path ...])

--- a/src/exec.js
+++ b/src/exec.js
@@ -13,8 +13,6 @@ common.register('exec', _exec, {
 
 function execSync(cmd, opts, pipe) {
   var silent = opts.silent || common.config.silent;
-  var stdout;
-  var stderr;
   var code;
 
   opts = common.extend({
@@ -31,18 +29,14 @@ function execSync(cmd, opts, pipe) {
   }
 
   opts.cwd = path.resolve(opts.cwd);
-
-  /* istanbul ignore else */
-  if (silent) {
-    opts.stdio = 'pipe';
-  } else {
-    opts.stdio = 'inherit';
-  }
+  opts.stdio = 'pipe';
 
   var c = child.spawnSync(cmd, opts);
 
-  stdout = c.stdout || '';
-  stderr = c.stderr || '';
+  if (!silent) {
+    process.stdout.write(c.stdout);
+    process.stderr.write(c.stderr);
+  }
 
   if (c.error) {
     code = (typeof c.error.code === 'number' ? c.error.code : 1);
@@ -53,7 +47,7 @@ function execSync(cmd, opts, pipe) {
   if (code !== 0) {
     common.error('', code, { continue: true });
   }
-  var obj = common.ShellString(stdout, stderr, code);
+  var obj = common.ShellString(c.stdout, c.stderr, code);
   return obj;
 } // execSync()
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -134,9 +134,7 @@ function execAsync(cmd, opts, pipe, callback) {
 //@ by default (or `cmd.exe` on Windows), which differs from `bash`. If you
 //@ need bash-specific behavior, try out the `{shell: 'path/to/bash'}` option.
 //@
-//@ **Note:** For long-lived processes, it's best to run `exec()` asynchronously as
-//@ the current synchronous implementation uses a lot of CPU. This should be getting
-//@ fixed soon.
+//@ **Note:** You should consider to run `exec()` asynchronously for long-lived processes.
 function _exec(command, options, callback) {
   options = options || {};
   if (!command) common.error('must specify command');

--- a/src/exec.js
+++ b/src/exec.js
@@ -1,8 +1,6 @@
 var common = require('./common');
-var _tempDir = require('./tempdir');
 var _pwd = require('./pwd');
 var path = require('path');
-var fs = require('fs');
 var child = require('child_process');
 
 var DEFAULT_MAXBUFFER_SIZE = 20 * 1024 * 1024;
@@ -13,105 +11,44 @@ common.register('exec', _exec, {
   wrapOutput: false,
 });
 
-// Hack to run child_process.exec() synchronously (sync avoids callback hell)
-// Uses a custom wait loop that checks for a flag file, created when the child process is done.
-// (Can't do a wait loop that checks for internal Node variables/messages as
-// Node is single-threaded; callbacks and other internal state changes are done in the
-// event loop).
 function execSync(cmd, opts, pipe) {
-  if (!common.config.execPath) {
-    common.error('Unable to find a path to the node binary. Please manually set config.execPath');
-  }
-
-  var tempDir = _tempDir();
-  var stdoutFile = path.resolve(tempDir + '/' + common.randomFileName());
-  var stderrFile = path.resolve(tempDir + '/' + common.randomFileName());
-  var codeFile = path.resolve(tempDir + '/' + common.randomFileName());
-  var scriptFile = path.resolve(tempDir + '/' + common.randomFileName());
+  var silent = opts.silent || common.config.silent;
+  var stdout;
+  var stderr;
+  var code;
 
   opts = common.extend({
-    silent: common.config.silent,
     cwd: _pwd().toString(),
     env: process.env,
     maxBuffer: DEFAULT_MAXBUFFER_SIZE,
+    shell: true,
   }, opts);
 
-  if (fs.existsSync(scriptFile)) common.unlinkSync(scriptFile);
-  if (fs.existsSync(stdoutFile)) common.unlinkSync(stdoutFile);
-  if (fs.existsSync(stderrFile)) common.unlinkSync(stderrFile);
-  if (fs.existsSync(codeFile)) common.unlinkSync(codeFile);
+  opts.encoding = 'utf8';
 
-  var execCommand = JSON.stringify(common.config.execPath) + ' ' + JSON.stringify(scriptFile);
-  var script;
+  if (pipe) {
+    opts.input = pipe;
+  }
 
   opts.cwd = path.resolve(opts.cwd);
-  var optString = JSON.stringify(opts);
-
-  script = [
-    "var child = require('child_process')",
-    "  , fs = require('fs');",
-    'var childProcess = child.exec(' + JSON.stringify(cmd) + ', ' + optString + ', function(err) {',
-    '  var fname = ' + JSON.stringify(codeFile) + ';',
-    '  if (!err) {',
-    '    fs.writeFileSync(fname, "0");',
-    '  } else if (err.code === undefined) {',
-    '    fs.writeFileSync(fname, "1");',
-    '  } else {',
-    '    fs.writeFileSync(fname, err.code.toString());',
-    '  }',
-    '});',
-    'var stdoutStream = fs.createWriteStream(' + JSON.stringify(stdoutFile) + ');',
-    'var stderrStream = fs.createWriteStream(' + JSON.stringify(stderrFile) + ');',
-    'childProcess.stdout.pipe(stdoutStream, {end: false});',
-    'childProcess.stderr.pipe(stderrStream, {end: false});',
-    'childProcess.stdout.pipe(process.stdout);',
-    'childProcess.stderr.pipe(process.stderr);',
-  ].join('\n') +
-    (pipe ? '\nchildProcess.stdin.end(' + JSON.stringify(pipe) + ');\n' : '\n') +
-    [
-      'var stdoutEnded = false, stderrEnded = false;',
-      'function tryClosingStdout(){ if(stdoutEnded){ stdoutStream.end(); } }',
-      'function tryClosingStderr(){ if(stderrEnded){ stderrStream.end(); } }',
-      "childProcess.stdout.on('end', function(){ stdoutEnded = true; tryClosingStdout(); });",
-      "childProcess.stderr.on('end', function(){ stderrEnded = true; tryClosingStderr(); });",
-    ].join('\n');
-
-  fs.writeFileSync(scriptFile, script);
 
   /* istanbul ignore else */
-  if (opts.silent) {
-    opts.stdio = 'ignore';
+  if (silent) {
+    opts.stdio = 'pipe';
   } else {
-    opts.stdio = [0, 1, 2];
+    opts.stdio = 'inherit';
   }
 
-  // Welcome to the future
-  try {
-    child.execSync(execCommand, opts);
-  } catch (e) {
-    // Clean up immediately if we have an exception
-    try { common.unlinkSync(scriptFile); } catch (e2) {}
-    try { common.unlinkSync(stdoutFile); } catch (e2) {}
-    try { common.unlinkSync(stderrFile); } catch (e2) {}
-    try { common.unlinkSync(codeFile); } catch (e2) {}
-    throw e;
+  var c = child.spawnSync(cmd, opts);
+
+  stdout = c.stdout || '';
+  stderr = c.stderr || '';
+
+  if (c.error) {
+    code = (typeof c.error.code === 'number' ? c.error.code : 1);
+  } else {
+    code = c.status || 0;
   }
-
-  // At this point codeFile exists, but it's not necessarily flushed yet.
-  // Keep reading it until it is.
-  var code = parseInt('', 10);
-  while (isNaN(code)) {
-    code = parseInt(fs.readFileSync(codeFile, 'utf8'), 10);
-  }
-
-  var stdout = fs.readFileSync(stdoutFile, 'utf8');
-  var stderr = fs.readFileSync(stderrFile, 'utf8');
-
-  // No biggie if we can't erase the files now -- they're in a temp dir anyway
-  try { common.unlinkSync(scriptFile); } catch (e) {}
-  try { common.unlinkSync(stdoutFile); } catch (e) {}
-  try { common.unlinkSync(stderrFile); } catch (e) {}
-  try { common.unlinkSync(codeFile); } catch (e) {}
 
   if (code !== 0) {
     common.error('', code, { continue: true });

--- a/test/exec.js
+++ b/test/exec.js
@@ -106,6 +106,13 @@ test('set maxBuffer (very small)', t => {
   t.truthy(shell.error());
 });
 
+test('multiple commands should work', t => {
+  const result = shell.exec('echo abc ; echo bcd');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, 'abc' + os.EOL + 'bcd' + os.EOL);
+});
+
 test('set timeout option', t => {
   const result = shell.exec(`${JSON.stringify(shell.config.execPath)} resources/exec/slow.js 100`); // default timeout is ok
   t.falsy(shell.error());

--- a/test/exec.js
+++ b/test/exec.js
@@ -8,12 +8,10 @@ import shell from '..';
 import utils from './utils/utils';
 
 const CWD = process.cwd();
-const ORIG_EXEC_PATH = shell.config.execPath;
 shell.config.silent = true;
 
 test.afterEach.always(() => {
   process.chdir(CWD);
-  shell.config.execPath = ORIG_EXEC_PATH;
 });
 
 //
@@ -37,15 +35,6 @@ test('config.fatal and unknown command', t => {
     shell.exec('asdfasdf'); // could not find command
   }, /exec: internal error/);
   shell.config.fatal = oldFatal;
-});
-
-test('exec exits gracefully if we cannot find the execPath', t => {
-  shell.config.execPath = null;
-  shell.exec('echo foo');
-  t.regex(
-    shell.error(),
-    /Unable to find a path to the node binary\. Please manually set config\.execPath/
-  );
 });
 
 //


### PR DESCRIPTION
Hello,

I tried to rewrite `execSync` method with usage of Node's native `spawnSync` as it should improve performance of sync version of `shell.exec` method rapidly.

According to my own test script the improvement is from original 12s to 1.6s after change.

What do you think?

I had to remove one test and I hope it works the same way as before. I don't have a Windows machine so it would be great to confirm it works the same also under Windows.

Btw. it could also fix following issues:
- #440, #108