### PR TITLE
refactor(test): update AVA and refactor tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rechoir": "^0.6.2"
   },
   "devDependencies": {
-    "ava": "^0.16.0",
+    "ava": "^0.21.0",
     "chalk": "^1.1.3",
     "codecov": "^1.0.1",
     "coffee-script": "^1.10.0",

--- a/test/cat.js
+++ b/test/cat.js
@@ -26,10 +26,10 @@ test('nonexistent file', t => {
 });
 
 test('directory', t => {
-  const result = shell.cat('resources/cat');
+  const result = shell.cat('test/resources/cat');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, 'cat: resources/cat: Is a directory');
+  t.is(result.stderr, 'cat: test/resources/cat: Is a directory');
 });
 
 //
@@ -37,28 +37,28 @@ test('directory', t => {
 //
 
 test('simple', t => {
-  const result = shell.cat('resources/cat/file1');
+  const result = shell.cat('test/resources/cat/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), 'test1\n');
 });
 
 test('multiple files', t => {
-  const result = shell.cat('resources/cat/file2', 'resources/cat/file1');
+  const result = shell.cat('test/resources/cat/file2', 'test/resources/cat/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), 'test2\ntest1\n');
 });
 
 test('multiple files, array syntax', t => {
-  const result = shell.cat(['resources/cat/file2', 'resources/cat/file1']);
+  const result = shell.cat(['test/resources/cat/file2', 'test/resources/cat/file1']);
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), 'test2\ntest1\n');
 });
 
 test('glob', t => {
-  const result = shell.cat('resources/file*.txt');
+  const result = shell.cat('test/resources/file*.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.truthy(result.search('test1') > -1); // file order might be random

--- a/test/cd.js
+++ b/test/cd.js
@@ -34,11 +34,11 @@ test('nonexistent directory', t => {
 });
 
 test('file not dir', t => {
-  t.truthy(fs.existsSync('resources/file1')); // sanity check
-  const result = shell.cd('resources/file1'); // file, not dir
+  t.truthy(fs.existsSync('test/resources/file1')); // sanity check
+  const result = shell.cd('test/resources/file1'); // file, not dir
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, 'cd: not a directory: resources/file1');
+  t.is(result.stderr, 'cd: not a directory: test/resources/file1');
 });
 
 test('no previous dir', t => {
@@ -76,13 +76,13 @@ test('previous directory (-)', t => {
 
 test('cd + other commands', t => {
   t.falsy(fs.existsSync(`${t.context.tmp}/file1`));
-  let result = shell.cd('resources');
+  let result = shell.cd('test/resources');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  result = shell.cp('file1', `../${t.context.tmp}`);
+  result = shell.cp('file1', `../../${t.context.tmp}`);
   t.falsy(shell.error());
   t.is(result.code, 0);
-  result = shell.cd(`../${t.context.tmp}`);
+  result = shell.cd(`../../${t.context.tmp}`);
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.truthy(fs.existsSync('file1'));

--- a/test/chmod.js
+++ b/test/chmod.js
@@ -10,7 +10,7 @@ const BITMASK = parseInt('777', 8);
 
 test.before(() => {
   TMP = utils.getTempDir();
-  shell.cp('-r', 'resources', TMP);
+  shell.cp('-r', 'test/resources', TMP);
   shell.config.silent = true;
 });
 

--- a/test/common.js
+++ b/test/common.js
@@ -23,7 +23,7 @@ test('too few args', t => {
 
 test('should be a list', t => {
   t.throws(() => {
-    common.expand('resources');
+    common.expand('test/resources');
   }, TypeError);
 });
 
@@ -138,36 +138,36 @@ test('convertErrorOutput: changes backslashes to forward slashes', t => {
 // common.expand()
 //
 test('single file, array syntax', t => {
-  const result = common.expand(['resources/file1.txt']);
+  const result = common.expand(['test/resources/file1.txt']);
   t.falsy(shell.error());
-  t.deepEqual(result, ['resources/file1.txt']);
+  t.deepEqual(result, ['test/resources/file1.txt']);
 });
 
 test('multiple file, glob syntax, * for file name', t => {
-  const result = common.expand(['resources/file*.txt']);
+  const result = common.expand(['test/resources/file*.txt']);
   t.falsy(shell.error());
-  t.deepEqual(result.sort(), ['resources/file1.txt', 'resources/file2.txt'].sort());
+  t.deepEqual(result.sort(), ['test/resources/file1.txt', 'test/resources/file2.txt'].sort());
 });
 
 test('multiple file, glob syntax, * for directory name', t => {
-  const result = common.expand(['r*/file*.txt']);
+  const result = common.expand(['test/r*/file*.txt']);
   t.falsy(shell.error());
-  t.deepEqual(result.sort(), ['resources/file1.txt', 'resources/file2.txt'].sort());
+  t.deepEqual(result.sort(), ['test/resources/file1.txt', 'test/resources/file2.txt'].sort());
 });
 
 test('multiple file, glob syntax, ** for directory name', t => {
-  const result = common.expand(['resources/**/file*.js']);
+  const result = common.expand(['test/resources/**/file*.js']);
   t.falsy(shell.error());
   t.deepEqual(
     result.sort(),
-    ['resources/file1.js', 'resources/file2.js', 'resources/ls/file1.js', 'resources/ls/file2.js'].sort()
+    ['test/resources/file1.js', 'test/resources/file2.js', 'test/resources/ls/file1.js', 'test/resources/ls/file2.js'].sort()
   );
 });
 
 test('broken links still expand', t => {
-  const result = common.expand(['resources/b*dlink']);
+  const result = common.expand(['test/resources/b*dlink']);
   t.falsy(shell.error());
-  t.deepEqual(result, ['resources/badlink']);
+  t.deepEqual(result, ['test/resources/badlink']);
 });
 
 test('empty array', t => {
@@ -285,7 +285,7 @@ test('Some basic tests on the ShellString type', t => {
 });
 
 test.cb('Commands that fail will still output error messages to stderr', t => {
-  const script = 'require(\'../global\'); ls(\'noexist\'); cd(\'noexist\');';
+  const script = 'require(\'./global\'); ls(\'noexist\'); cd(\'noexist\');';
   utils.runScript(script, (err, stdout, stderr) => {
     t.is(stdout, '');
     t.is(

--- a/test/config.js
+++ b/test/config.js
@@ -32,7 +32,7 @@ test('config.silent can be set to false', t => {
 
 test.cb('config.fatal = false', t => {
   t.falsy(shell.config.fatal);
-  const script = 'require(\'../global.js\'); config.silent=true; config.fatal=false; cp("this_file_doesnt_exist", "."); echo("got here");';
+  const script = 'require(\'./global.js\'); config.silent=true; config.fatal=false; cp("this_file_doesnt_exist", "."); echo("got here");';
   utils.runScript(script, (err, stdout) => {
     t.truthy(stdout.match('got here'));
     t.end();
@@ -40,7 +40,7 @@ test.cb('config.fatal = false', t => {
 });
 
 test.cb('config.fatal = true', t => {
-  const script = 'require(\'../global.js\'); config.silent=true; config.fatal=true; cp("this_file_doesnt_exist", "."); echo("got here");';
+  const script = 'require(\'./global.js\'); config.silent=true; config.fatal=true; cp("this_file_doesnt_exist", "."); echo("got here");';
   utils.runScript(script, (err, stdout) => {
     t.falsy(stdout.match('got here'));
     t.end();
@@ -52,24 +52,24 @@ test.cb('config.fatal = true', t => {
 //
 
 test('Expands to directories by default', t => {
-  const result = common.expand(['resources/*a*']);
+  const result = common.expand(['test/resources/*a*']);
   t.is(result.length, 5);
-  t.truthy(result.indexOf('resources/a.txt') > -1);
-  t.truthy(result.indexOf('resources/badlink') > -1);
-  t.truthy(result.indexOf('resources/cat') > -1);
-  t.truthy(result.indexOf('resources/head') > -1);
-  t.truthy(result.indexOf('resources/external') > -1);
+  t.truthy(result.indexOf('test/resources/a.txt') > -1);
+  t.truthy(result.indexOf('test/resources/badlink') > -1);
+  t.truthy(result.indexOf('test/resources/cat') > -1);
+  t.truthy(result.indexOf('test/resources/head') > -1);
+  t.truthy(result.indexOf('test/resources/external') > -1);
 });
 
 test(
   'Check to make sure options get passed through (nodir is an example)',
   t => {
     shell.config.globOptions = { nodir: true };
-    const result = common.expand(['resources/*a*']);
+    const result = common.expand(['test/resources/*a*']);
     t.is(result.length, 2);
-    t.truthy(result.indexOf('resources/a.txt') > -1);
-    t.truthy(result.indexOf('resources/badlink') > -1);
-    t.truthy(result.indexOf('resources/cat') < 0);
-    t.truthy(result.indexOf('resources/external') < 0);
+    t.truthy(result.indexOf('test/resources/a.txt') > -1);
+    t.truthy(result.indexOf('test/resources/badlink') > -1);
+    t.truthy(result.indexOf('test/resources/cat') < 0);
+    t.truthy(result.indexOf('test/resources/external') < 0);
   }
 );

--- a/test/cp.js
+++ b/test/cp.js
@@ -46,7 +46,7 @@ test('only an option', t => {
 });
 
 test('invalid option', t => {
-  const result = shell.cp('-@', 'resources/file1', `${t.context.tmp}/file1`);
+  const result = shell.cp('-@', 'test/resources/file1', `${t.context.tmp}/file1`);
   t.truthy(shell.error());
   t.is(result.code, 1);
   t.falsy(fs.existsSync(`${t.context.tmp}/file1`));
@@ -84,14 +84,14 @@ test('multiple sources do not exist', t => {
 });
 
 test('too many sources', t => {
-  const result = shell.cp('asdfasdf1', 'asdfasdf2', 'resources/file1');
+  const result = shell.cp('asdfasdf1', 'asdfasdf2', 'test/resources/file1');
   t.truthy(shell.error());
   t.is(result.code, 1);
   t.is(result.stderr, 'cp: dest is not a directory (too many sources)');
 });
 
 test('too many sources #2', t => {
-  const result = shell.cp('resources/file1', 'resources/file2', `${t.context.tmp}/a_file`);
+  const result = shell.cp('test/resources/file1', 'test/resources/file2', `${t.context.tmp}/a_file`);
   t.truthy(shell.error());
   t.is(result.code, 1);
   t.falsy(fs.existsSync(`${t.context.tmp}/a_file`));
@@ -110,12 +110,12 @@ test('empty string source', t => {
 //
 
 test('dest already exists', t => {
-  const oldContents = shell.cat('resources/file2').toString();
-  const result = shell.cp('-n', 'resources/file1', 'resources/file2');
+  const oldContents = shell.cat('test/resources/file2').toString();
+  const result = shell.cp('-n', 'test/resources/file1', 'test/resources/file2');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.stderr, '');
-  t.is(shell.cat('resources/file2').toString(), oldContents);
+  t.is(shell.cat('test/resources/file2').toString(), oldContents);
 });
 
 test('-nR does not overwrite an existing file at the destination', t => {
@@ -125,8 +125,8 @@ test('-nR does not overwrite an existing file at the destination', t => {
   const oldContents = 'original content';
   shell.ShellString(oldContents).to(`${dest}/a`);
 
-  // Attempt to overwrite /tmp/new/cp/ with resources/cp/
-  const result = shell.cp('-nR', 'resources/cp/', `${t.context.tmp}/new/`);
+  // Attempt to overwrite /tmp/new/cp/ with test/resources/cp/
+  const result = shell.cp('-nR', 'test/resources/cp/', `${t.context.tmp}/new/`);
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.falsy(result.stderr);
@@ -135,9 +135,9 @@ test('-nR does not overwrite an existing file at the destination', t => {
 
 test('-n does not overwrite an existing file if the destination is a directory', t => {
   const oldContents = 'original content';
-  shell.cp('resources/file1', `${t.context.tmp}`);
+  shell.cp('test/resources/file1', `${t.context.tmp}`);
   new shell.ShellString(oldContents).to(`${t.context.tmp}/file1`);
-  const result = shell.cp('-n', 'resources/file1', `${t.context.tmp}`);
+  const result = shell.cp('-n', 'test/resources/file1', `${t.context.tmp}`);
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.falsy(result.stderr);
@@ -145,30 +145,30 @@ test('-n does not overwrite an existing file if the destination is a directory',
 });
 
 test('-f by default', t => {
-  shell.cp('resources/file2', 'resources/copyfile2');
-  const result = shell.cp('resources/file1', 'resources/file2'); // dest already exists
+  shell.cp('test/resources/file2', 'test/resources/copyfile2');
+  const result = shell.cp('test/resources/file1', 'test/resources/file2'); // dest already exists
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.falsy(result.stderr);
-  t.is(shell.cat('resources/file1').toString(), shell.cat('resources/file2').toString()); // after cp
-  shell.mv('resources/copyfile2', 'resources/file2'); // restore
+  t.is(shell.cat('test/resources/file1').toString(), shell.cat('test/resources/file2').toString()); // after cp
+  shell.mv('test/resources/copyfile2', 'test/resources/file2'); // restore
   t.falsy(shell.error());
 });
 
 test('-f (explicitly)', t => {
-  shell.cp('resources/file2', 'resources/copyfile2');
-  const result = shell.cp('-f', 'resources/file1', 'resources/file2'); // dest already exists
+  shell.cp('test/resources/file2', 'test/resources/copyfile2');
+  const result = shell.cp('-f', 'test/resources/file1', 'test/resources/file2'); // dest already exists
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
-  t.is(shell.cat('resources/file1').toString(), shell.cat('resources/file2').toString()); // after cp
-  shell.mv('resources/copyfile2', 'resources/file2'); // restore
+  t.is(shell.cat('test/resources/file1').toString(), shell.cat('test/resources/file2').toString()); // after cp
+  shell.mv('test/resources/copyfile2', 'test/resources/file2'); // restore
   t.falsy(shell.error());
   t.is(result.code, 0);
 });
 
 test('simple - to dir', t => {
-  const result = shell.cp('resources/file1', t.context.tmp);
+  const result = shell.cp('test/resources/file1', t.context.tmp);
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
@@ -176,7 +176,7 @@ test('simple - to dir', t => {
 });
 
 test('simple - to file', t => {
-  const result = shell.cp('resources/file2', `${t.context.tmp}/file2`);
+  const result = shell.cp('test/resources/file2', `${t.context.tmp}/file2`);
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
@@ -184,7 +184,7 @@ test('simple - to file', t => {
 });
 
 test('simple - file list', t => {
-  const result = shell.cp('resources/file1', 'resources/file2', t.context.tmp);
+  const result = shell.cp('test/resources/file1', 'test/resources/file2', t.context.tmp);
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
@@ -193,7 +193,7 @@ test('simple - file list', t => {
 });
 
 test('simple - file list, array syntax', t => {
-  const result = shell.cp(['resources/file1', 'resources/file2'], t.context.tmp);
+  const result = shell.cp(['test/resources/file1', 'test/resources/file2'], t.context.tmp);
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
@@ -202,9 +202,9 @@ test('simple - file list, array syntax', t => {
 });
 
 test('-f option', t => {
-  shell.cp('resources/file2', `${t.context.tmp}/file3`);
+  shell.cp('test/resources/file2', `${t.context.tmp}/file3`);
   t.truthy(fs.existsSync(`${t.context.tmp}/file3`));
-  const result = shell.cp('-f', 'resources/file2', `${t.context.tmp}/file3`); // file exists, but -f specified
+  const result = shell.cp('-f', 'test/resources/file2', `${t.context.tmp}/file3`); // file exists, but -f specified
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
@@ -212,7 +212,7 @@ test('-f option', t => {
 });
 
 test('glob', t => {
-  const result = shell.cp('resources/file?', t.context.tmp);
+  const result = shell.cp('test/resources/file?', t.context.tmp);
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
@@ -226,7 +226,7 @@ test('glob', t => {
 
 test('wildcard', t => {
   shell.rm(`${t.context.tmp}/file1`, `${t.context.tmp}/file2`);
-  const result = shell.cp('resources/file*', t.context.tmp);
+  const result = shell.cp('test/resources/file*', t.context.tmp);
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
@@ -239,7 +239,7 @@ test('wildcard', t => {
 });
 
 test('recursive, with regular files', t => {
-  const result = shell.cp('-R', 'resources/file1', 'resources/file2', t.context.tmp);
+  const result = shell.cp('-R', 'test/resources/file1', 'test/resources/file2', t.context.tmp);
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
@@ -248,37 +248,37 @@ test('recursive, with regular files', t => {
 });
 
 test('omit directory if missing recursive flag', t => {
-  const result = shell.cp('resources/cp', t.context.tmp);
-  t.is(shell.error(), "cp: omitting directory 'resources/cp'");
-  t.is(result.stderr, "cp: omitting directory 'resources/cp'");
+  const result = shell.cp('test/resources/cp', t.context.tmp);
+  t.is(shell.error(), "cp: omitting directory 'test/resources/cp'");
+  t.is(result.stderr, "cp: omitting directory 'test/resources/cp'");
   t.is(result.code, 1);
   t.falsy(fs.existsSync(`${t.context.tmp}/file1`));
   t.falsy(fs.existsSync(`${t.context.tmp}/file2`));
 });
 
 test('recursive, nothing exists', t => {
-  const result = shell.cp('-R', 'resources/cp', t.context.tmp);
+  const result = shell.cp('-R', 'test/resources/cp', t.context.tmp);
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
-  t.is(shell.ls('-R', 'resources/cp').toString(), shell.ls('-R', `${t.context.tmp}/cp`).toString());
+  t.is(shell.ls('-R', 'test/resources/cp').toString(), shell.ls('-R', `${t.context.tmp}/cp`).toString());
 });
 
 test(
   'recursive, nothing exists, source ends in \'/\' (see Github issue #15)',
   t => {
-    const result = shell.cp('-R', 'resources/cp/', `${t.context.tmp}/`);
+    const result = shell.cp('-R', 'test/resources/cp/', `${t.context.tmp}/`);
     t.falsy(shell.error());
     t.falsy(result.stderr);
     t.is(result.code, 0);
-    t.is(shell.ls('-R', 'resources/cp').toString(), shell.ls('-R', `${t.context.tmp}/cp`).toString());
+    t.is(shell.ls('-R', 'test/resources/cp').toString(), shell.ls('-R', `${t.context.tmp}/cp`).toString());
   }
 );
 
 test(
   'recursive, globbing regular files with extension (see Github issue #376)',
   t => {
-    const result = shell.cp('-R', 'resources/file*.txt', t.context.tmp);
+    const result = shell.cp('-R', 'test/resources/file*.txt', t.context.tmp);
     t.falsy(shell.error());
     t.falsy(result.stderr);
     t.is(result.code, 0);
@@ -290,7 +290,7 @@ test(
 test(
   'recursive, copying one regular file (also related to Github issue #376)',
   t => {
-    const result = shell.cp('-R', 'resources/file1.txt', t.context.tmp);
+    const result = shell.cp('-R', 'test/resources/file1.txt', t.context.tmp);
     t.falsy(shell.error());
     t.falsy(result.stderr);
     t.is(result.code, 0);
@@ -300,7 +300,7 @@ test(
 );
 
 test('recursive, everything exists, no force flag', t => {
-  const result = shell.cp('-R', 'resources/cp', t.context.tmp);
+  const result = shell.cp('-R', 'test/resources/cp', t.context.tmp);
   t.falsy(shell.error()); // crash test only
   t.falsy(result.stderr);
   t.is(result.code, 0);
@@ -308,7 +308,7 @@ test('recursive, everything exists, no force flag', t => {
 
 test('-R implies to not follow links', t => {
   utils.skipOnWin(t, () => {
-    shell.cp('-R', 'resources/cp/*', t.context.tmp);
+    shell.cp('-R', 'test/resources/cp/*', t.context.tmp);
     t.truthy(fs.lstatSync(`${t.context.tmp}/links/sym.lnk`).isSymbolicLink()); // this one is a link
     t.falsy((fs.lstatSync(`${t.context.tmp}/fakeLinks/sym.lnk`).isSymbolicLink())); // this one isn't
     t.not(
@@ -332,7 +332,7 @@ test('Missing -R implies -L', t => {
   utils.skipOnWin(t, () => {
     // Recursive, everything exists, overwrite a real file *by following a link*
     // Because missing the -R implies -L.
-    shell.cp('-R', 'resources/cp/*', t.context.tmp);
+    shell.cp('-R', 'test/resources/cp/*', t.context.tmp);
     t.truthy(fs.lstatSync(`${t.context.tmp}/links/sym.lnk`).isSymbolicLink()); // this one is a link
     t.falsy((fs.lstatSync(`${t.context.tmp}/fakeLinks/sym.lnk`).isSymbolicLink())); // this one isn't
     t.not(
@@ -354,26 +354,26 @@ test('Missing -R implies -L', t => {
 });
 
 test('recursive, everything exists, with force flag', t => {
-  let result = shell.cp('-R', 'resources/cp', t.context.tmp);
+  let result = shell.cp('-R', 'test/resources/cp', t.context.tmp);
   shell.ShellString('changing things around').to(`${t.context.tmp}/cp/dir_a/z`);
-  t.not(shell.cat('resources/cp/dir_a/z').toString(), shell.cat(`${t.context.tmp}/cp/dir_a/z`).toString()); // before cp
-  result = shell.cp('-Rf', 'resources/cp', t.context.tmp);
+  t.not(shell.cat('test/resources/cp/dir_a/z').toString(), shell.cat(`${t.context.tmp}/cp/dir_a/z`).toString()); // before cp
+  result = shell.cp('-Rf', 'test/resources/cp', t.context.tmp);
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
-  t.is(shell.cat('resources/cp/dir_a/z').toString(), shell.cat(`${t.context.tmp}/cp/dir_a/z`).toString()); // after cp
+  t.is(shell.cat('test/resources/cp/dir_a/z').toString(), shell.cat(`${t.context.tmp}/cp/dir_a/z`).toString()); // after cp
 });
 
 test(
   'recursive, creates dest dir since it\'s only one level deep (see Github issue #44)',
   t => {
-    const result = shell.cp('-r', 'resources/issue44', `${t.context.tmp}/dir2`);
+    const result = shell.cp('-r', 'test/resources/issue44', `${t.context.tmp}/dir2`);
     t.falsy(shell.error());
     t.falsy(result.stderr);
     t.is(result.code, 0);
-    t.is(shell.ls('-R', 'resources/issue44').toString(), shell.ls('-R', `${t.context.tmp}/dir2`).toString());
+    t.is(shell.ls('-R', 'test/resources/issue44').toString(), shell.ls('-R', `${t.context.tmp}/dir2`).toString());
     t.is(
-      shell.cat('resources/issue44/main.js').toString(),
+      shell.cat('test/resources/issue44/main.js').toString(),
       shell.cat(`${t.context.tmp}/dir2/main.js`).toString()
     );
   }
@@ -382,7 +382,7 @@ test(
 test(
   'recursive, does *not* create dest dir since it\'s too deep (see Github issue #44)',
   t => {
-    const result = shell.cp('-r', 'resources/issue44', `${t.context.tmp}/dir2/dir3`);
+    const result = shell.cp('-r', 'test/resources/issue44', `${t.context.tmp}/dir2/dir3`);
     t.truthy(shell.error());
     t.is(
       result.stderr,
@@ -394,7 +394,7 @@ test(
 );
 
 test('recursive, copies entire directory', t => {
-  const result = shell.cp('-r', 'resources/cp/dir_a', `${t.context.tmp}/dest`);
+  const result = shell.cp('-r', 'test/resources/cp/dir_a', `${t.context.tmp}/dest`);
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
@@ -402,7 +402,7 @@ test('recursive, copies entire directory', t => {
 });
 
 test('recursive, with trailing slash, does the exact same', t => {
-  const result = shell.cp('-r', 'resources/cp/dir_a/', `${t.context.tmp}/dest`);
+  const result = shell.cp('-r', 'test/resources/cp/dir_a/', `${t.context.tmp}/dest`);
   t.is(result.code, 0);
   t.falsy(shell.error());
   t.truthy(fs.existsSync(`${t.context.tmp}/dest/z`));
@@ -414,10 +414,10 @@ test(
     utils.skipOnWin(t, () => {
       // preserve mode bits
       const execBit = parseInt('001', 8);
-      t.is(fs.statSync('resources/cp-mode-bits/executable').mode & execBit, execBit);
-      shell.cp('resources/cp-mode-bits/executable', `${t.context.tmp}/executable`);
+      t.is(fs.statSync('test/resources/cp-mode-bits/executable').mode & execBit, execBit);
+      shell.cp('test/resources/cp-mode-bits/executable', `${t.context.tmp}/executable`);
       t.is(
-        fs.statSync('resources/cp-mode-bits/executable').mode,
+        fs.statSync('test/resources/cp-mode-bits/executable').mode,
         fs.statSync(`${t.context.tmp}/executable`).mode
       );
     });
@@ -426,7 +426,7 @@ test(
 
 test('Make sure hidden files are copied recursively', t => {
   shell.rm('-rf', t.context.tmp);
-  const result = shell.cp('-r', 'resources/ls/', t.context.tmp);
+  const result = shell.cp('-r', 'test/resources/ls/', t.context.tmp);
   t.falsy(shell.error());
   t.falsy(result.stderr);
   t.is(result.code, 0);
@@ -434,7 +434,7 @@ test('Make sure hidden files are copied recursively', t => {
 });
 
 test('no-recursive will copy regular files only', t => {
-  const result = shell.cp('resources/file1.txt', 'resources/ls/', t.context.tmp);
+  const result = shell.cp('test/resources/file1.txt', 'test/resources/ls/', t.context.tmp);
   t.is(result.code, 1);
   t.truthy(shell.error());
   t.falsy(fs.existsSync(`${t.context.tmp}/.hidden_file`)); // doesn't copy dir contents
@@ -443,8 +443,8 @@ test('no-recursive will copy regular files only', t => {
 });
 
 test('no-recursive will copy regular files only', t => {
-  const result = shell.cp('resources/file1.txt', 'resources/file2.txt', 'resources/cp',
-    'resources/ls/', t.context.tmp);
+  const result = shell.cp('test/resources/file1.txt', 'test/resources/file2.txt', 'test/resources/cp',
+    'test/resources/ls/', t.context.tmp);
 
   t.is(result.code, 1);
   t.truthy(shell.error());
@@ -458,28 +458,28 @@ test('no-recursive will copy regular files only', t => {
 
 test('-R implies -P', t => {
   utils.skipOnWin(t, () => {
-    shell.cp('-R', 'resources/cp/links/sym.lnk', t.context.tmp);
+    shell.cp('-R', 'test/resources/cp/links/sym.lnk', t.context.tmp);
     t.truthy(fs.lstatSync(`${t.context.tmp}/sym.lnk`).isSymbolicLink());
   });
 });
 
 test('using -P explicitly works', t => {
   utils.skipOnWin(t, () => {
-    shell.cp('-P', 'resources/cp/links/sym.lnk', t.context.tmp);
+    shell.cp('-P', 'test/resources/cp/links/sym.lnk', t.context.tmp);
     t.truthy(fs.lstatSync(`${t.context.tmp}/sym.lnk`).isSymbolicLink());
   });
 });
 
 test('using -PR on a link to a folder does not follow the link', t => {
   utils.skipOnWin(t, () => {
-    shell.cp('-PR', 'resources/cp/symFolder', t.context.tmp);
+    shell.cp('-PR', 'test/resources/cp/symFolder', t.context.tmp);
     t.truthy(fs.lstatSync(`${t.context.tmp}/symFolder`).isSymbolicLink());
   });
 });
 
 test('-L overrides -P for copying directory', t => {
   utils.skipOnWin(t, () => {
-    shell.cp('-LPR', 'resources/cp/symFolder', t.context.tmp);
+    shell.cp('-LPR', 'test/resources/cp/symFolder', t.context.tmp);
     t.falsy(fs.lstatSync(`${t.context.tmp}/symFolder`).isSymbolicLink());
     t.falsy(fs.lstatSync(`${t.context.tmp}/symFolder/sym.lnk`).isSymbolicLink());
   });
@@ -487,7 +487,7 @@ test('-L overrides -P for copying directory', t => {
 
 test('Recursive, copies entire directory with no symlinks and -L option does not cause change in behavior', t => {
   utils.skipOnWin(t, () => {
-    const result = shell.cp('-rL', 'resources/cp/dir_a', `${t.context.tmp}/dest`);
+    const result = shell.cp('-rL', 'test/resources/cp/dir_a', `${t.context.tmp}/dest`);
     t.falsy(shell.error());
     t.falsy(result.stderr);
     t.is(result.code, 0);
@@ -497,23 +497,23 @@ test('Recursive, copies entire directory with no symlinks and -L option does not
 
 test('-u flag won\'t overwrite newer files', t => {
   shell.touch(`${t.context.tmp}/file1.js`);
-  shell.cp('-u', 'resources/file1.js', t.context.tmp);
+  shell.cp('-u', 'test/resources/file1.js', t.context.tmp);
   t.falsy(shell.error());
-  t.not(shell.cat('resources/file1.js').toString(), shell.cat(`${t.context.tmp}/file1.js`).toString());
+  t.not(shell.cat('test/resources/file1.js').toString(), shell.cat(`${t.context.tmp}/file1.js`).toString());
 });
 
 test('-u flag does overwrite older files', t => {
   shell.touch({ '-d': new Date(10) }, `${t.context.tmp}/file1.js`); // really old file
-  shell.cp('-u', 'resources/file1.js', t.context.tmp);
+  shell.cp('-u', 'test/resources/file1.js', t.context.tmp);
   t.falsy(shell.error());
-  t.is(shell.cat('resources/file1.js').toString(), shell.cat(`${t.context.tmp}/file1.js`).toString());
+  t.is(shell.cat('test/resources/file1.js').toString(), shell.cat(`${t.context.tmp}/file1.js`).toString());
 });
 
 test('-u flag works even if it\'s not overwriting a file', t => {
   t.falsy(fs.existsSync(`${t.context.tmp}/file1.js`));
-  shell.cp('-u', 'resources/file1.js', t.context.tmp);
+  shell.cp('-u', 'test/resources/file1.js', t.context.tmp);
   t.falsy(shell.error());
-  t.is(shell.cat('resources/file1.js').toString(), shell.cat(`${t.context.tmp}/file1.js`).toString());
+  t.is(shell.cat('test/resources/file1.js').toString(), shell.cat(`${t.context.tmp}/file1.js`).toString());
 });
 
 test('-u flag works correctly recursively', t => {
@@ -536,34 +536,34 @@ test('-u flag works correctly recursively', t => {
 });
 
 test('using -R on a link to a folder *does* follow the link', t => {
-  shell.cp('-R', 'resources/cp/symFolder', t.context.tmp);
+  shell.cp('-R', 'test/resources/cp/symFolder', t.context.tmp);
   t.falsy(fs.lstatSync(`${t.context.tmp}/symFolder`).isSymbolicLink());
 });
 
 test('Without -R, -L is implied', t => {
-  shell.cp('resources/cp/links/sym.lnk', t.context.tmp);
+  shell.cp('test/resources/cp/links/sym.lnk', t.context.tmp);
   t.falsy(fs.lstatSync(`${t.context.tmp}/sym.lnk`).isSymbolicLink());
 });
 
 test('-L explicitly works', t => {
-  shell.cp('-L', 'resources/cp/links/sym.lnk', t.context.tmp);
+  shell.cp('-L', 'test/resources/cp/links/sym.lnk', t.context.tmp);
   t.falsy(fs.lstatSync(`${t.context.tmp}/sym.lnk`).isSymbolicLink());
 });
 
 test('using -LR does not imply -P', t => {
-  shell.cp('-LR', 'resources/cp/links/sym.lnk', t.context.tmp);
+  shell.cp('-LR', 'test/resources/cp/links/sym.lnk', t.context.tmp);
   t.falsy(fs.lstatSync(`${t.context.tmp}/sym.lnk`).isSymbolicLink());
 });
 
 test('using -LR also works recursively on directories containing links', t => {
-  shell.cp('-LR', 'resources/cp/links', t.context.tmp);
+  shell.cp('-LR', 'test/resources/cp/links', t.context.tmp);
   t.falsy(fs.lstatSync(`${t.context.tmp}/links/sym.lnk`).isSymbolicLink());
 });
 
 test('-L always overrides a -P', t => {
-  shell.cp('-LP', 'resources/cp/links/sym.lnk', t.context.tmp);
+  shell.cp('-LP', 'test/resources/cp/links/sym.lnk', t.context.tmp);
   t.falsy(fs.lstatSync(`${t.context.tmp}/sym.lnk`).isSymbolicLink());
-  shell.cp('-LPR', 'resources/cp/links/sym.lnk', t.context.tmp);
+  shell.cp('-LPR', 'test/resources/cp/links/sym.lnk', t.context.tmp);
   t.falsy(fs.lstatSync(`${t.context.tmp}/sym.lnk`).isSymbolicLink());
 });
 
@@ -623,7 +623,7 @@ test('cp -L follows symlinks', t => {
   utils.skipOnWinForEPERM(shell.ln.bind(shell, '-s', `${t.context.tmp}/0`, `${t.context.tmp}/symlinktest`), () => {
     shell.mkdir('-p', `${t.context.tmp}/sub`);
     shell.mkdir('-p', `${t.context.tmp}/new`);
-    shell.cp('-f', 'resources/file1.txt', `${t.context.tmp}/sub/file.txt`);
+    shell.cp('-f', 'test/resources/file1.txt', `${t.context.tmp}/sub/file.txt`);
     shell.cd(`${t.context.tmp}/sub`);
     shell.ln('-s', 'file.txt', 'foo.lnk');
     shell.ln('-s', 'file.txt', 'sym.lnk');
@@ -631,7 +631,7 @@ test('cp -L follows symlinks', t => {
     shell.cp('-L', 'sub/*', 'new/');
     shell.cd('new');
 
-    shell.cp('-f', '../../resources/file2.txt', 'file.txt');
+    shell.cp('-f', '../../test/resources/file2.txt', 'file.txt');
     t.is(shell.cat('file.txt').toString(), 'test2\n');
     // Ensure other files have not changed.
     t.is(shell.cat('foo.lnk').toString(), 'test1\n');
@@ -645,8 +645,8 @@ test('cp -L follows symlinks', t => {
 test('Test with recursive option and symlinks.', t => {
   utils.skipOnWinForEPERM(shell.ln.bind(shell, '-s', `${t.context.tmp}/0`, `${t.context.tmp}/symlinktest`), () => {
     shell.mkdir('-p', `${t.context.tmp}/sub/sub1`);
-    shell.cp('-f', 'resources/file1.txt', `${t.context.tmp}/sub/file.txt`);
-    shell.cp('-f', 'resources/file1.txt', `${t.context.tmp}/sub/sub1/file.txt`);
+    shell.cp('-f', 'test/resources/file1.txt', `${t.context.tmp}/sub/file.txt`);
+    shell.cp('-f', 'test/resources/file1.txt', `${t.context.tmp}/sub/sub1/file.txt`);
     shell.cd(`${t.context.tmp}/sub`);
     shell.ln('-s', 'file.txt', 'foo.lnk');
     shell.ln('-s', 'file.txt', 'sym.lnk');
@@ -665,7 +665,7 @@ test('Test with recursive option and symlinks.', t => {
     shell.cd('new');
 
     // Ensure copies of files are symlinks by updating file contents.
-    shell.cp('-f', '../../resources/file2.txt', 'file.txt');
+    shell.cp('-f', '../../test/resources/file2.txt', 'file.txt');
     t.is(shell.cat('file.txt').toString(), 'test2\n');
     // Ensure other files have not changed.
     t.is(shell.cat('foo.lnk').toString(), 'test1\n');
@@ -677,7 +677,7 @@ test('Test with recursive option and symlinks.', t => {
 
     // Ensure other files have not changed.
     shell.cd('sub1');
-    shell.cp('-f', '../../../resources/file2.txt', 'file.txt');
+    shell.cp('-f', '../../../test/resources/file2.txt', 'file.txt');
     t.is(shell.cat('file.txt').toString(), 'test2\n');
     t.is(shell.cat('foo.lnk').toString(), 'test1\n');
     t.is(shell.cat('sym.lnk').toString(), 'test1\n');
@@ -689,39 +689,39 @@ test('Test with recursive option and symlinks.', t => {
 });
 
 test('recursive, with a non-normalized path', t => {
-  const result = shell.cp('-R', 'resources/../resources/./cp', t.context.tmp);
+  const result = shell.cp('-R', 'test/resources/../resources/./cp', t.context.tmp);
   t.falsy(shell.error()); // crash test only
   t.falsy(result.stderr);
   t.is(result.code, 0);
 });
 
 test('copy file to same path', t => {
-  const result = shell.cp('resources/file1', 'resources/file1');
+  const result = shell.cp('test/resources/file1', 'test/resources/file1');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, "cp: 'resources/file1' and 'resources/file1' are the same file");
+  t.is(result.stderr, "cp: 'test/resources/file1' and 'test/resources/file1' are the same file");
 });
 
 test('copy file to same directory', t => {
-  const result = shell.cp('resources/file1', 'resources');
+  const result = shell.cp('test/resources/file1', 'test/resources');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, "cp: 'resources/file1' and 'resources/file1' are the same file");
+  t.is(result.stderr, "cp: 'test/resources/file1' and 'test/resources/file1' are the same file");
 });
 
 test('copy mutliple files to same location', t => {
-  const result = shell.cp('resources/file1', 'resources/file2', 'resources');
+  const result = shell.cp('test/resources/file1', 'test/resources/file2', 'test/resources');
   t.truthy(shell.error());
   t.is(result.code, 1);
   t.is(
     result.stderr,
-    "cp: 'resources/file1' and 'resources/file1' are the same file\n" +
-    "cp: 'resources/file2' and 'resources/file2' are the same file"
+    "cp: 'test/resources/file1' and 'test/resources/file1' are the same file\n" +
+    "cp: 'test/resources/file2' and 'test/resources/file2' are the same file"
   );
 });
 
 test('should not overwrite recently created files', t => {
-  const result = shell.cp('resources/file1', 'resources/cp/file1', t.context.tmp);
+  const result = shell.cp('test/resources/file1', 'test/resources/cp/file1', t.context.tmp);
   t.truthy(shell.error());
   t.is(result.code, 1);
 
@@ -729,13 +729,13 @@ test('should not overwrite recently created files', t => {
   t.is(shell.cat(`${t.context.tmp}/file1`).toString(), 'test1');
   t.is(
     result.stderr,
-    `cp: will not overwrite just-created '${t.context.tmp}/file1' with 'resources/cp/file1'`
+    `cp: will not overwrite just-created '${t.context.tmp}/file1' with 'test/resources/cp/file1'`
   );
 });
 
 
 test('should not overwrite recently created files (in recursive Mode)', t => {
-  const result = shell.cp('-R', 'resources/file1', 'resources/cp/file1', t.context.tmp);
+  const result = shell.cp('-R', 'test/resources/file1', 'test/resources/cp/file1', t.context.tmp);
   t.truthy(shell.error());
   t.is(result.code, 1);
 
@@ -743,12 +743,12 @@ test('should not overwrite recently created files (in recursive Mode)', t => {
   t.is(shell.cat(`${t.context.tmp}/file1`).toString(), 'test1');
   t.is(
     result.stderr,
-    `cp: will not overwrite just-created '${t.context.tmp}/file1' with 'resources/cp/file1'`
+    `cp: will not overwrite just-created '${t.context.tmp}/file1' with 'test/resources/cp/file1'`
   );
 });
 
 test('should not overwrite recently created files (not give error no-force mode)', t => {
-  const result = shell.cp('-n', 'resources/file1', 'resources/cp/file1', t.context.tmp);
+  const result = shell.cp('-n', 'test/resources/file1', 'test/resources/cp/file1', t.context.tmp);
   t.falsy(shell.error());
   t.is(result.code, 0);
 

--- a/test/dirs.js
+++ b/test/dirs.js
@@ -6,7 +6,7 @@ import shell from '..';
 
 test.beforeEach(() => {
   shell.config.resetForTesting();
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
 });
 
@@ -15,8 +15,8 @@ test.beforeEach(() => {
 //
 
 const trail = [
-  path.resolve(path.resolve(), 'resources/pushd/a'),
-  path.resolve(path.resolve(), 'resources/pushd'),
+  path.resolve(path.resolve(), 'test/resources/pushd/a'),
+  path.resolve(path.resolve(), 'test/resources/pushd'),
   path.resolve(),
 ];
 

--- a/test/exec.js
+++ b/test/exec.js
@@ -86,7 +86,7 @@ test('check exit code', t => {
 });
 
 test('interaction with cd', t => {
-  shell.cd('resources/external');
+  shell.cd('test/resources/external');
   const result = shell.exec(`${JSON.stringify(shell.config.execPath)} node_script.js`);
   t.falsy(shell.error());
   t.is(result.code, 0);
@@ -118,12 +118,12 @@ test('set maxBuffer (very small)', t => {
 });
 
 test('set timeout option', t => {
-  const result = shell.exec(`${JSON.stringify(shell.config.execPath)} resources/exec/slow.js 100`); // default timeout is ok
+  const result = shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`); // default timeout is ok
   t.falsy(shell.error());
   t.is(result.code, 0);
   if (process.version >= 'v0.11') {
     // this option doesn't work on v0.10
-    shell.exec(`${JSON.stringify(shell.config.execPath)} resources/exec/slow.js 100`, { timeout: 10 }); // times out
+    shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`, { timeout: 10 }); // times out
   }
   t.truthy(shell.error());
 });

--- a/test/find.js
+++ b/test/find.js
@@ -24,7 +24,7 @@ test('no args', t => {
 //
 
 test('current path', t => {
-  shell.cd('resources/find');
+  shell.cd('test/resources/find');
   const result = shell.find('.');
   t.falsy(shell.error());
   t.is(result.code, 0);
@@ -35,34 +35,34 @@ test('current path', t => {
 });
 
 test('simple path', t => {
-  const result = shell.find('resources/find');
+  const result = shell.find('test/resources/find');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('resources/find/.hidden') > -1);
-  t.truthy(result.indexOf('resources/find/dir1/dir11/a_dir11') > -1);
+  t.truthy(result.indexOf('test/resources/find/.hidden') > -1);
+  t.truthy(result.indexOf('test/resources/find/dir1/dir11/a_dir11') > -1);
   t.is(result.length, 11);
 });
 
 test('multiple paths - comma', t => {
-  const result = shell.find('resources/find/dir1', 'resources/find/dir2');
+  const result = shell.find('test/resources/find/dir1', 'test/resources/find/dir2');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('resources/find/dir1/dir11/a_dir11') > -1);
-  t.truthy(result.indexOf('resources/find/dir2/a_dir1') > -1);
+  t.truthy(result.indexOf('test/resources/find/dir1/dir11/a_dir11') > -1);
+  t.truthy(result.indexOf('test/resources/find/dir2/a_dir1') > -1);
   t.is(result.length, 6);
 });
 
 test('multiple paths - array', t => {
-  const result = shell.find(['resources/find/dir1', 'resources/find/dir2']);
+  const result = shell.find(['test/resources/find/dir1', 'test/resources/find/dir2']);
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('resources/find/dir1/dir11/a_dir11') > -1);
-  t.truthy(result.indexOf('resources/find/dir2/a_dir1') > -1);
+  t.truthy(result.indexOf('test/resources/find/dir1/dir11/a_dir11') > -1);
+  t.truthy(result.indexOf('test/resources/find/dir2/a_dir1') > -1);
   t.is(result.length, 6);
 });
 
 test('nonexistent path', t => {
-  const result = shell.find('resources/find/nonexistent');
-  t.is(shell.error(), 'find: no such file or directory: resources/find/nonexistent');
+  const result = shell.find('test/resources/find/nonexistent');
+  t.is(shell.error(), 'find: no such file or directory: test/resources/find/nonexistent');
   t.is(result.code, 1);
 });

--- a/test/global.js
+++ b/test/global.js
@@ -26,14 +26,14 @@ test('env is exported', t => {
 });
 
 test('cat', t => {
-  const result = cat('resources/cat/file1');
+  const result = cat('test/resources/cat/file1');
   t.falsy(error());
   t.is(result.code, 0);
   t.is(result.toString(), 'test1\n');
 });
 
 test('rm', t => {
-  cp('-f', 'resources/file1', `${t.context.tmp}/file1`);
+  cp('-f', 'test/resources/file1', `${t.context.tmp}/file1`);
   t.truthy(fs.existsSync(`${t.context.tmp}/file1`));
   const result = rm(`${t.context.tmp}/file1`);
   t.falsy(error());

--- a/test/grep.js
+++ b/test/grep.js
@@ -8,7 +8,7 @@ import utils from './utils/utils';
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
   shell.config.resetForTesting();
-  shell.cp('-r', 'resources', t.context.tmp);
+  shell.cp('-r', 'test/resources', t.context.tmp);
 });
 
 test.afterEach.always(t => {
@@ -54,82 +54,82 @@ test('if at least one file is missing, this should be an error', t => {
 //
 
 test('basic', t => {
-  const result = shell.grep('line', 'resources/a.txt');
+  const result = shell.grep('line', 'test/resources/a.txt');
   t.falsy(shell.error());
   t.is(result.split('\n').length - 1, 4);
 });
 
 test('-v option', t => {
-  const result = shell.grep('-v', 'line', 'resources/a.txt');
+  const result = shell.grep('-v', 'line', 'test/resources/a.txt');
   t.falsy(shell.error());
   t.is(result.split('\n').length - 1, 8);
 });
 
 test('matches one line', t => {
-  const result = shell.grep('line one', 'resources/a.txt');
+  const result = shell.grep('line one', 'test/resources/a.txt');
   t.falsy(shell.error());
   t.is(result.toString(), 'This is line one\n');
 });
 
 test('multiple files', t => {
-  const result = shell.grep(/test/, 'resources/file1.txt',
-    'resources/file2.txt');
+  const result = shell.grep(/test/, 'test/resources/file1.txt',
+    'test/resources/file2.txt');
   t.falsy(shell.error());
   t.is(result.toString(), 'test1\ntest2\n');
 });
 
 test('multiple files, array syntax', t => {
-  const result = shell.grep(/test/, ['resources/file1.txt',
-    'resources/file2.txt']);
+  const result = shell.grep(/test/, ['test/resources/file1.txt',
+    'test/resources/file2.txt']);
   t.falsy(shell.error());
   t.is(result.toString(), 'test1\ntest2\n');
 });
 
 test('multiple files, glob syntax, * for file name', t => {
-  const result = shell.grep(/test/, 'resources/file*.txt');
+  const result = shell.grep(/test/, 'test/resources/file*.txt');
   t.falsy(shell.error());
   t.truthy(result.toString(), 'test1\ntest2\n');
 });
 
 test('multiple files, glob syntax, * for directory name', t => {
-  const result = shell.grep(/test/, 'r*/file*.txt');
+  const result = shell.grep(/test/, 'test/r*/file*.txt');
   t.falsy(shell.error());
   t.is(result.toString(), 'test1\ntest2\n');
 });
 
 test('multiple files, double-star glob', t => {
-  const result = shell.grep(/test/, 'resources/**/file*.js');
+  const result = shell.grep(/test/, 'test/resources/**/file*.js');
   t.falsy(shell.error());
   t.is(result.toString(), 'test\ntest\ntest\ntest\n');
 });
 
 test('one file, * in regex', t => {
-  const result = shell.grep(/alpha*beta/, 'resources/grep/file');
+  const result = shell.grep(/alpha*beta/, 'test/resources/grep/file');
   t.falsy(shell.error());
   t.is(result.toString(), 'alphaaaaaaabeta\nalphbeta\n');
 });
 
 test('one file, * in string-regex', t => {
-  const result = shell.grep('alpha*beta', 'resources/grep/file');
+  const result = shell.grep('alpha*beta', 'test/resources/grep/file');
   t.falsy(shell.error());
   t.is(result.toString(), 'alphaaaaaaabeta\nalphbeta\n');
 });
 
 test('one file, * in regex, make sure * is not globbed', t => {
-  const result = shell.grep(/l*\.js/, 'resources/grep/file');
+  const result = shell.grep(/l*\.js/, 'test/resources/grep/file');
   t.falsy(shell.error());
   t.is(result.toString(), 'this line ends in.js\nlllllllllllllllll.js\n');
 });
 
 test('one file, * in string-regex, make sure * is not globbed', t => {
-  const result = shell.grep('l*\\.js', 'resources/grep/file');
+  const result = shell.grep('l*\\.js', 'test/resources/grep/file');
   t.falsy(shell.error());
   t.is(result.toString(), 'this line ends in.js\nlllllllllllllllll.js\n');
 });
 
 test('-l option', t => {
-  const result = shell.grep('-l', 'test1', 'resources/file1', 'resources/file2',
-    'resources/file1.txt');
+  const result = shell.grep('-l', 'test1', 'test/resources/file1', 'test/resources/file2',
+    'test/resources/file1.txt');
   t.falsy(shell.error());
   t.truthy(result.match(/file1(\n|$)/));
   t.truthy(result.match(/file1.txt/));

--- a/test/head.js
+++ b/test/head.js
@@ -25,11 +25,11 @@ test('file does not exist', t => {
 });
 
 test('directory', t => {
-  t.truthy(fs.statSync('resources/').isDirectory()); // sanity check
-  const result = shell.head('resources/');
+  t.truthy(fs.statSync('test/resources/').isDirectory()); // sanity check
+  const result = shell.head('test/resources/');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, "head: error reading 'resources/': Is a directory");
+  t.is(result.stderr, "head: error reading 'test/resources/': Is a directory");
 });
 
 //
@@ -46,15 +46,15 @@ const topOfFile2 = ['file2 1', 'file2 2', 'file2 3', 'file2 4', 'file2 5',
                     'file2 16', 'file2 17', 'file2 18', 'file2 19', 'file2 20'];
 
 test('simple', t => {
-  const result = shell.head('resources/head/file1.txt');
+  const result = shell.head('test/resources/head/file1.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), topOfFile1.slice(0, 10).join('\n') + '\n');
 });
 
 test('multiple files', t => {
-  const result = shell.head('resources/head/file2.txt',
-    'resources/head/file1.txt');
+  const result = shell.head('test/resources/head/file2.txt',
+    'test/resources/head/file1.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), topOfFile2
@@ -64,8 +64,8 @@ test('multiple files', t => {
 });
 
 test('multiple files, array syntax', t => {
-  const result = shell.head(['resources/head/file2.txt',
-    'resources/head/file1.txt']);
+  const result = shell.head(['test/resources/head/file2.txt',
+    'test/resources/head/file1.txt']);
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), topOfFile2
@@ -75,22 +75,22 @@ test('multiple files, array syntax', t => {
 });
 
 test('reading more lines than are in the file (no trailing newline)', t => {
-  const result = shell.head('resources/file2', 'resources/file1');
+  const result = shell.head('test/resources/file2', 'test/resources/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), 'test2\ntest1'); // these files only have one line (no \n)
 });
 
 test('reading more lines than are in the file (with trailing newline)', t => {
-  const result = shell.head('resources/head/shortfile2',
-    'resources/head/shortfile1');
+  const result = shell.head('test/resources/head/shortfile2',
+    'test/resources/head/shortfile1');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), 'short2\nshort1\n'); // these files only have one line (with \n)
 });
 
 test('Globbed file', t => {
-  const result = shell.head('resources/head/file?.txt');
+  const result = shell.head('test/resources/head/file?.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), topOfFile1
@@ -100,8 +100,8 @@ test('Globbed file', t => {
 });
 
 test('With `\'-n\' <num>` option', t => {
-  const result = shell.head('-n', 4, 'resources/head/file2.txt',
-    'resources/head/file1.txt');
+  const result = shell.head('-n', 4, 'test/resources/head/file2.txt',
+    'test/resources/head/file1.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), topOfFile2
@@ -111,8 +111,8 @@ test('With `\'-n\' <num>` option', t => {
 });
 
 test('With `{\'-n\': <num>}` option', t => {
-  const result = shell.head({ '-n': 4 }, 'resources/head/file2.txt',
-    'resources/head/file1.txt');
+  const result = shell.head({ '-n': 4 }, 'test/resources/head/file2.txt',
+    'test/resources/head/file1.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), topOfFile2
@@ -122,14 +122,14 @@ test('With `{\'-n\': <num>}` option', t => {
 });
 
 test('negative values (-num) are the same as (numLines - num)', t => {
-  const result = shell.head('-n', -46, 'resources/head/file1.txt');
+  const result = shell.head('-n', -46, 'test/resources/head/file1.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), 'file1 1\nfile1 2\nfile1 3\nfile1 4\n');
 });
 
 test('right-hand side of a pipe', t => {
-  const result = shell.cat('resources/head/file1.txt').head();
+  const result = shell.cat('test/resources/head/file1.txt').head();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), topOfFile1.slice(0, 10).join('\n') + '\n');

--- a/test/ln.js
+++ b/test/ln.js
@@ -11,7 +11,7 @@ const CWD = process.cwd();
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
   shell.config.resetForTesting();
-  shell.cp('-r', 'resources', t.context.tmp);
+  shell.cp('-r', 'test/resources', t.context.tmp);
   process.chdir(CWD);
 });
 

--- a/test/ls.js
+++ b/test/ls.js
@@ -48,7 +48,7 @@ test('root directory', t => {
 });
 
 test('no args provides the correct result', t => {
-  shell.cd('resources/ls');
+  shell.cd('test/resources/ls');
   const result = shell.ls();
   t.falsy(shell.error());
   t.is(result.code, 0);
@@ -62,7 +62,7 @@ test('no args provides the correct result', t => {
 });
 
 test('simple arg', t => {
-  const result = shell.ls('resources/ls');
+  const result = shell.ls('test/resources/ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.truthy(result.indexOf('file1') > -1);
@@ -75,7 +75,7 @@ test('simple arg', t => {
 });
 
 test('simple arg, with a trailing slash', t => {
-  const result = shell.ls('resources/ls/');
+  const result = shell.ls('test/resources/ls/');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.truthy(result.indexOf('file1') > -1);
@@ -88,7 +88,7 @@ test('simple arg, with a trailing slash', t => {
 });
 
 test('no args, -A option', t => {
-  shell.cd('resources/ls');
+  shell.cd('test/resources/ls');
   const result = shell.ls('-A');
   t.falsy(shell.error());
   t.is(result.code, 0);
@@ -104,7 +104,7 @@ test('no args, -A option', t => {
 });
 
 test('no args, deprecated -a option', t => {
-  shell.cd('resources/ls');
+  shell.cd('test/resources/ls');
   const result = shell.ls('-a'); // (deprecated) backwards compatibility test
   t.falsy(shell.error());
   t.is(result.code, 0);
@@ -120,148 +120,148 @@ test('no args, deprecated -a option', t => {
 });
 
 test('wildcard, very simple', t => {
-  const result = shell.ls('resources/cat/*');
+  const result = shell.ls('test/resources/cat/*');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('resources/cat/file1') > -1);
-  t.truthy(result.indexOf('resources/cat/file2') > -1);
+  t.truthy(result.indexOf('test/resources/cat/file1') > -1);
+  t.truthy(result.indexOf('test/resources/cat/file2') > -1);
   t.is(result.length, 2);
 });
 
 test('wildcard, simple', t => {
-  const result = shell.ls('resources/ls/*');
+  const result = shell.ls('test/resources/ls/*');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('resources/ls/file1') > -1);
-  t.truthy(result.indexOf('resources/ls/file2') > -1);
-  t.truthy(result.indexOf('resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('resources/ls/file2.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
   t.truthy(
-    result.indexOf('resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
+    result.indexOf('test/resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
   );
-  t.is(result.indexOf('resources/ls/a_dir'), -1); // this shouldn't be there
+  t.is(result.indexOf('test/resources/ls/a_dir'), -1); // this shouldn't be there
   t.truthy(result.indexOf('nada') > -1);
   t.truthy(result.indexOf('b_dir') > -1);
   t.is(result.length, 7);
 });
 
 test('wildcard, simple, with -d', t => {
-  const result = shell.ls('-d', 'resources/ls/*');
+  const result = shell.ls('-d', 'test/resources/ls/*');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('resources/ls/file1') > -1);
-  t.truthy(result.indexOf('resources/ls/file2') > -1);
-  t.truthy(result.indexOf('resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('resources/ls/file2.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
   t.truthy(
-    result.indexOf('resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
+    result.indexOf('test/resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
   );
-  t.truthy(result.indexOf('resources/ls/a_dir') > -1);
+  t.truthy(result.indexOf('test/resources/ls/a_dir') > -1);
   t.is(result.length, 6);
 });
 
 test('wildcard, hidden only', t => {
-  const result = shell.ls('-d', 'resources/ls/.*');
+  const result = shell.ls('-d', 'test/resources/ls/.*');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('resources/ls/.hidden_file') > -1);
-  t.truthy(result.indexOf('resources/ls/.hidden_dir') > -1);
+  t.truthy(result.indexOf('test/resources/ls/.hidden_file') > -1);
+  t.truthy(result.indexOf('test/resources/ls/.hidden_dir') > -1);
   t.is(result.length, 2);
 });
 
 test('wildcard, mid-file', t => {
-  const result = shell.ls('resources/ls/f*le*');
+  const result = shell.ls('test/resources/ls/f*le*');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 5);
-  t.truthy(result.indexOf('resources/ls/file1') > -1);
-  t.truthy(result.indexOf('resources/ls/file2') > -1);
-  t.truthy(result.indexOf('resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('resources/ls/file2.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
   t.truthy(
-    result.indexOf('resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
+    result.indexOf('test/resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
   );
 });
 
 test('wildcard, mid-file with dot (should escape dot for regex)', t => {
-  const result = shell.ls('resources/ls/f*le*.js');
+  const result = shell.ls('test/resources/ls/f*le*.js');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 2);
-  t.truthy(result.indexOf('resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('resources/ls/file2.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
 });
 
 test('one file that exists, one that doesn\'t', t => {
-  const result = shell.ls('resources/ls/file1.js', 'resources/ls/thisdoesntexist');
+  const result = shell.ls('test/resources/ls/file1.js', 'test/resources/ls/thisdoesntexist');
   t.truthy(shell.error());
   t.is(result.code, 2);
   t.is(result.length, 1);
-  t.truthy(result.indexOf('resources/ls/file1.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
 });
 
 test('one file that exists, one that doesn\'t (other order)', t => {
-  const result = shell.ls('resources/ls/thisdoesntexist', 'resources/ls/file1.js');
+  const result = shell.ls('test/resources/ls/thisdoesntexist', 'test/resources/ls/file1.js');
   t.truthy(shell.error());
   t.is(result.code, 2);
   t.is(result.length, 1);
-  t.truthy(result.indexOf('resources/ls/file1.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
 });
 
 test('wildcard, should not do partial matches', t => {
-  const result = shell.ls('resources/ls/*.j'); // shouldn't get .js
+  const result = shell.ls('test/resources/ls/*.j'); // shouldn't get .js
   t.truthy(shell.error());
   t.is(result.code, 2);
   t.is(result.length, 0);
 });
 
 test('wildcard, all files with extension', t => {
-  const result = shell.ls('resources/ls/*.*');
+  const result = shell.ls('test/resources/ls/*.*');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 3);
-  t.truthy(result.indexOf('resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('resources/ls/file2.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
   t.truthy(
-    result.indexOf('resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
+    result.indexOf('test/resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
   );
 });
 
 test('wildcard, with additional path', t => {
-  const result = shell.ls('resources/ls/f*le*.js', 'resources/ls/a_dir');
+  const result = shell.ls('test/resources/ls/f*le*.js', 'test/resources/ls/a_dir');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 4);
-  t.truthy(result.indexOf('resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('resources/ls/file2.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
   t.truthy(result.indexOf('b_dir') > -1); // no wildcard == no path prefix
   t.truthy(result.indexOf('nada') > -1); // no wildcard == no path prefix
 });
 
 test('wildcard for both paths', t => {
-  const result = shell.ls('resources/ls/f*le*.js', 'resources/ls/a_dir/*');
+  const result = shell.ls('test/resources/ls/f*le*.js', 'test/resources/ls/a_dir/*');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 4);
-  t.truthy(result.indexOf('resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('resources/ls/file2.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
   t.truthy(result.indexOf('z') > -1);
-  t.truthy(result.indexOf('resources/ls/a_dir/nada') > -1);
+  t.truthy(result.indexOf('test/resources/ls/a_dir/nada') > -1);
 });
 
 test('wildcard for both paths, array', t => {
-  const result = shell.ls(['resources/ls/f*le*.js', 'resources/ls/a_dir/*']);
+  const result = shell.ls(['test/resources/ls/f*le*.js', 'test/resources/ls/a_dir/*']);
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 4);
-  t.truthy(result.indexOf('resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('resources/ls/file2.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
   t.truthy(result.indexOf('z') > -1);
-  t.truthy(result.indexOf('resources/ls/a_dir/nada') > -1);
+  t.truthy(result.indexOf('test/resources/ls/a_dir/nada') > -1);
 });
 
 test('recursive, no path', t => {
-  shell.cd('resources/ls');
+  shell.cd('test/resources/ls');
   const result = shell.ls('-R');
   t.falsy(shell.error());
   t.is(result.code, 0);
@@ -272,7 +272,7 @@ test('recursive, no path', t => {
 });
 
 test('recursive, path given', t => {
-  const result = shell.ls('-R', 'resources/ls');
+  const result = shell.ls('-R', 'test/resources/ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.truthy(result.indexOf('a_dir') > -1);
@@ -282,7 +282,7 @@ test('recursive, path given', t => {
 });
 
 test('-RA flag, path given', t => {
-  const result = shell.ls('-RA', 'resources/ls');
+  const result = shell.ls('-RA', 'test/resources/ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.truthy(result.indexOf('a_dir') > -1);
@@ -293,7 +293,7 @@ test('-RA flag, path given', t => {
 });
 
 test('-RA flag, symlinks are not followed', t => {
-  const result = shell.ls('-RA', 'resources/rm');
+  const result = shell.ls('-RA', 'test/resources/rm');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.truthy(result.indexOf('a_dir') > -1);
@@ -306,7 +306,7 @@ test('-RA flag, symlinks are not followed', t => {
 
 test('-RAL flag, follows symlinks', t => {
   utils.skipOnWin(t, () => {
-    const result = shell.ls('-RAL', 'resources/rm');
+    const result = shell.ls('-RAL', 'test/resources/rm');
     t.falsy(shell.error());
     t.is(result.code, 0);
     t.truthy(result.indexOf('a_dir') > -1);
@@ -320,7 +320,7 @@ test('-RAL flag, follows symlinks', t => {
 
 test('-L flag, path is symlink', t => {
   utils.skipOnWin(t, () => {
-    const result = shell.ls('-L', 'resources/rm/link_to_a_dir');
+    const result = shell.ls('-L', 'test/resources/rm/link_to_a_dir');
     t.falsy(shell.error());
     t.is(result.code, 0);
     t.truthy(result.indexOf('a_file') > -1);
@@ -329,52 +329,52 @@ test('-L flag, path is symlink', t => {
 });
 
 test('-Rd works like -d', t => {
-  const result = shell.ls('-Rd', 'resources/ls');
+  const result = shell.ls('-Rd', 'test/resources/ls');
   t.falsy(shell.error());
   t.is(result.length, 1);
 });
 
 test('directory option, single arg', t => {
-  const result = shell.ls('-d', 'resources/ls');
+  const result = shell.ls('-d', 'test/resources/ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 1);
 });
 
 test('directory option, single arg with trailing \'/\'', t => {
-  const result = shell.ls('-d', 'resources/ls/');
+  const result = shell.ls('-d', 'test/resources/ls/');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 1);
 });
 
 test('directory option, multiple args', t => {
-  const result = shell.ls('-d', 'resources/ls/a_dir', 'resources/ls/file1');
+  const result = shell.ls('-d', 'test/resources/ls/a_dir', 'test/resources/ls/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('resources/ls/a_dir') > -1);
-  t.truthy(result.indexOf('resources/ls/file1') > -1);
+  t.truthy(result.indexOf('test/resources/ls/a_dir') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1') > -1);
   t.is(result.length, 2);
 });
 
 test('directory option, globbed arg', t => {
-  const result = shell.ls('-d', 'resources/ls/*');
+  const result = shell.ls('-d', 'test/resources/ls/*');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('resources/ls/a_dir') > -1);
-  t.truthy(result.indexOf('resources/ls/file1') > -1);
-  t.truthy(result.indexOf('resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('resources/ls/file2') > -1);
-  t.truthy(result.indexOf('resources/ls/file2.js') > -1);
-  t.truthy(result.indexOf('resources/ls/file2') > -1);
+  t.truthy(result.indexOf('test/resources/ls/a_dir') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
+  t.truthy(result.indexOf('test/resources/ls/file2') > -1);
   t.truthy(
-    result.indexOf('resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
+    result.indexOf('test/resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
   );
   t.is(result.length, 6);
 });
 
 test('long option, single file', t => {
-  let result = shell.ls('-l', 'resources/ls/file1');
+  let result = shell.ls('-l', 'test/resources/ls/file1');
   t.is(result.length, 1);
   result = result[0];
   t.falsy(shell.error());
@@ -393,7 +393,7 @@ test('long option, single file', t => {
 });
 
 test('long option, glob files', t => {
-  let result = shell.ls('-l', 'resources/ls/f*le1');
+  let result = shell.ls('-l', 'test/resources/ls/f*le1');
   t.is(result.length, 1);
   result = result[0];
   t.falsy(shell.error());
@@ -412,7 +412,7 @@ test('long option, glob files', t => {
 });
 
 test('long option, directory', t => {
-  let result = shell.ls('-l', 'resources/ls');
+  let result = shell.ls('-l', 'test/resources/ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
   const idx = result.map(r => r.name).indexOf('file1');
@@ -434,7 +434,7 @@ test('long option, directory', t => {
 });
 
 test('long option, directory, recursive (and windows converts slashes)', t => {
-  let result = shell.ls('-lR', 'resources/ls/');
+  let result = shell.ls('-lR', 'test/resources/ls/');
   t.falsy(shell.error());
   t.is(result.code, 0);
   const idx = result.map(r => r.name).indexOf('a_dir/b_dir');
@@ -442,7 +442,7 @@ test('long option, directory, recursive (and windows converts slashes)', t => {
   t.truthy(idx >= 0);
   result = result[idx];
   t.is(result.name, result.name);
-  t.truthy(fs.statSync('resources/ls/a_dir/b_dir').isDirectory());
+  t.truthy(fs.statSync('test/resources/ls/a_dir/b_dir').isDirectory());
   t.is(typeof result.nlink, 'number'); // This can vary between the local machine and travis
   t.is(typeof result.size, 'number'); // This can vary between different file systems
   t.truthy(result.mode); // check that these keys exist
@@ -457,15 +457,15 @@ test('long option, directory, recursive (and windows converts slashes)', t => {
 });
 
 test('still lists broken links', t => {
-  const result = shell.ls('resources/badlink');
+  const result = shell.ls('test/resources/badlink');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('resources/badlink') > -1);
+  t.truthy(result.indexOf('test/resources/badlink') > -1);
   t.is(result.length, 1);
 });
 
 test('Test new ShellString-like attributes', t => {
-  const result = shell.ls('resources/ls');
+  const result = shell.ls('test/resources/ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.truthy(result.stdout.indexOf('file1') > -1);
@@ -496,13 +496,13 @@ test('No trailing newline for ls() on empty directories', t => {
 
 test('Check stderr field', t => {
   t.falsy(fs.existsSync('/asdfasdf')); // sanity check
-  const result = shell.ls('resources/ls/file1', '/asdfasdf');
+  const result = shell.ls('test/resources/ls/file1', '/asdfasdf');
   t.truthy(shell.error());
   t.is('ls: no such file or directory: /asdfasdf', result.stderr);
 });
 
 test('non-normalized paths are still ok with -R', t => {
-  const result = shell.ls('-R', 'resources/./ls/../ls');
+  const result = shell.ls('-R', 'test/resources/./ls/../ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.truthy(result.indexOf('a_dir') > -1);

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -37,12 +37,12 @@ test('dir already exists', t => {
 });
 
 test('Can\'t overwrite a broken link', t => {
-  const mtime = fs.lstatSync('resources/badlink').mtime.toString();
-  const result = shell.mkdir('resources/badlink');
+  const mtime = fs.lstatSync('test/resources/badlink').mtime.toString();
+  const result = shell.mkdir('test/resources/badlink');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, 'mkdir: path already exists: resources/badlink');
-  t.is(fs.lstatSync('resources/badlink').mtime.toString(), mtime); // didn't mess with file
+  t.is(result.stderr, 'mkdir: path already exists: test/resources/badlink');
+  t.is(fs.lstatSync('test/resources/badlink').mtime.toString(), mtime); // didn't mess with file
 });
 
 test('root path does not exist', t => {
@@ -56,31 +56,31 @@ test('root path does not exist', t => {
 });
 
 test('try to overwrite file', t => {
-  t.truthy(fs.statSync('resources/file1').isFile());
-  const result = shell.mkdir('resources/file1');
+  t.truthy(fs.statSync('test/resources/file1').isFile());
+  const result = shell.mkdir('test/resources/file1');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, 'mkdir: path already exists: resources/file1');
-  t.truthy(fs.statSync('resources/file1').isFile());
+  t.is(result.stderr, 'mkdir: path already exists: test/resources/file1');
+  t.truthy(fs.statSync('test/resources/file1').isFile());
 });
 
 test('try to overwrite file, with -p', t => {
-  t.truthy(fs.statSync('resources/file1').isFile());
-  const result = shell.mkdir('-p', 'resources/file1');
+  t.truthy(fs.statSync('test/resources/file1').isFile());
+  const result = shell.mkdir('-p', 'test/resources/file1');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, 'mkdir: cannot create directory resources/file1: File exists');
-  t.truthy(fs.statSync('resources/file1').isFile());
+  t.is(result.stderr, 'mkdir: cannot create directory test/resources/file1: File exists');
+  t.truthy(fs.statSync('test/resources/file1').isFile());
 });
 
 test('try to make a subdirectory of a file', t => {
-  t.truthy(fs.statSync('resources/file1').isFile());
-  const result = shell.mkdir('resources/file1/subdir');
+  t.truthy(fs.statSync('test/resources/file1').isFile());
+  const result = shell.mkdir('test/resources/file1/subdir');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, 'mkdir: cannot create directory resources/file1/subdir: Not a directory');
-  t.truthy(fs.statSync('resources/file1').isFile());
-  t.falsy(fs.existsSync('resources/file1/subdir'));
+  t.is(result.stderr, 'mkdir: cannot create directory test/resources/file1/subdir: Not a directory');
+  t.truthy(fs.statSync('test/resources/file1').isFile());
+  t.falsy(fs.existsSync('test/resources/file1/subdir'));
 });
 
 test('Check for invalid permissions', t => {

--- a/test/mv.js
+++ b/test/mv.js
@@ -11,7 +11,7 @@ const numLines = utils.numLines;
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
   shell.config.resetForTesting();
-  shell.cp('-r', 'resources', t.context.tmp);
+  shell.cp('-r', 'test/resources', t.context.tmp);
   shell.cd(t.context.tmp);
 });
 

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -10,7 +10,7 @@ shell.config.silent = true;
 
 test('commands like `rm` cannot be on the right side of pipes', t => {
   t.is(shell.ls('.').rm, undefined);
-  t.is(shell.cat('resources/file1.txt').rm, undefined);
+  t.is(shell.cat('test/resources/file1.txt').rm, undefined);
 });
 
 //
@@ -19,33 +19,33 @@ test('commands like `rm` cannot be on the right side of pipes', t => {
 
 test('piping to cat() should return roughly the same thing', t => {
   t.is(
-    shell.cat('resources/file1.txt').cat().toString(),
-    shell.cat('resources/file1.txt').toString()
+    shell.cat('test/resources/file1.txt').cat().toString(),
+    shell.cat('test/resources/file1.txt').toString()
   );
 });
 
 test('piping ls() into cat() converts to a string-like object', t => {
-  t.is(shell.ls('resources/').cat().toString(), shell.ls('resources/').stdout);
+  t.is(shell.ls('test/resources/').cat().toString(), shell.ls('test/resources/').stdout);
 });
 
 test('grep works in a pipe', t => {
-  const result = shell.ls('resources/').grep('file1');
+  const result = shell.ls('test/resources/').grep('file1');
   t.is(result.toString(), 'file1\nfile1.js\nfile1.txt\n');
 });
 
 test('multiple pipes work', t => {
-  const result = shell.ls('resources/').cat().grep('file1');
+  const result = shell.ls('test/resources/').cat().grep('file1');
   t.is(result.toString(), 'file1\nfile1.js\nfile1.txt\n');
 });
 
 test('Equivalent to a simple grep() test case', t => {
-  const result = shell.cat('resources/grep/file').grep(/alpha*beta/);
+  const result = shell.cat('test/resources/grep/file').grep(/alpha*beta/);
   t.falsy(shell.error());
   t.is(result.toString(), 'alphaaaaaaabeta\nalphbeta\n');
 });
 
 test('Equivalent to a simple sed() test case', t => {
-  const result = shell.cat('resources/grep/file').sed(/l*\.js/, '');
+  const result = shell.cat('test/resources/grep/file').sed(/l*\.js/, '');
   t.falsy(shell.error());
   t.is(
     result.toString(),
@@ -54,19 +54,19 @@ test('Equivalent to a simple sed() test case', t => {
 });
 
 test('Sort a file by frequency of each line', t => {
-  const result = shell.sort('resources/uniq/pipe').uniq('-c').sort('-n');
+  const result = shell.sort('test/resources/uniq/pipe').uniq('-c').sort('-n');
   t.falsy(shell.error());
-  t.is(result.toString(), shell.cat('resources/uniq/pipeSorted').toString());
+  t.is(result.toString(), shell.cat('test/resources/uniq/pipeSorted').toString());
 });
 
 test('Synchronous exec', t => {
-  const result = shell.cat('resources/grep/file').exec('shx grep "alpha*beta"');
+  const result = shell.cat('test/resources/grep/file').exec('shx grep "alpha*beta"');
   t.falsy(shell.error());
   t.is(result.toString(), 'alphaaaaaaabeta\nalphbeta\n');
 });
 
 test.cb('Asynchronous exec', t => {
-  shell.cat('resources/grep/file').exec('shx grep "alpha*beta"', (code, stdout) => {
+  shell.cat('test/resources/grep/file').exec('shx grep "alpha*beta"', (code, stdout) => {
     t.is(code, 0);
     t.is(stdout, 'alphaaaaaaabeta\nalphbeta\n');
     t.end();

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -95,9 +95,9 @@ test('The command parses options', t => {
 });
 
 test('The command supports globbing by default', t => {
-  shell.foo('-f', 're*u?ces');
+  shell.foo('-f', 'test/re*u?ces');
   t.is(data, 12);
-  t.is(fname, 'resources');
+  t.is(fname, 'test/resources');
 });
 
 test('Plugins are also compatible with shelljs/global', t => {

--- a/test/popd.js
+++ b/test/popd.js
@@ -26,7 +26,7 @@ test.after.always(() => {
 //
 
 test('basic usage', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   const trail = shell.popd();
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
@@ -34,33 +34,33 @@ test('basic usage', t => {
 });
 
 test('two directories on the stack', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   const trail = shell.popd();
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
   ]);
 });
 
 test('three directories on the stack', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('b');
   shell.pushd('c');
   const trail = shell.popd();
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd/b'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
   ]);
 });
 
 test('Valid by index', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   const trail = shell.popd('+0');
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
@@ -68,23 +68,23 @@ test('Valid by index', t => {
 });
 
 test('Using +1 option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   const trail = shell.popd('+1');
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
-  t.deepEqual(trail, [path.resolve(rootDir, 'resources/pushd')]);
+  t.deepEqual(trail, [path.resolve(rootDir, 'test/resources/pushd')]);
 });
 
 test('Using -0 option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   const trail = shell.popd('-0');
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
-  t.deepEqual(trail, [path.resolve(rootDir, 'resources/pushd')]);
+  t.deepEqual(trail, [path.resolve(rootDir, 'test/resources/pushd')]);
 });
 
 test('Using -1 option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   const trail = shell.popd('-1');
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
@@ -92,11 +92,11 @@ test('Using -1 option', t => {
 });
 
 test('Using -n option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   const trail = shell.popd('-n');
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
-  t.deepEqual(trail, [path.resolve(rootDir, 'resources/pushd')]);
+  t.deepEqual(trail, [path.resolve(rootDir, 'test/resources/pushd')]);
 });
 
 test('Popping an empty stack', t => {
@@ -105,11 +105,11 @@ test('Popping an empty stack', t => {
 });
 
 test('Test that rootDir is not stored', t => {
-  shell.cd('resources/pushd');
+  shell.cd('test/resources/pushd');
   shell.pushd('b');
   const trail = shell.popd();
   t.falsy(shell.error());
-  t.is(trail[0], path.resolve(rootDir, 'resources/pushd'));
+  t.is(trail[0], path.resolve(rootDir, 'test/resources/pushd'));
   t.is(process.cwd(), trail[0]);
   shell.popd(); // no more in the stack
   t.truthy(shell.error());

--- a/test/pushd.js
+++ b/test/pushd.js
@@ -25,59 +25,59 @@ test.after.always(() => {
 //
 
 test('Push valid directories', t => {
-  const trail = shell.pushd('resources/pushd');
+  const trail = shell.pushd('test/resources/pushd');
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
   ]);
 });
 
 test('Two directories', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   const trail = shell.pushd('a');
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd/a'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
   ]);
 });
 
 test('Three directories', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   const trail = shell.pushd('../b');
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd/b'),
-    path.resolve(rootDir, 'resources/pushd/a'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
   ]);
 });
 
 test('Four directories', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   shell.pushd('../b');
   const trail = shell.pushd('c');
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd/b/c'),
-    path.resolve(rootDir, 'resources/pushd/b'),
-    path.resolve(rootDir, 'resources/pushd/a'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/b/c'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
   ]);
 });
 
 test('Push stuff around with positive indices', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   shell.pushd('../b');
   shell.pushd('c');
@@ -85,16 +85,16 @@ test('Push stuff around with positive indices', t => {
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd/b/c'),
-    path.resolve(rootDir, 'resources/pushd/b'),
-    path.resolve(rootDir, 'resources/pushd/a'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/b/c'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
   ]);
 });
 
 test('+1 option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   shell.pushd('../b');
   shell.pushd('c');
@@ -102,16 +102,16 @@ test('+1 option', t => {
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd/b'),
-    path.resolve(rootDir, 'resources/pushd/a'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
-    path.resolve(rootDir, 'resources/pushd/b/c'),
+    path.resolve(rootDir, 'test/resources/pushd/b/c'),
   ]);
 });
 
 test('+2 option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   shell.pushd('../b');
   shell.pushd('c');
@@ -119,16 +119,16 @@ test('+2 option', t => {
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd/a'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
-    path.resolve(rootDir, 'resources/pushd/b/c'),
-    path.resolve(rootDir, 'resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/b/c'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
   ]);
 });
 
 test('+3 option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   shell.pushd('../b');
   shell.pushd('c');
@@ -136,16 +136,16 @@ test('+3 option', t => {
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
-    path.resolve(rootDir, 'resources/pushd/b/c'),
-    path.resolve(rootDir, 'resources/pushd/b'),
-    path.resolve(rootDir, 'resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd/b/c'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
   ]);
 });
 
 test('+4 option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   shell.pushd('../b');
   shell.pushd('c');
@@ -154,15 +154,15 @@ test('+4 option', t => {
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
     rootDir,
-    path.resolve(rootDir, 'resources/pushd/b/c'),
-    path.resolve(rootDir, 'resources/pushd/b'),
-    path.resolve(rootDir, 'resources/pushd/a'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/b/c'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd'),
   ]);
 });
 
 test('Push stuff around with negative indices', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   shell.pushd('../b');
   shell.pushd('c');
@@ -171,15 +171,15 @@ test('Push stuff around with negative indices', t => {
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
     rootDir,
-    path.resolve(rootDir, 'resources/pushd/b/c'),
-    path.resolve(rootDir, 'resources/pushd/b'),
-    path.resolve(rootDir, 'resources/pushd/a'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/b/c'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd'),
   ]);
 });
 
 test('-1 option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   shell.pushd('../b');
   shell.pushd('c');
@@ -187,16 +187,16 @@ test('-1 option', t => {
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
-    path.resolve(rootDir, 'resources/pushd/b/c'),
-    path.resolve(rootDir, 'resources/pushd/b'),
-    path.resolve(rootDir, 'resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd/b/c'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
   ]);
 });
 
 test('-2 option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   shell.pushd('../b');
   shell.pushd('c');
@@ -204,16 +204,16 @@ test('-2 option', t => {
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd/a'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
-    path.resolve(rootDir, 'resources/pushd/b/c'),
-    path.resolve(rootDir, 'resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/b/c'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
   ]);
 });
 
 test('-3 option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   shell.pushd('../b');
   shell.pushd('c');
@@ -221,16 +221,16 @@ test('-3 option', t => {
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd/b'),
-    path.resolve(rootDir, 'resources/pushd/a'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
-    path.resolve(rootDir, 'resources/pushd/b/c'),
+    path.resolve(rootDir, 'test/resources/pushd/b/c'),
   ]);
 });
 
 test('-4 option', t => {
-  shell.pushd('resources/pushd');
+  shell.pushd('test/resources/pushd');
   shell.pushd('a');
   shell.pushd('../b');
   shell.pushd('c');
@@ -238,33 +238,33 @@ test('-4 option', t => {
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
-    path.resolve(rootDir, 'resources/pushd/b/c'),
-    path.resolve(rootDir, 'resources/pushd/b'),
-    path.resolve(rootDir, 'resources/pushd/a'),
-    path.resolve(rootDir, 'resources/pushd'),
+    path.resolve(rootDir, 'test/resources/pushd/b/c'),
+    path.resolve(rootDir, 'test/resources/pushd/b'),
+    path.resolve(rootDir, 'test/resources/pushd/a'),
+    path.resolve(rootDir, 'test/resources/pushd'),
     rootDir,
   ]);
 });
 
 test('Push without changing directory or resolving paths', t => {
-  const trail = shell.pushd('-n', 'resources/pushd');
+  const trail = shell.pushd('-n', 'test/resources/pushd');
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
     rootDir,
-    'resources/pushd',
+    'test/resources/pushd',
   ]);
 });
 
 test('Using the -n option with a non-empty stack', t => {
-  shell.pushd('-n', 'resources/pushd');
-  const trail = shell.pushd('-n', 'resources/pushd/a');
+  shell.pushd('-n', 'test/resources/pushd');
+  const trail = shell.pushd('-n', 'test/resources/pushd/a');
   t.falsy(shell.error());
   t.is(process.cwd(), trail[0]);
   t.deepEqual(trail, [
     rootDir,
-    'resources/pushd/a',
-    'resources/pushd',
+    'test/resources/pushd/a',
+    'test/resources/pushd',
   ]);
 });
 
@@ -282,17 +282,17 @@ test('Push invalid directory', t => {
 test(
   'Push without args swaps top two directories when stack length is 2',
   t => {
-    let trail = shell.pushd('resources/pushd');
+    let trail = shell.pushd('test/resources/pushd');
     t.falsy(shell.error());
     t.is(trail.length, 2);
-    t.is(path.relative(rootDir, trail[0]), path.join('resources', 'pushd'));
+    t.is(path.relative(rootDir, trail[0]), path.join('test/resources', 'pushd'));
     t.is(trail[1], rootDir);
     t.is(process.cwd(), trail[0]);
     trail = shell.pushd();
     t.falsy(shell.error());
     t.is(trail.length, 2);
     t.is(trail[0], rootDir);
-    t.is(path.relative(rootDir, trail[1]), path.join('resources', 'pushd'));
+    t.is(path.relative(rootDir, trail[1]), path.join('test/resources', 'pushd'));
     t.is(process.cwd(), trail[0]);
   }
 );
@@ -300,27 +300,27 @@ test(
 test(
   'Push without args swaps top two directories for larger stacks',
   t => {
-    shell.pushd('resources/pushd');
+    shell.pushd('test/resources/pushd');
     shell.pushd();
-    const trail = shell.pushd('resources/pushd/a');
+    const trail = shell.pushd('test/resources/pushd/a');
     t.falsy(shell.error());
     t.is(trail.length, 3);
-    t.is(path.relative(rootDir, trail[0]), path.join('resources', 'pushd', 'a'));
+    t.is(path.relative(rootDir, trail[0]), path.join('test/resources', 'pushd', 'a'));
     t.is(trail[1], rootDir);
-    t.is(path.relative(rootDir, trail[2]), path.join('resources', 'pushd'));
+    t.is(path.relative(rootDir, trail[2]), path.join('test/resources', 'pushd'));
     t.is(process.cwd(), trail[0]);
   }
 );
 
 test('Pushing with no args', t => {
-  shell.pushd('-n', 'resources/pushd');
-  shell.pushd('resources/pushd/a');
+  shell.pushd('-n', 'test/resources/pushd');
+  shell.pushd('test/resources/pushd/a');
   const trail = shell.pushd();
   t.falsy(shell.error());
   t.is(trail.length, 3);
   t.is(trail[0], rootDir);
-  t.is(path.relative(rootDir, trail[1]), path.join('resources', 'pushd', 'a'));
-  t.is(path.relative(rootDir, trail[2]), path.join('resources', 'pushd'));
+  t.is(path.relative(rootDir, trail[1]), path.join('test/resources', 'pushd', 'a'));
+  t.is(path.relative(rootDir, trail[2]), path.join('test/resources', 'pushd'));
   t.is(process.cwd(), trail[0]);
 });
 

--- a/test/rm.js
+++ b/test/rm.js
@@ -9,7 +9,7 @@ import utils from './utils/utils';
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
   shell.config.resetForTesting();
-  shell.cp('-r', 'resources', t.context.tmp);
+  shell.cp('-r', 'test/resources', t.context.tmp);
 });
 
 test.afterEach.always(t => {
@@ -50,10 +50,10 @@ test('only an option', t => {
 });
 
 test('invalid option', t => {
-  const result = shell.rm('-@', 'resources/file1');
+  const result = shell.rm('-@', 'test/resources/file1');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.truthy(fs.existsSync('resources/file1'));
+  t.truthy(fs.existsSync('test/resources/file1'));
   t.is(result.stderr, 'rm: option not recognized: @');
 });
 

--- a/test/sed.js
+++ b/test/sed.js
@@ -8,7 +8,7 @@ import utils from './utils/utils';
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
   shell.config.resetForTesting();
-  shell.cp('-r', 'resources', t.context.tmp);
+  shell.cp('-r', 'test/resources', t.context.tmp);
 });
 
 test.afterEach.always(t => {
@@ -99,7 +99,7 @@ test('-i option', t => {
 });
 
 test('make sure * in regex is not globbed', t => {
-  const result = shell.sed(/alpha*beta/, 'hello', 'resources/grep/file');
+  const result = shell.sed(/alpha*beta/, 'hello', 'test/resources/grep/file');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(
@@ -109,7 +109,7 @@ test('make sure * in regex is not globbed', t => {
 });
 
 test('make sure * in string-regex is not globbed', t => {
-  const result = shell.sed('alpha*beta', 'hello', 'resources/grep/file');
+  const result = shell.sed('alpha*beta', 'hello', 'test/resources/grep/file');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(
@@ -119,7 +119,7 @@ test('make sure * in string-regex is not globbed', t => {
 });
 
 test('make sure * in regex is not globbed (matches something)', t => {
-  const result = shell.sed(/l*\.js/, '', 'resources/grep/file');
+  const result = shell.sed(/l*\.js/, '', 'test/resources/grep/file');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(
@@ -129,7 +129,7 @@ test('make sure * in regex is not globbed (matches something)', t => {
 });
 
 test('make sure * in string-regex is not globbed (matches something)', t => {
-  const result = shell.sed('l*\\.js', '', 'resources/grep/file');
+  const result = shell.sed('l*\\.js', '', 'test/resources/grep/file');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(

--- a/test/set.js
+++ b/test/set.js
@@ -9,7 +9,7 @@ const uncaughtErrorExitCode = 1;
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
   shell.config.resetForTesting();
-  shell.cp('-r', 'resources', t.context.tmp);
+  shell.cp('-r', 'test/resources', t.context.tmp);
 });
 
 test.afterEach.always(t => {
@@ -28,21 +28,21 @@ test('initial values', t => {
 });
 
 test('default behavior', t => {
-  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'../global\'); ls(\'file_doesnt_exist\'); echo(1234);"');
+  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'./global\'); ls(\'file_doesnt_exist\'); echo(1234);"');
   t.is(result.code, 0);
   t.is(result.stdout, '1234\n');
   t.is(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');
 });
 
 test('set -e', t => {
-  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'../global\'); set(\'-e\'); ls(\'file_doesnt_exist\'); echo(1234);"');
+  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'./global\'); set(\'-e\'); ls(\'file_doesnt_exist\'); echo(1234);"');
   t.is(result.code, uncaughtErrorExitCode);
   t.is(result.stdout, '');
   t.truthy(result.stderr.indexOf('Error: ls: no such file or directory: file_doesnt_exist') >= 0);
 });
 
 test('set -v', t => {
-  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'../global\'); set(\'-v\'); ls(\'file_doesnt_exist\'); echo(1234);"');
+  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'./global\'); set(\'-v\'); ls(\'file_doesnt_exist\'); echo(1234);"');
   t.is(result.code, 0);
   t.is(result.stdout, '1234\n');
   t.is(
@@ -52,7 +52,7 @@ test('set -v', t => {
 });
 
 test('set -ev', t => {
-  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'../global\'); set(\'-ev\'); ls(\'file_doesnt_exist\'); echo(1234);"');
+  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'./global\'); set(\'-ev\'); ls(\'file_doesnt_exist\'); echo(1234);"');
   t.is(result.code, uncaughtErrorExitCode);
   t.is(result.stdout, '');
   t.truthy(result.stderr.indexOf('Error: ls: no such file or directory: file_doesnt_exist') >= 0);
@@ -61,7 +61,7 @@ test('set -ev', t => {
 });
 
 test('set -e, set +e', t => {
-  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'../global\'); set(\'-e\'); set(\'+e\'); ls(\'file_doesnt_exist\'); echo(1234);"');
+  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'./global\'); set(\'-e\'); set(\'+e\'); ls(\'file_doesnt_exist\'); echo(1234);"');
   t.is(result.code, 0);
   t.is(result.stdout, '1234\n');
   t.is(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');

--- a/test/sort.js
+++ b/test/sort.js
@@ -6,7 +6,7 @@ import shell from '..';
 
 shell.config.silent = true;
 
-const doubleSorted = shell.cat('resources/sort/sorted')
+const doubleSorted = shell.cat('test/resources/sort/sorted')
                         .trimRight()
                         .split('\n')
                         .reduce((prev, cur) => prev.concat([cur, cur]), [])
@@ -31,11 +31,11 @@ test('file does not exist', t => {
 });
 
 test('directory', t => {
-  t.truthy(fs.statSync('resources/').isDirectory()); // sanity check
-  const result = shell.sort('resources/');
+  t.truthy(fs.statSync('test/resources/').isDirectory()); // sanity check
+  const result = shell.sort('test/resources/');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, 'sort: read failed: resources/: Is a directory');
+  t.is(result.stderr, 'sort: read failed: test/resources/: Is a directory');
 });
 
 //
@@ -43,52 +43,52 @@ test('directory', t => {
 //
 
 test('simple', t => {
-  const result = shell.sort('resources/sort/file1');
+  const result = shell.sort('test/resources/sort/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.toString(), shell.cat('resources/sort/sorted').toString());
+  t.is(result.toString(), shell.cat('test/resources/sort/sorted').toString());
 });
 
 test('simple #2', t => {
-  const result = shell.sort('resources/sort/file2');
+  const result = shell.sort('test/resources/sort/file2');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.toString(), shell.cat('resources/sort/sorted').toString());
+  t.is(result.toString(), shell.cat('test/resources/sort/sorted').toString());
 });
 
 test('multiple files', t => {
-  const result = shell.sort('resources/sort/file2', 'resources/sort/file1');
+  const result = shell.sort('test/resources/sort/file2', 'test/resources/sort/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), doubleSorted);
 });
 
 test('multiple files, array syntax', t => {
-  const result = shell.sort(['resources/sort/file2', 'resources/sort/file1']);
+  const result = shell.sort(['test/resources/sort/file2', 'test/resources/sort/file1']);
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), doubleSorted);
 });
 
 test('Globbed file', t => {
-  const result = shell.sort('resources/sort/file?');
+  const result = shell.sort('test/resources/sort/file?');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), doubleSorted);
 });
 
 test('With \'-n\' option', t => {
-  const result = shell.sort('-n', 'resources/sort/file2');
+  const result = shell.sort('-n', 'test/resources/sort/file2');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.toString(), shell.cat('resources/sort/sortedDashN').toString());
+  t.is(result.toString(), shell.cat('test/resources/sort/sortedDashN').toString());
 });
 
 test('With \'-r\' option', t => {
-  const result = shell.sort('-r', 'resources/sort/file2');
+  const result = shell.sort('-r', 'test/resources/sort/file2');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.toString(), shell.cat('resources/sort/sorted')
+  t.is(result.toString(), shell.cat('test/resources/sort/sorted')
     .trimRight()
     .split('\n')
     .reverse()
@@ -96,10 +96,10 @@ test('With \'-r\' option', t => {
 });
 
 test('With \'-rn\' option', t => {
-  const result = shell.sort('-rn', 'resources/sort/file2');
+  const result = shell.sort('-rn', 'test/resources/sort/file2');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.toString(), shell.cat('resources/sort/sortedDashN')
+  t.is(result.toString(), shell.cat('test/resources/sort/sortedDashN')
     .trimRight()
     .split('\n')
     .reverse()

--- a/test/tail.js
+++ b/test/tail.js
@@ -24,11 +24,11 @@ test('file does not exist', t => {
 });
 
 test('directory', t => {
-  t.truthy(fs.statSync('resources/').isDirectory()); // sanity check
-  const result = shell.tail('resources/');
+  t.truthy(fs.statSync('test/resources/').isDirectory()); // sanity check
+  const result = shell.tail('test/resources/');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, "tail: error reading 'resources/': Is a directory");
+  t.is(result.stderr, "tail: error reading 'test/resources/': Is a directory");
 });
 
 //
@@ -45,14 +45,14 @@ const bottomOfFile2 = ['file2 50', 'file2 49', 'file2 48', 'file2 47', 'file2 46
                        'file2 35', 'file2 34', 'file2 33', 'file2 32', 'file2 31'];
 
 test('simple', t => {
-  const result = shell.tail('resources/head/file1.txt');
+  const result = shell.tail('test/resources/head/file1.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), bottomOfFile1.slice(0, 10).reverse().join('\n') + '\n');
 });
 
 test('multiple files', t => {
-  const result = shell.tail('resources/head/file2.txt', 'resources/head/file1.txt');
+  const result = shell.tail('test/resources/head/file2.txt', 'test/resources/head/file1.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(),
@@ -64,7 +64,7 @@ test('multiple files', t => {
 });
 
 test('multiple files, array syntax', t => {
-  const result = shell.tail(['resources/head/file2.txt', 'resources/head/file1.txt']);
+  const result = shell.tail(['test/resources/head/file2.txt', 'test/resources/head/file1.txt']);
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(),
@@ -76,21 +76,21 @@ test('multiple files, array syntax', t => {
 });
 
 test('reading more lines than are in the file (no trailing newline)', t => {
-  const result = shell.tail('resources/file2', 'resources/file1');
+  const result = shell.tail('test/resources/file2', 'test/resources/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), 'test2\ntest1'); // these files only have one line (no \n)
 });
 
 test('reading more lines than are in the file (with trailing newline)', t => {
-  const result = shell.tail('resources/head/shortfile2', 'resources/head/shortfile1');
+  const result = shell.tail('test/resources/head/shortfile2', 'test/resources/head/shortfile1');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), 'short2\nshort1\n'); // these files only have one line (with \n)
 });
 
 test('Globbed file', t => {
-  const result = shell.tail('resources/head/file?.txt');
+  const result = shell.tail('test/resources/head/file?.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(),
@@ -102,8 +102,8 @@ test('Globbed file', t => {
 });
 
 test('With `\'-n\' <num>` option', t => {
-  const result = shell.tail('-n', 4, 'resources/head/file2.txt',
-    'resources/head/file1.txt');
+  const result = shell.tail('-n', 4, 'test/resources/head/file2.txt',
+    'test/resources/head/file1.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(),
@@ -115,8 +115,8 @@ test('With `\'-n\' <num>` option', t => {
 });
 
 test('With `{\'-n\': <num>}` option', t => {
-  const result = shell.tail({ '-n': 4 }, 'resources/head/file2.txt',
-    'resources/head/file1.txt');
+  const result = shell.tail({ '-n': 4 }, 'test/resources/head/file2.txt',
+    'test/resources/head/file1.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(),
@@ -128,8 +128,8 @@ test('With `{\'-n\': <num>}` option', t => {
 });
 
 test('negative values are the same as positive values', t => {
-  const result = shell.tail('-n', -4, 'resources/head/file2.txt',
-    'resources/head/file1.txt');
+  const result = shell.tail('-n', -4, 'test/resources/head/file2.txt',
+    'test/resources/head/file1.txt');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(),

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ test('bad expression', t => {
 });
 
 test('bad expression #2', t => {
-  shell.test('f', 'resources/file1');
+  shell.test('f', 'test/resources/file1');
   t.truthy(shell.error());
 });
 
@@ -35,56 +35,56 @@ test('no file', t => {
 
 
 test('-e option succeeds for files', t => {
-  const result = shell.test('-e', 'resources/file1');
+  const result = shell.test('-e', 'test/resources/file1');
   t.falsy(shell.error());
   t.truthy(result);
 });
 
 test('-e option fails if it does not exist', t => {
-  const result = shell.test('-e', 'resources/404');
+  const result = shell.test('-e', 'test/resources/404');
   t.falsy(shell.error());
   t.falsy(result);
 });
 
 test('-d option succeeds for a directory', t => {
-  const result = shell.test('-d', 'resources');
+  const result = shell.test('-d', 'test/resources');
   t.falsy(shell.error());
   t.truthy(result);
 });
 
 test('-f option fails for a directory', t => {
-  const result = shell.test('-f', 'resources');
+  const result = shell.test('-f', 'test/resources');
   t.falsy(shell.error());
   t.falsy(result);
 });
 
 test('-L option fails for a directory', t => {
-  const result = shell.test('-L', 'resources');
+  const result = shell.test('-L', 'test/resources');
   t.falsy(shell.error());
   t.falsy(result);
 });
 
 test('-d option fails for a file', t => {
-  const result = shell.test('-d', 'resources/file1');
+  const result = shell.test('-d', 'test/resources/file1');
   t.falsy(shell.error());
   t.falsy(result);
 });
 
 test('-f option succeeds for a file', t => {
-  const result = shell.test('-f', 'resources/file1');
+  const result = shell.test('-f', 'test/resources/file1');
   t.falsy(shell.error());
   t.truthy(result);
 });
 
 test('-L option fails for a file', t => {
-  const result = shell.test('-L', 'resources/file1');
+  const result = shell.test('-L', 'test/resources/file1');
   t.falsy(shell.error());
   t.falsy(result);
 });
 
 test('test command is not globbed', t => {
   // regression #529
-  const result = shell.test('-f', 'resources/**/*.js');
+  const result = shell.test('-f', 'test/resources/**/*.js');
   t.falsy(shell.error());
   t.falsy(result);
 });
@@ -92,7 +92,7 @@ test('test command is not globbed', t => {
 // TODO(nate): figure out a way to test links on Windows
 test('-d option fails for a link', t => {
   utils.skipOnWin(t, () => {
-    const result = shell.test('-d', 'resources/link');
+    const result = shell.test('-d', 'test/resources/link');
     t.falsy(shell.error());
     t.falsy(result);
   });
@@ -100,7 +100,7 @@ test('-d option fails for a link', t => {
 
 test('-f option succeeds for a link', t => {
   utils.skipOnWin(t, () => {
-    const result = shell.test('-f', 'resources/link');
+    const result = shell.test('-f', 'test/resources/link');
     t.falsy(shell.error());
     t.truthy(result);
   });
@@ -108,7 +108,7 @@ test('-f option succeeds for a link', t => {
 
 test('-L option succeeds for a symlink', t => {
   utils.skipOnWin(t, () => {
-    const result = shell.test('-L', 'resources/link');
+    const result = shell.test('-L', 'test/resources/link');
     t.falsy(shell.error());
     t.truthy(result);
   });
@@ -116,7 +116,7 @@ test('-L option succeeds for a symlink', t => {
 
 test('-L option works for broken symlinks', t => {
   utils.skipOnWin(t, () => {
-    const result = shell.test('-L', 'resources/badlink');
+    const result = shell.test('-L', 'test/resources/badlink');
     t.falsy(shell.error());
     t.truthy(result);
   });
@@ -124,7 +124,7 @@ test('-L option works for broken symlinks', t => {
 
 test('-L option fails for missing files', t => {
   utils.skipOnWin(t, () => {
-    const result = shell.test('-L', 'resources/404');
+    const result = shell.test('-L', 'test/resources/404');
     t.falsy(shell.error());
     t.falsy(result);
   });

--- a/test/touch.js
+++ b/test/touch.js
@@ -165,10 +165,10 @@ test('file array', t => {
 
 test('touching broken link creates a new file', t => {
   utils.skipOnWin(t, () => {
-    const result = shell.touch('resources/badlink');
+    const result = shell.touch('test/resources/badlink');
     t.is(result.code, 0);
     t.falsy(shell.error());
-    t.truthy(fs.existsSync('resources/not_existed_file'));
-    shell.rm('resources/not_existed_file');
+    t.truthy(fs.existsSync('test/resources/not_existed_file'));
+    shell.rm('test/resources/not_existed_file');
   });
 });

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -24,24 +24,24 @@ test('file does not exist', t => {
 });
 
 test('directory', t => {
-  t.truthy(fs.statSync('resources/').isDirectory()); // sanity check
-  const result = shell.uniq('resources/');
+  t.truthy(fs.statSync('test/resources/').isDirectory()); // sanity check
+  const result = shell.uniq('test/resources/');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, "uniq: error reading 'resources/'");
+  t.is(result.stderr, "uniq: error reading 'test/resources/'");
 });
 
 test('output directory', t => {
-  t.truthy(fs.statSync('resources/').isDirectory()); // sanity check
-  const result = shell.uniq('resources/file1.txt', 'resources/');
+  t.truthy(fs.statSync('test/resources/').isDirectory()); // sanity check
+  const result = shell.uniq('test/resources/file1.txt', 'test/resources/');
   t.truthy(shell.error());
   t.is(result.code, 1);
-  t.is(result.stderr, 'uniq: resources/: Is a directory');
+  t.is(result.stderr, 'uniq: test/resources/: Is a directory');
 });
 
 test('file does not exist with output directory', t => {
   t.falsy(fs.existsSync('/asdfasdf')); // sanity check
-  const result = shell.uniq('/asdfasdf', 'resources/');
+  const result = shell.uniq('/asdfasdf', 'test/resources/');
   t.is(result.code, 1);
   t.truthy(shell.error());
 });
@@ -51,53 +51,53 @@ test('file does not exist with output directory', t => {
 //
 
 test('uniq file1', t => {
-  const result = shell.uniq('resources/uniq/file1');
+  const result = shell.uniq('test/resources/uniq/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.toString(), shell.cat('resources/uniq/file1u').toString());
+  t.is(result.toString(), shell.cat('test/resources/uniq/file1u').toString());
 });
 
 test('uniq -i file2', t => {
-  const result = shell.uniq('-i', 'resources/uniq/file2');
+  const result = shell.uniq('-i', 'test/resources/uniq/file2');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.toString(), shell.cat('resources/uniq/file2u').toString());
+  t.is(result.toString(), shell.cat('test/resources/uniq/file2u').toString());
 });
 
 test('with glob character', t => {
-  const result = shell.uniq('-i', 'resources/uniq/fi?e2');
+  const result = shell.uniq('-i', 'test/resources/uniq/fi?e2');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.toString(), shell.cat('resources/uniq/file2u').toString());
+  t.is(result.toString(), shell.cat('test/resources/uniq/file2u').toString());
 });
 
 test('uniq file1 file2', t => {
-  const result = shell.uniq('resources/uniq/file1', 'resources/uniq/file1t');
+  const result = shell.uniq('test/resources/uniq/file1', 'test/resources/uniq/file1t');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(
-    shell.cat('resources/uniq/file1u').toString(),
-    shell.cat('resources/uniq/file1t').toString()
+    shell.cat('test/resources/uniq/file1u').toString(),
+    shell.cat('test/resources/uniq/file1t').toString()
   );
 });
 
 test('cat file1 |uniq', t => {
-  const result = shell.cat('resources/uniq/file1').uniq();
+  const result = shell.cat('test/resources/uniq/file1').uniq();
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.toString(), shell.cat('resources/uniq/file1u').toString());
+  t.is(result.toString(), shell.cat('test/resources/uniq/file1u').toString());
 });
 
 test('uniq -c file1', t => {
-  const result = shell.uniq('-c', 'resources/uniq/file1');
+  const result = shell.uniq('-c', 'test/resources/uniq/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.toString(), shell.cat('resources/uniq/file1c').toString());
+  t.is(result.toString(), shell.cat('test/resources/uniq/file1c').toString());
 });
 
 test('uniq -d file1', t => {
-  const result = shell.uniq('-d', 'resources/uniq/file1');
+  const result = shell.uniq('-d', 'test/resources/uniq/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.is(result.toString(), shell.cat('resources/uniq/file1d').toString());
+  t.is(result.toString(), shell.cat('test/resources/uniq/file1d').toString());
 });


### PR DESCRIPTION
This updates tests for `AVA` 19.0.0+.

`AVA` 0.18.0 has a breaking change which changes the current working directory
for tests. As a result, we need to change 'resources' -> 'test/resources' (and
 similar path changes).

`AVA` 0.19.0 has a breaking change that all tests must run at least one assert.
This breaking change was already resolved by #746, so no change was necessary in
this PR.

This updates to `AVA` 0.21.0, since there are no other breaking changes.