### PR TITLE
Add "encoding" option to exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,11 +273,13 @@ like `.to()`.
 
 
 ### exec(command [, options] [, callback])
-Available options (all `false` by default):
+Available options:
 
 + `async`: Asynchronous execution. If a callback is provided, it will be set to
-  `true`, regardless of the passed value.
-+ `silent`: Do not echo program output to console.
+  `true`, regardless of the passed value (default: `false`).
++ `silent`: Do not echo program output to console (default: `false`).
++ `encoding`: Character encoding to use. Affects the returned stdout and stderr values, and
+  what is written to stdout and stderr when not in silent mode (default: `'utf8'`).
 + and any option available to Node.js's
   [child_process.exec()](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -105,11 +105,17 @@ function execSync(cmd, opts, pipe) {
     code = parseInt(fs.readFileSync(codeFile, 'utf8'), 10);
   }
 
-  // fs.readFileSync uses buffer encoding by default, so set
-  // the encoding only if opts.encoding wasn't set to 'buffer'
-  var encoding = opts.encoding !== 'buffer' ? opts.encoding : null;
-  var stdout = fs.readFileSync(stdoutFile, encoding);
-  var stderr = fs.readFileSync(stderrFile, encoding);
+  // fs.readFileSync uses buffer encoding by default, so call
+  // it without the encoding option if the encoding is 'buffer'
+  var stdout;
+  var stderr;
+  if (opts.encoding === 'buffer') {
+    stdout = fs.readFileSync(stdoutFile);
+    stderr = fs.readFileSync(stderrFile);
+  } else {
+    stdout = fs.readFileSync(stdoutFile, opts.encoding);
+    stderr = fs.readFileSync(stderrFile, opts.encoding);
+  }
 
   // No biggie if we can't erase the files now -- they're in a temp dir anyway
   try { common.unlinkSync(scriptFile); } catch (e) {}

--- a/src/exec.js
+++ b/src/exec.js
@@ -160,11 +160,13 @@ function execAsync(cmd, opts, pipe, callback) {
 
 //@
 //@ ### exec(command [, options] [, callback])
-//@ Available options (all `false` by default):
+//@ Available options:
 //@
 //@ + `async`: Asynchronous execution. If a callback is provided, it will be set to
-//@   `true`, regardless of the passed value.
-//@ + `silent`: Do not echo program output to console.
+//@   `true`, regardless of the passed value (default: `false`).
+//@ + `silent`: Do not echo program output to console (default: `false`).
+//@ + `encoding`: Character encoding to use. Affects the returned stdout and stderr values, and
+//@   what is written to stdout and stderr when not in silent mode (default: `'utf8'`).
 //@ + and any option available to Node.js's
 //@   [child_process.exec()](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
 //@

--- a/test/exec.js
+++ b/test/exec.js
@@ -163,6 +163,14 @@ test('exec returns a ShellString', t => {
   t.is(result.toString(), result.stdout);
 });
 
+test('encoding option works', t => {
+  const result = shell.exec(`${JSON.stringify(shell.config.execPath)} -e "console.log(1234);"`, { encoding: 'buffer' });
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.truthy(Buffer.isBuffer(result.stdout));
+  t.is(result.stdout.toString(), '1234\n');
+});
+
 //
 // async
 //
@@ -206,6 +214,17 @@ test.cb('command that fails', t => {
     t.is(code, 1);
     t.is(stdout, '');
     t.is(stderr, 'cp: missing <source> and/or <dest>\n');
+    t.end();
+  });
+});
+
+test.cb('encoding option works with async', t => {
+  shell.exec(`${JSON.stringify(shell.config.execPath)} -e "console.log(5566);"`, { async: true, encoding: 'buffer' }, (code, stdout, stderr) => {
+    t.is(code, 0);
+    t.truthy(Buffer.isBuffer(stdout));
+    t.truthy(Buffer.isBuffer(stderr));
+    t.is(stdout.toString(), '5566\n');
+    t.is(stderr.toString(), '');
     t.end();
   });
 });

--- a/test/exec.js
+++ b/test/exec.js
@@ -168,7 +168,9 @@ test('encoding option works', t => {
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.truthy(Buffer.isBuffer(result.stdout));
+  t.truthy(Buffer.isBuffer(result.stderr));
   t.is(result.stdout.toString(), '1234\n');
+  t.is(result.stderr.toString(), '');
 });
 
 //


### PR DESCRIPTION
Fixes #675 by adding support for the `'encoding'` option to `exec`. It technically supported the `'encoding'` option before, but the return values of `stdout` and `stderr` did not honor the encoding. Now, they will.