### PR TITLE
Fix ls not following links to directories by default

### DIFF
--- a/src/ls.js
+++ b/src/ls.js
@@ -75,6 +75,15 @@ function _ls(options, paths) {
 
     try {
       stat = options.link ? fs.statSync(p) : fs.lstatSync(p);
+      // follow links to directories by default
+      if (stat.isSymbolicLink()) {
+        try {
+          var _stat = fs.statSync(p);
+          if (_stat.isDirectory()) {
+            stat = _stat;
+          }
+        } catch (_) {} // bad symlink, treat it like a file
+      }
     } catch (e) {
       common.error('no such file or directory: ' + p, 2, { continue: true });
       return;

--- a/test/ls.js
+++ b/test/ls.js
@@ -328,6 +328,16 @@ test('-L flag, path is symlink', t => {
   });
 });
 
+test('follow links to directories by default', t => {
+  utils.skipOnWin(t, () => {
+    const result = shell.ls('test/resources/rm/link_to_a_dir');
+    t.falsy(shell.error());
+    t.is(result.code, 0);
+    t.truthy(result.indexOf('a_file') > -1);
+    t.is(result.length, 1);
+  });
+});
+
 test('-Rd works like -d', t => {
   const result = shell.ls('-Rd', 'test/resources/ls');
   t.falsy(shell.error());


### PR DESCRIPTION
Fixes #733 by specifically checking if the stat'ed file is a symlink and that the linked file is a directory.