### PR TITLE
chore: clean up refs to unsupported node versions

### DIFF
--- a/src/tempdir.js
+++ b/src/tempdir.js
@@ -40,7 +40,7 @@ function _tempDir() {
   var state = common.state;
   if (state.tempDir) return state.tempDir; // from cache
 
-  state.tempDir = writeableDir(os.tmpdir && os.tmpdir()) || // node 0.10+
+  state.tempDir = writeableDir(os.tmpdir()) ||
                   writeableDir(process.env.TMPDIR) ||
                   writeableDir(process.env.TEMP) ||
                   writeableDir(process.env.TMP) ||

--- a/test/exec.js
+++ b/test/exec.js
@@ -121,10 +121,7 @@ test('set timeout option', t => {
   const result = shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`); // default timeout is ok
   t.falsy(shell.error());
   t.is(result.code, 0);
-  if (process.version >= 'v0.11') {
-    // this option doesn't work on v0.10
-    shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`, { timeout: 10 }); // times out
-  }
+  shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`, { timeout: 10 }); // times out
   t.truthy(shell.error());
 });
 
@@ -145,7 +142,6 @@ test('set shell option (TODO: add tests for Windows)', t => {
     t.is(result.code, 0);
     t.is(result.stdout, '/bin/sh\n'); // sh by default
     const bashPath = shell.which('bash').trim();
-    // this option doesn't work on v0.10
     if (bashPath) {
       result = shell.exec('echo $0', { shell: '/bin/bash' });
       t.falsy(shell.error());


### PR DESCRIPTION
Also removes unnecessary guard code leftover from old versions.