### PR TITLE
chore: set AVA options

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   ],
   "scripts": {
     "posttest": "npm run lint",
-    "test": "nyc --reporter=text --reporter=lcov ava --serial test/*.js",
-    "test-no-coverage": "ava --serial test/*.js",
+    "test": "nyc --reporter=text --reporter=lcov ava test/*.js",
+    "test-no-coverage": "ava test/*.js",
     "gendocs": "node scripts/generate-docs",
     "lint": "eslint .",
     "after-travis": "travis-check-changes",
@@ -52,6 +52,10 @@
     "glob": "^7.0.0",
     "interpret": "^1.0.0",
     "rechoir": "^0.6.2"
+  },
+  "ava": {
+    "serial": true,
+    "powerAssert": false
   },
   "devDependencies": {
     "ava": "^0.21.0",


### PR DESCRIPTION
This sets 2 AVA options:

 * `serial`: same behavior as the CLI flag, which this replaces
 * `powerAssert`: if an assert fails, it will inspect all objects involved in
   the failed assert. This causes readability issues if `t.falsy(shell.error())`
   breaks, since it inspects all of `shell` (which is way too large).

AVA options are a little easier to manage than CLI options (we only update one
place instead of 2 in `package.json`).