### PR TITLE
Wrap fs.statSync and fs.lstatSync

### DIFF
--- a/src/cat.js
+++ b/src/cat.js
@@ -36,7 +36,7 @@ function _cat(options, files) {
   files.forEach(function (file) {
     if (!fs.existsSync(file)) {
       common.error('no such file or directory: ' + file);
-    } else if (fs.statSync(file).isDirectory()) {
+    } else if (common.statFollowLinks(file).isDirectory()) {
       common.error(file + ': Is a directory');
     }
 

--- a/src/cd.js
+++ b/src/cd.js
@@ -1,4 +1,3 @@
-var fs = require('fs');
 var os = require('os');
 var common = require('./common');
 
@@ -27,7 +26,7 @@ function _cd(options, dir) {
     // something went wrong, let's figure out the error
     var err;
     try {
-      fs.statSync(dir); // if this succeeds, it must be some sort of file
+      common.statFollowLinks(dir); // if this succeeds, it must be some sort of file
       err = 'not a directory: ' + dir;
     } catch (e2) {
       err = 'no such file or directory: ' + dir;

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -85,7 +85,7 @@ function _chmod(options, mode, filePattern) {
   if (options.recursive) {
     files = [];
     filePattern.forEach(function addFile(expandedFile) {
-      var stat = fs.lstatSync(expandedFile);
+      var stat = common.statNoFollowLinks(expandedFile);
 
       if (!stat.isSymbolicLink()) {
         files.push(expandedFile);
@@ -108,11 +108,11 @@ function _chmod(options, mode, filePattern) {
     }
 
     // When recursing, don't follow symlinks.
-    if (options.recursive && fs.lstatSync(file).isSymbolicLink()) {
+    if (options.recursive && common.statNoFollowLinks(file).isSymbolicLink()) {
       return;
     }
 
-    var stat = fs.statSync(file);
+    var stat = common.statFollowLinks(file);
     var isDir = stat.isDirectory();
     var perms = stat.mode;
     var type = perms & PERMS.TYPE_MASK;
@@ -175,7 +175,7 @@ function _chmod(options, mode, filePattern) {
 
               // According to POSIX, when using = to explicitly set the
               // permissions, setuid and setgid can never be cleared.
-              if (fs.statSync(file).isDirectory()) {
+              if (common.statFollowLinks(file).isDirectory()) {
                 newPerms |= (PERMS.SETUID + PERMS.SETGID) & perms;
               }
               break;
@@ -204,7 +204,7 @@ function _chmod(options, mode, filePattern) {
 
       // POSIX rules are that setuid and setgid can only be added using numeric
       // form, but not cleared.
-      if (fs.statSync(file).isDirectory()) {
+      if (common.statFollowLinks(file).isDirectory()) {
         newPerms |= (PERMS.SETUID + PERMS.SETGID) & perms;
       }
 

--- a/src/common.js
+++ b/src/common.js
@@ -277,6 +277,18 @@ function unlinkSync(file) {
 }
 exports.unlinkSync = unlinkSync;
 
+// wrappers around fs.statSync and fs.lstatSync that clarify intent
+// and improve readability
+function statFollowLinks() {
+  return fs.statSync.apply(fs, arguments);
+}
+exports.statFollowLinks = statFollowLinks;
+
+function statNoFollowLinks() {
+  return fs.lstatSync.apply(fs, arguments);
+}
+exports.statNoFollowLinks = statNoFollowLinks;
+
 // e.g. 'shelljs_a5f185d0443ca...'
 function randomFileName() {
   function randomHash(count) {

--- a/src/common.js
+++ b/src/common.js
@@ -277,7 +277,7 @@ function unlinkSync(file) {
 }
 exports.unlinkSync = unlinkSync;
 
-// wrappers around fs.statSync and fs.lstatSync that clarify intent
+// wrappers around common.statFollowLinks and common.statNoFollowLinks that clarify intent
 // and improve readability
 function statFollowLinks() {
   return fs.statSync.apply(fs, arguments);

--- a/src/find.js
+++ b/src/find.js
@@ -1,4 +1,3 @@
-var fs = require('fs');
 var path = require('path');
 var common = require('./common');
 var _ls = require('./ls');
@@ -42,7 +41,7 @@ function _find(options, paths) {
   paths.forEach(function (file) {
     var stat;
     try {
-      stat = fs.statSync(file);
+      stat = common.statFollowLinks(file);
     } catch (e) {
       common.error('no such file or directory: ' + file);
     }

--- a/src/head.js
+++ b/src/head.js
@@ -71,7 +71,7 @@ function _head(options, files) {
       if (!fs.existsSync(file)) {
         common.error('no such file or directory: ' + file, { continue: true });
         return;
-      } else if (fs.statSync(file).isDirectory()) {
+      } else if (common.statFollowLinks(file).isDirectory()) {
         common.error("error reading '" + file + "': Is a directory", {
           continue: true,
         });

--- a/src/ln.js
+++ b/src/ln.js
@@ -48,7 +48,7 @@ function _ln(options, source, dest) {
     var resolvedSourcePath = isAbsolute ? sourcePath : path.resolve(process.cwd(), path.dirname(dest), source);
     if (!fs.existsSync(resolvedSourcePath)) {
       common.error('Source file does not exist', { continue: true });
-    } else if (isWindows && fs.statSync(resolvedSourcePath).isDirectory()) {
+    } else if (isWindows && common.statFollowLinks(resolvedSourcePath).isDirectory()) {
       linkType = 'junction';
     }
 

--- a/src/ls.js
+++ b/src/ls.js
@@ -62,7 +62,7 @@ function _ls(options, paths) {
       relName = relName.replace(/\\/g, '/');
     }
     if (options.long) {
-      stat = stat || (options.link ? fs.statSync(abs) : fs.lstatSync(abs));
+      stat = stat || (options.link ? common.statFollowLinks(abs) : common.statNoFollowLinks(abs));
       list.push(addLsAttributes(relName, stat));
     } else {
       // list.push(path.relative(rel || '.', file));
@@ -74,11 +74,11 @@ function _ls(options, paths) {
     var stat;
 
     try {
-      stat = options.link ? fs.statSync(p) : fs.lstatSync(p);
+      stat = options.link ? common.statFollowLinks(p) : common.statNoFollowLinks(p);
       // follow links to directories by default
       if (stat.isSymbolicLink()) {
         try {
-          var _stat = fs.statSync(p);
+          var _stat = common.statFollowLinks(p);
           if (_stat.isDirectory()) {
             stat = _stat;
           }

--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -57,7 +57,7 @@ function _mkdir(options, dirs) {
 
   dirs.forEach(function (dir) {
     try {
-      var stat = fs.lstatSync(dir);
+      var stat = common.statNoFollowLinks(dir);
       if (!options.fullpath) {
         common.error('path already exists: ' + dir, { continue: true });
       } else if (stat.isFile()) {

--- a/src/mv.js
+++ b/src/mv.js
@@ -51,7 +51,7 @@ function _mv(options, sources, dest) {
   }
 
   var exists = fs.existsSync(dest);
-  var stats = exists && fs.statSync(dest);
+  var stats = exists && common.statFollowLinks(dest);
 
   // Dest is not existing dir, but multiple sources given
   if ((!exists || !stats.isDirectory()) && sources.length > 1) {
@@ -74,7 +74,7 @@ function _mv(options, sources, dest) {
     // When copying to '/path/dir':
     //    thisDest = '/path/dir/file1'
     var thisDest = dest;
-    if (fs.existsSync(dest) && fs.statSync(dest).isDirectory()) {
+    if (fs.existsSync(dest) && common.statFollowLinks(dest).isDirectory()) {
       thisDest = path.normalize(dest + '/' + path.basename(src));
     }
 

--- a/src/rm.js
+++ b/src/rm.js
@@ -25,7 +25,7 @@ function rmdirSyncRecursive(dir, force, fromSymlink) {
   // Loop through and delete everything in the sub-tree after checking it
   for (var i = 0; i < files.length; i++) {
     var file = dir + '/' + files[i];
-    var currFile = fs.lstatSync(file);
+    var currFile = common.statNoFollowLinks(file);
 
     if (currFile.isDirectory()) { // Recursive function back to the beginning
       rmdirSyncRecursive(file, force);
@@ -116,7 +116,7 @@ function handleDirectory(file, options) {
 function handleSymbolicLink(file, options) {
   var stats;
   try {
-    stats = fs.statSync(file);
+    stats = common.statFollowLinks(file);
   } catch (e) {
     // symlink is broken, so remove the symlink itself
     common.unlinkSync(file);
@@ -175,7 +175,7 @@ function _rm(options, files) {
       var filepath = (file[file.length - 1] === '/')
         ? file.slice(0, -1) // remove the '/' so lstatSync can detect symlinks
         : file;
-      lstats = fs.lstatSync(filepath); // test for existence
+      lstats = common.statNoFollowLinks(filepath); // test for existence
     } catch (e) {
       // Path does not exist, no force flag given
       if (!options.force) {

--- a/src/sort.js
+++ b/src/sort.js
@@ -72,7 +72,7 @@ function _sort(options, files) {
       if (!fs.existsSync(file)) {
         common.error('no such file or directory: ' + file, { continue: true });
         return accum;
-      } else if (fs.statSync(file).isDirectory()) {
+      } else if (common.statFollowLinks(file).isDirectory()) {
         common.error('read failed: ' + file + ': Is a directory', {
           continue: true,
         });

--- a/src/tail.js
+++ b/src/tail.js
@@ -50,7 +50,7 @@ function _tail(options, files) {
       if (!fs.existsSync(file)) {
         common.error('no such file or directory: ' + file, { continue: true });
         return;
-      } else if (fs.statSync(file).isDirectory()) {
+      } else if (common.statFollowLinks(file).isDirectory()) {
         common.error("error reading '" + file + "': Is a directory", {
           continue: true,
         });

--- a/src/tempdir.js
+++ b/src/tempdir.js
@@ -11,7 +11,7 @@ common.register('tempdir', _tempDir, {
 function writeableDir(dir) {
   if (!dir || !fs.existsSync(dir)) return false;
 
-  if (!fs.statSync(dir).isDirectory()) return false;
+  if (!common.statFollowLinks(dir).isDirectory()) return false;
 
   var testFile = dir + '/' + common.randomFileName();
   try {

--- a/src/test.js
+++ b/src/test.js
@@ -52,7 +52,7 @@ function _test(options, path) {
 
   if (options.link) {
     try {
-      return fs.lstatSync(path).isSymbolicLink();
+      return common.statNoFollowLinks(path).isSymbolicLink();
     } catch (e) {
       return false;
     }
@@ -62,7 +62,7 @@ function _test(options, path) {
 
   if (options.exists) return true;
 
-  var stats = fs.statSync(path);
+  var stats = common.statFollowLinks(path);
 
   if (options.block) return stats.isBlockDevice();
 

--- a/src/touch.js
+++ b/src/touch.js
@@ -103,7 +103,7 @@ module.exports = _touch;
 
 function tryStatFile(filePath) {
   try {
-    return fs.statSync(filePath);
+    return common.statFollowLinks(filePath);
   } catch (e) {
     return null;
   }

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -45,11 +45,11 @@ function _uniq(options, input, output) {
 
     if (!fs.existsSync(input)) {
       common.error(input + ': No such file or directory');
-    } else if (fs.statSync(input).isDirectory()) {
+    } else if (common.statFollowLinks(input).isDirectory()) {
       common.error("error reading '" + input + "'");
     }
   }
-  if (output && fs.existsSync(output) && fs.statSync(output).isDirectory()) {
+  if (output && fs.existsSync(output) && common.statFollowLinks(output).isDirectory()) {
     common.error(output + ': Is a directory');
   }
 

--- a/src/which.js
+++ b/src/which.js
@@ -19,7 +19,7 @@ function splitPath(p) {
 }
 
 function checkPath(pathName) {
-  return fs.existsSync(pathName) && !fs.statSync(pathName).isDirectory();
+  return fs.existsSync(pathName) && !common.statFollowLinks(pathName).isDirectory();
 }
 
 //@

--- a/test/chmod.js
+++ b/test/chmod.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import test from 'ava';
 
 import shell from '..';
+import common from '../src/common';
 import utils from './utils/utils';
 
 let TMP;
@@ -36,13 +37,13 @@ test('Basic usage with octal codes', t => {
     let result = shell.chmod('755', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & BITMASK,
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & BITMASK,
       parseInt('755', 8)
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & BITMASK,
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & BITMASK,
       parseInt('644', 8)
     );
   });
@@ -53,7 +54,7 @@ test('symbolic mode', t => {
     let result = shell.chmod('o+x', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('007', 8),
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('007', 8),
       parseInt('005', 8)
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -66,7 +67,7 @@ test('symbolic mode, without group', t => {
     let result = shell.chmod('+x', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & BITMASK,
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & BITMASK,
       parseInt('755', 8)
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -79,13 +80,13 @@ test('Test setuid', t => {
     let result = shell.chmod('u+s', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('4000', 8),
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('4000', 8),
       parseInt('4000', 8)
     );
     result = shell.chmod('u-s', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & BITMASK,
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & BITMASK,
       parseInt('644', 8)
     );
 
@@ -97,7 +98,7 @@ test('Test setuid', t => {
     result = shell.chmod('755', `${TMP}/chmod/c`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/c`).mode & parseInt('4000', 8),
+      common.statFollowLinks(`${TMP}/chmod/c`).mode & parseInt('4000', 8),
       parseInt('4000', 8)
     );
     result = shell.chmod('u-s', `${TMP}/chmod/c`);
@@ -110,13 +111,13 @@ test('Test setgid', t => {
     let result = shell.chmod('g+s', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('2000', 8),
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('2000', 8),
       parseInt('2000', 8)
     );
     result = shell.chmod('g-s', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & BITMASK,
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & BITMASK,
       parseInt('644', 8)
     );
   });
@@ -127,16 +128,16 @@ test('Test sticky bit', t => {
     let result = shell.chmod('+t', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('1000', 8),
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('1000', 8),
       parseInt('1000', 8)
     );
     result = shell.chmod('-t', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & BITMASK,
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & BITMASK,
       parseInt('644', 8)
     );
-    t.is(fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('1000', 8), 0);
+    t.is(common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('1000', 8), 0);
   });
 });
 
@@ -145,7 +146,7 @@ test('Test directories', t => {
     let result = shell.chmod('a-w', `${TMP}/chmod/b/a/b`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/b/a/b`).mode & BITMASK,
+      common.statFollowLinks(`${TMP}/chmod/b/a/b`).mode & BITMASK,
       parseInt('555', 8)
     );
     result = shell.chmod('755', `${TMP}/chmod/b/a/b`);
@@ -158,13 +159,13 @@ test('Test recursion', t => {
     let result = shell.chmod('-R', 'a+w', `${TMP}/chmod/b`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/b/a/b`).mode & BITMASK,
+      common.statFollowLinks(`${TMP}/chmod/b/a/b`).mode & BITMASK,
       BITMASK
     );
     result = shell.chmod('-R', '755', `${TMP}/chmod/b`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/b/a/b`).mode & BITMASK,
+      common.statFollowLinks(`${TMP}/chmod/b/a/b`).mode & BITMASK,
       parseInt('755', 8)
     );
   });
@@ -176,11 +177,11 @@ test('Test symbolic links w/ recursion  - WARNING: *nix only', t => {
     let result = shell.chmod('-R', 'u-w', `${TMP}/chmod/a/b`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/a/b/c`).mode & parseInt('700', 8),
+      common.statFollowLinks(`${TMP}/chmod/a/b/c`).mode & parseInt('700', 8),
       parseInt('500', 8)
     );
     t.is(
-      fs.statSync(`${TMP}/chmod/b/a`).mode & parseInt('700', 8),
+      common.statFollowLinks(`${TMP}/chmod/b/a`).mode & parseInt('700', 8),
       parseInt('700', 8)
     );
     result = shell.chmod('-R', 'u+w', `${TMP}/chmod/a/b`);
@@ -193,7 +194,7 @@ test('Test combinations', t => {
   let result = shell.chmod('a-rwx', `${TMP}/chmod/file1`);
   t.is(result.code, 0);
   t.is(
-    fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('000', 8),
+    common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('000', 8),
     parseInt('000', 8)
   );
   result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -204,7 +205,7 @@ test('multiple symbolic modes', t => {
   let result = shell.chmod('a-rwx,u+r', `${TMP}/chmod/file1`);
   t.is(result.code, 0);
   t.is(
-    fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('400', 8),
+    common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('400', 8),
     parseInt('400', 8)
   );
   result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -215,7 +216,7 @@ test('multiple symbolic modes #2', t => {
   let result = shell.chmod('a-rwx,u+rw', `${TMP}/chmod/file1`);
   t.is(result.code, 0);
   t.is(
-    fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('600', 8),
+    common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('600', 8),
     parseInt('600', 8)
   );
   result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -227,7 +228,7 @@ test('multiple symbolic modes #3', t => {
     let result = shell.chmod('a-rwx,u+rwx', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('700', 8),
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('700', 8),
       parseInt('700', 8)
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -241,7 +242,7 @@ test('u+rw', t => {
   result = shell.chmod('u+rw', `${TMP}/chmod/file1`);
   t.is(result.code, 0);
   t.is(
-    fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('600', 8),
+    common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('600', 8),
     parseInt('600', 8)
   );
   result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -255,7 +256,7 @@ test('u+wx', t => {
     result = shell.chmod('u+wx', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('300', 8),
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('300', 8),
       parseInt('300', 8)
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -270,7 +271,7 @@ test('Multiple symbolic modes at once', t => {
     result = shell.chmod('u+r,g+w,o+x', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('421', 8),
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('421', 8),
       parseInt('421', 8)
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -285,7 +286,7 @@ test('u+rw,g+wx', t => {
     result = shell.chmod('u+rw,g+wx', `${TMP}/chmod/file1`);
     t.is(result.code, 0);
     t.is(
-      fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('630', 8),
+      common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('630', 8),
       parseInt('630', 8)
     );
     result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -299,7 +300,7 @@ test('u-x,g+rw', t => {
   result = shell.chmod('u-x,g+rw', `${TMP}/chmod/file1`);
   t.is(result.code, 0);
   t.is(
-    fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('660', 8),
+    common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('660', 8),
     parseInt('660', 8)
   );
   result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -310,13 +311,13 @@ test('a-rwx,u+rw', t => {
   let result = shell.chmod('a-rwx,u+rw', `${TMP}/chmod/file1`);
   t.is(result.code, 0);
   t.is(
-    fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('600', 8),
+    common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('600', 8),
     parseInt('600', 8)
   );
   result = shell.chmod('a-rwx,u+rw', `${TMP}/chmod/file1`);
   t.is(result.code, 0);
   t.is(
-    fs.statSync(`${TMP}/chmod/file1`).mode & parseInt('600', 8),
+    common.statFollowLinks(`${TMP}/chmod/file1`).mode & parseInt('600', 8),
     parseInt('600', 8)
   );
   result = shell.chmod('644', `${TMP}/chmod/file1`);
@@ -339,19 +340,19 @@ test('Numeric modes', t => {
 test('Make sure chmod succeeds for a variety of octal codes', t => {
   utils.skipOnWin(t, () => {
     t.is(
-      fs.statSync(`${TMP}/chmod/xdir`).mode & parseInt('755', 8),
+      common.statFollowLinks(`${TMP}/chmod/xdir`).mode & parseInt('755', 8),
       parseInt('755', 8)
     );
     t.is(
-      fs.statSync(`${TMP}/chmod/xdir/file`).mode & parseInt('644', 8),
+      common.statFollowLinks(`${TMP}/chmod/xdir/file`).mode & parseInt('644', 8),
       parseInt('644', 8)
     );
     t.is(
-      fs.statSync(`${TMP}/chmod/xdir/deep`).mode & parseInt('755', 8),
+      common.statFollowLinks(`${TMP}/chmod/xdir/deep`).mode & parseInt('755', 8),
       parseInt('755', 8)
     );
     t.is(
-      fs.statSync(`${TMP}/chmod/xdir/deep/file`).mode & parseInt('644', 8),
+      common.statFollowLinks(`${TMP}/chmod/xdir/deep/file`).mode & parseInt('644', 8),
       parseInt('644', 8)
     );
   });

--- a/test/head.js
+++ b/test/head.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import test from 'ava';
 
 import shell from '..';
+import common from '../src/common';
 
 shell.config.silent = true;
 
@@ -25,7 +26,7 @@ test('file does not exist', t => {
 });
 
 test('directory', t => {
-  t.truthy(fs.statSync('test/resources/').isDirectory()); // sanity check
+  t.truthy(common.statFollowLinks('test/resources/').isDirectory()); // sanity check
   const result = shell.head('test/resources/');
   t.truthy(shell.error());
   t.is(result.code, 1);

--- a/test/ls.js
+++ b/test/ls.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import test from 'ava';
 
 import shell from '..';
+import common from '../src/common';
 import utils from './utils/utils';
 
 const CWD = process.cwd();
@@ -455,7 +456,7 @@ test('long option, directory, recursive (and windows converts slashes)', t => {
   t.truthy(idx >= 0);
   result = result[idx];
   t.is(result.name, result.name);
-  t.truthy(fs.statSync('test/resources/ls/a_dir/b_dir').isDirectory());
+  t.truthy(common.statFollowLinks('test/resources/ls/a_dir/b_dir').isDirectory());
   t.is(typeof result.nlink, 'number'); // This can vary between the local machine and travis
   t.is(typeof result.size, 'number'); // This can vary between different file systems
   t.truthy(result.mode); // check that these keys exist

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import test from 'ava';
 
 import shell from '..';
+import common from '../src/common';
 import utils from './utils/utils';
 
 test.beforeEach(t => {
@@ -28,21 +29,21 @@ test('no args', t => {
 });
 
 test('dir already exists', t => {
-  const mtime = fs.statSync(t.context.tmp).mtime.toString();
+  const mtime = common.statFollowLinks(t.context.tmp).mtime.toString();
   const result = shell.mkdir(t.context.tmp); // dir already exists
   t.truthy(shell.error());
   t.is(result.code, 1);
   t.is(result.stderr, `mkdir: path already exists: ${t.context.tmp}`);
-  t.is(fs.statSync(t.context.tmp).mtime.toString(), mtime); // didn't mess with dir
+  t.is(common.statFollowLinks(t.context.tmp).mtime.toString(), mtime); // didn't mess with dir
 });
 
 test('Can\'t overwrite a broken link', t => {
-  const mtime = fs.lstatSync('test/resources/badlink').mtime.toString();
+  const mtime = common.statNoFollowLinks('test/resources/badlink').mtime.toString();
   const result = shell.mkdir('test/resources/badlink');
   t.truthy(shell.error());
   t.is(result.code, 1);
   t.is(result.stderr, 'mkdir: path already exists: test/resources/badlink');
-  t.is(fs.lstatSync('test/resources/badlink').mtime.toString(), mtime); // didn't mess with file
+  t.is(common.statNoFollowLinks('test/resources/badlink').mtime.toString(), mtime); // didn't mess with file
 });
 
 test('root path does not exist', t => {
@@ -56,30 +57,30 @@ test('root path does not exist', t => {
 });
 
 test('try to overwrite file', t => {
-  t.truthy(fs.statSync('test/resources/file1').isFile());
+  t.truthy(common.statFollowLinks('test/resources/file1').isFile());
   const result = shell.mkdir('test/resources/file1');
   t.truthy(shell.error());
   t.is(result.code, 1);
   t.is(result.stderr, 'mkdir: path already exists: test/resources/file1');
-  t.truthy(fs.statSync('test/resources/file1').isFile());
+  t.truthy(common.statFollowLinks('test/resources/file1').isFile());
 });
 
 test('try to overwrite file, with -p', t => {
-  t.truthy(fs.statSync('test/resources/file1').isFile());
+  t.truthy(common.statFollowLinks('test/resources/file1').isFile());
   const result = shell.mkdir('-p', 'test/resources/file1');
   t.truthy(shell.error());
   t.is(result.code, 1);
   t.is(result.stderr, 'mkdir: cannot create directory test/resources/file1: File exists');
-  t.truthy(fs.statSync('test/resources/file1').isFile());
+  t.truthy(common.statFollowLinks('test/resources/file1').isFile());
 });
 
 test('try to make a subdirectory of a file', t => {
-  t.truthy(fs.statSync('test/resources/file1').isFile());
+  t.truthy(common.statFollowLinks('test/resources/file1').isFile());
   const result = shell.mkdir('test/resources/file1/subdir');
   t.truthy(shell.error());
   t.is(result.code, 1);
   t.is(result.stderr, 'mkdir: cannot create directory test/resources/file1/subdir: Not a directory');
-  t.truthy(fs.statSync('test/resources/file1').isFile());
+  t.truthy(common.statFollowLinks('test/resources/file1').isFile());
   t.falsy(fs.existsSync('test/resources/file1/subdir'));
 });
 

--- a/test/sort.js
+++ b/test/sort.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import test from 'ava';
 
 import shell from '..';
+import common from '../src/common';
 
 shell.config.silent = true;
 
@@ -31,7 +32,7 @@ test('file does not exist', t => {
 });
 
 test('directory', t => {
-  t.truthy(fs.statSync('test/resources/').isDirectory()); // sanity check
+  t.truthy(common.statFollowLinks('test/resources/').isDirectory()); // sanity check
   const result = shell.sort('test/resources/');
   t.truthy(shell.error());
   t.is(result.code, 1);

--- a/test/tail.js
+++ b/test/tail.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import test from 'ava';
 
 import shell from '..';
+import common from '../src/common';
 
 shell.config.silent = true;
 
@@ -24,7 +25,7 @@ test('file does not exist', t => {
 });
 
 test('directory', t => {
-  t.truthy(fs.statSync('test/resources/').isDirectory()); // sanity check
+  t.truthy(common.statFollowLinks('test/resources/').isDirectory()); // sanity check
   const result = shell.tail('test/resources/');
   t.truthy(shell.error());
   t.is(result.code, 1);

--- a/test/touch.js
+++ b/test/touch.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import test from 'ava';
 
 import shell from '..';
+import common from '../src/common';
 import utils from './utils/utils';
 
 test.beforeEach(t => {
@@ -21,7 +22,7 @@ function resetUtimes(f) {
   const d = new Date();
   d.setYear(2000);
   fs.utimesSync(f, d, d);
-  return fs.statSync(f);
+  return common.statFollowLinks(f);
 }
 
 function tmpFile(t, noCreate) {
@@ -98,23 +99,23 @@ test('uses a reference file for mtime', t => {
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.not(
-    fs.statSync(testFile).mtime.getTime(),
-    fs.statSync(testFile2).mtime.getTime()
+    common.statFollowLinks(testFile).mtime.getTime(),
+    common.statFollowLinks(testFile2).mtime.getTime()
   );
   t.not(
-    fs.statSync(testFile).atime.getTime(),
-    fs.statSync(testFile2).atime.getTime()
+    common.statFollowLinks(testFile).atime.getTime(),
+    common.statFollowLinks(testFile2).atime.getTime()
   );
   result = shell.touch({ '-r': testFile2 }, testFile);
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(
-    fs.statSync(testFile).mtime.getTime(),
-    fs.statSync(testFile2).mtime.getTime()
+    common.statFollowLinks(testFile).mtime.getTime(),
+    common.statFollowLinks(testFile2).mtime.getTime()
   );
   t.is(
-    fs.statSync(testFile).atime.getTime(),
-    fs.statSync(testFile2).atime.getTime()
+    common.statFollowLinks(testFile).atime.getTime(),
+    common.statFollowLinks(testFile2).atime.getTime()
   );
 });
 
@@ -123,8 +124,8 @@ test('sets mtime and atime by default', t => {
   const oldStat = resetUtimes(testFile);
   const result = shell.touch(testFile);
   t.is(result.code, 0);
-  t.truthy(oldStat.mtime < fs.statSync(testFile).mtime);
-  t.truthy(oldStat.atime < fs.statSync(testFile).atime);
+  t.truthy(oldStat.mtime < common.statFollowLinks(testFile).mtime);
+  t.truthy(oldStat.atime < common.statFollowLinks(testFile).atime);
 });
 
 test('does not set mtime if told not to', t => {
@@ -132,7 +133,7 @@ test('does not set mtime if told not to', t => {
   const oldStat = resetUtimes(testFile);
   const result = shell.touch('-a', testFile);
   t.is(result.code, 0);
-  t.is(oldStat.mtime.getTime(), fs.statSync(testFile).mtime.getTime());
+  t.is(oldStat.mtime.getTime(), common.statFollowLinks(testFile).mtime.getTime());
 });
 
 test('does not set atime if told not to', t => {
@@ -140,7 +141,7 @@ test('does not set atime if told not to', t => {
   const oldStat = resetUtimes(testFile);
   const result = shell.touch('-m', testFile);
   t.is(result.code, 0);
-  t.is(oldStat.atime.getTime(), fs.statSync(testFile).atime.getTime());
+  t.is(oldStat.atime.getTime(), common.statFollowLinks(testFile).atime.getTime());
 });
 
 test('multiple files', t => {

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import test from 'ava';
 
 import shell from '..';
+import common from '../src/common';
 
 shell.config.silent = true;
 
@@ -24,7 +25,7 @@ test('file does not exist', t => {
 });
 
 test('directory', t => {
-  t.truthy(fs.statSync('test/resources/').isDirectory()); // sanity check
+  t.truthy(common.statFollowLinks('test/resources/').isDirectory()); // sanity check
   const result = shell.uniq('test/resources/');
   t.truthy(shell.error());
   t.is(result.code, 1);
@@ -32,7 +33,7 @@ test('directory', t => {
 });
 
 test('output directory', t => {
-  t.truthy(fs.statSync('test/resources/').isDirectory()); // sanity check
+  t.truthy(common.statFollowLinks('test/resources/').isDirectory()); // sanity check
   const result = shell.uniq('test/resources/file1.txt', 'test/resources/');
   t.truthy(shell.error());
   t.is(result.code, 1);


### PR DESCRIPTION
Fixes #745 

Adds two new methods to `src/common.js`, `common.statFollowLinks` and `common.statNoFollowLinks`, which wrap `fs.statSync` and `fs.lstatSync`, respectively. This change is meant to improve readability and clarify intent.