### PR TITLE
Remove codeFile parameter

### DIFF
--- a/src/exec-child.js
+++ b/src/exec-child.js
@@ -19,8 +19,9 @@ var pipe = params.pipe;
 var stdoutFile = params.stdoutFile;
 var stderrFile = params.stderrFile;
 
+var c;
 try {
-  var c = childProcess.exec(cmd, execOptions, function (err) {
+  c = childProcess.exec(cmd, execOptions, function (err) {
     if (!err) {
       process.exit(0);
     } else if (err.code === undefined) {

--- a/src/exec-child.js
+++ b/src/exec-child.js
@@ -32,6 +32,7 @@ try {
   });
 } catch (e) {
   // child_process could not run the command.
+  /* istanbul ignore next */
   process.exitCode = 127;
 }
 

--- a/src/exec-child.js
+++ b/src/exec-child.js
@@ -23,29 +23,26 @@ var c;
 try {
   c = childProcess.exec(cmd, execOptions, function (err) {
     if (!err) {
-      process.exit(0);
+      process.exitCode = 0;
     } else if (err.code === undefined) {
-      process.exit(1);
+      process.exitCode = 1;
     } else {
-      process.exit(err.code);
+      process.exitCode = err.code;
     }
   });
 } catch (e) {
   // child_process could not run the command.
-  process.exit(127);
+  process.exitCode = 127;
 }
 
 var stdoutStream = fs.createWriteStream(stdoutFile);
 var stderrStream = fs.createWriteStream(stderrFile);
 
-c.stdout.pipe(stdoutStream, { end: false });
-c.stderr.pipe(stderrStream, { end: false });
+c.stdout.pipe(stdoutStream);
+c.stderr.pipe(stderrStream);
 c.stdout.pipe(process.stdout);
 c.stderr.pipe(process.stderr);
 
 if (pipe) {
   c.stdin.end(pipe);
 }
-
-c.stdout.on('end', stdoutStream.end);
-c.stderr.on('end', stderrStream.end);

--- a/src/exec-child.js
+++ b/src/exec-child.js
@@ -18,17 +18,21 @@ var execOptions = params.execOptions;
 var pipe = params.pipe;
 var stdoutFile = params.stdoutFile;
 var stderrFile = params.stderrFile;
-var codeFile = params.codeFile;
 
-var c = childProcess.exec(cmd, execOptions, function (err) {
-  if (!err) {
-    fs.writeFileSync(codeFile, '0');
-  } else if (err.code === undefined) {
-    fs.writeFileSync(codeFile, '1');
-  } else {
-    fs.writeFileSync(codeFile, err.code.toString());
-  }
-});
+try {
+  var c = childProcess.exec(cmd, execOptions, function (err) {
+    if (!err) {
+      process.exit(0);
+    } else if (err.code === undefined) {
+      process.exit(1);
+    } else {
+      process.exit(err.code);
+    }
+  });
+} catch (e) {
+  // child_process could not run the command.
+  process.exit(127);
+}
 
 var stdoutStream = fs.createWriteStream(stdoutFile);
 var stderrStream = fs.createWriteStream(stderrFile);

--- a/src/exec-child.js
+++ b/src/exec-child.js
@@ -19,22 +19,15 @@ var pipe = params.pipe;
 var stdoutFile = params.stdoutFile;
 var stderrFile = params.stderrFile;
 
-var c;
-try {
-  c = childProcess.exec(cmd, execOptions, function (err) {
-    if (!err) {
-      process.exitCode = 0;
-    } else if (err.code === undefined) {
-      process.exitCode = 1;
-    } else {
-      process.exitCode = err.code;
-    }
-  });
-} catch (e) {
-  // child_process could not run the command.
-  /* istanbul ignore next */
-  process.exitCode = 127;
-}
+var c = childProcess.exec(cmd, execOptions, function (err) {
+  if (!err) {
+    process.exitCode = 0;
+  } else if (err.code === undefined) {
+    process.exitCode = 1;
+  } else {
+    process.exitCode = err.code;
+  }
+});
 
 var stdoutStream = fs.createWriteStream(stdoutFile);
 var stderrStream = fs.createWriteStream(stderrFile);


### PR DESCRIPTION
This parameter isn't needed, we can easily rely on exit code status for this.

Eliminating the parameter reduces file IO, code complexity, and removes a busy
loop.

Issue #782