### PR TITLE
Remove separate "internal error" from exec

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -77,14 +77,14 @@ function execSync(cmd, opts, pipe) {
 
   // fs.readFileSync uses buffer encoding by default, so call
   // it without the encoding option if the encoding is 'buffer'
-  var stdout;
-  var stderr;
+  var stdout = '';
+  var stderr = '';
   if (opts.encoding === 'buffer') {
-    stdout = fs.readFileSync(stdoutFile);
-    stderr = fs.readFileSync(stderrFile);
+    try { stdout = fs.readFileSync(stdoutFile); } catch (e) {}
+    try { stderr = fs.readFileSync(stderrFile); } catch (e) {}
   } else {
-    stdout = fs.readFileSync(stdoutFile, opts.encoding);
-    stderr = fs.readFileSync(stderrFile, opts.encoding);
+    try { stdout = fs.readFileSync(stdoutFile, opts.encoding); } catch (e) {}
+    try { stderr = fs.readFileSync(stderrFile, opts.encoding); } catch (e) {}
   }
 
   // No biggie if we can't erase the files now -- they're in a temp dir anyway

--- a/src/exec.js
+++ b/src/exec.js
@@ -6,6 +6,7 @@ var fs = require('fs');
 var child = require('child_process');
 
 var DEFAULT_MAXBUFFER_SIZE = 20 * 1024 * 1024;
+var DEFAULT_ERROR_CODE = 1;
 
 common.register('exec', _exec, {
   unix: false,
@@ -72,7 +73,7 @@ function execSync(cmd, opts, pipe) {
     child.execFileSync(common.config.execPath, execArgs, opts);
   } catch (e) {
     // Commands with non-zero exit code raise an exception.
-    code = e.status;
+    code = e.status || DEFAULT_ERROR_CODE;
   }
 
   // fs.readFileSync uses buffer encoding by default, so call

--- a/src/exec.js
+++ b/src/exec.js
@@ -76,15 +76,17 @@ function execSync(cmd, opts, pipe) {
   }
 
   // fs.readFileSync uses buffer encoding by default, so call
-  // it without the encoding option if the encoding is 'buffer'
+  // it without the encoding option if the encoding is 'buffer'.
+  // Also, if the exec timeout is too short for node to start up,
+  // the files will not be created, so these calls will throw.
   var stdout = '';
   var stderr = '';
   if (opts.encoding === 'buffer') {
-    try { stdout = fs.readFileSync(stdoutFile); } catch (e) {}
-    try { stderr = fs.readFileSync(stderrFile); } catch (e) {}
+    stdout = fs.readFileSync(stdoutFile);
+    stderr = fs.readFileSync(stderrFile);
   } else {
-    try { stdout = fs.readFileSync(stdoutFile, opts.encoding); } catch (e) {}
-    try { stderr = fs.readFileSync(stderrFile, opts.encoding); } catch (e) {}
+    stdout = fs.readFileSync(stdoutFile, opts.encoding);
+    stderr = fs.readFileSync(stderrFile, opts.encoding);
   }
 
   // No biggie if we can't erase the files now -- they're in a temp dir anyway

--- a/src/exec.js
+++ b/src/exec.js
@@ -93,7 +93,7 @@ function execSync(cmd, opts, pipe) {
   try { common.unlinkSync(stdoutFile); } catch (e) {}
 
   if (code !== 0) {
-    common.error('', code, { continue: true });
+    common.error(stderr, code, { continue: true });
   }
   var obj = common.ShellString(stdout, stderr, code);
   return obj;
@@ -196,14 +196,10 @@ function _exec(command, options, callback) {
     async: false,
   }, options);
 
-  try {
-    if (options.async) {
-      return execAsync(command, options, pipe, callback);
-    } else {
-      return execSync(command, options, pipe);
-    }
-  } catch (e) {
-    common.error('internal error');
+  if (options.async) {
+    return execAsync(command, options, pipe, callback);
+  } else {
+    return execSync(command, options, pipe);
   }
 }
 module.exports = _exec;

--- a/test/exec.js
+++ b/test/exec.js
@@ -35,6 +35,10 @@ test('config.fatal and unknown command', t => {
   shell.config.fatal = true;
   t.throws(() => {
     shell.exec('asdfasdf'); // could not find command
+    // the expected message depends on where tests are run:
+    //   /bin/sh says "foo: not found"
+    //   /bin/bash says "foo: command not found"
+    //   cmd.exe says "'foo' is not recognized..."
   }, /((asdfasdf: not found)|(asdfasdf: command not found)|('asdfasdf' is not recognized))/);
   shell.config.fatal = oldFatal;
 });

--- a/test/exec.js
+++ b/test/exec.js
@@ -131,10 +131,8 @@ test('set timeout option', t => {
   const result = shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`); // default timeout is ok
   t.falsy(shell.error());
   t.is(result.code, 0);
-  const err = t.throws(() => {
-    shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`, { timeout: 10 }); // times out
-  }, /ENOENT: no such file or directory/);
-  t.is(err.name, 'ShellJSInternalError');
+  shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`, { timeout: 10 }); // times out
+  t.truthy(shell.error());
 });
 
 test('check process.env works', t => {

--- a/test/exec.js
+++ b/test/exec.js
@@ -131,7 +131,7 @@ test('set timeout option', t => {
   const result = shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`); // default timeout is ok
   t.falsy(shell.error());
   t.is(result.code, 0);
-  shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`, { timeout: 10 }); // times out
+  shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 2000`, { timeout: 1000 }); // times out
   t.truthy(shell.error());
 });
 

--- a/test/exec.js
+++ b/test/exec.js
@@ -35,7 +35,7 @@ test('config.fatal and unknown command', t => {
   shell.config.fatal = true;
   t.throws(() => {
     shell.exec('asdfasdf'); // could not find command
-  }, /asdfasdf: command not found/);
+  }, /((asdfasdf: not found)|(asdfasdf: command not found)|('asdfasdf' is not recognized))/);
   shell.config.fatal = oldFatal;
 });
 

--- a/test/exec.js
+++ b/test/exec.js
@@ -35,11 +35,7 @@ test('config.fatal and unknown command', t => {
   shell.config.fatal = true;
   t.throws(() => {
     shell.exec('asdfasdf'); // could not find command
-    // the expected message depends on where tests are run:
-    //   /bin/sh says "foo: not found"
-    //   /bin/bash says "foo: command not found"
-    //   cmd.exe says "'foo' is not recognized..."
-  }, /((asdfasdf: not found)|(asdfasdf: command not found)|('asdfasdf' is not recognized))/);
+  }, /asdfasdf/); // name of command should be in error message
   shell.config.fatal = oldFatal;
 });
 

--- a/test/exec.js
+++ b/test/exec.js
@@ -35,7 +35,7 @@ test('config.fatal and unknown command', t => {
   shell.config.fatal = true;
   t.throws(() => {
     shell.exec('asdfasdf'); // could not find command
-  }, /exec: internal error/);
+  }, /asdfasdf: command not found/);
   shell.config.fatal = oldFatal;
 });
 
@@ -127,8 +127,10 @@ test('set timeout option', t => {
   const result = shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`); // default timeout is ok
   t.falsy(shell.error());
   t.is(result.code, 0);
-  shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`, { timeout: 10 }); // times out
-  t.truthy(shell.error());
+  const err = t.throws(() => {
+    shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`, { timeout: 10 }); // times out
+  }, /ENOENT: no such file or directory/);
+  t.is(err.name, 'ShellJSInternalError');
 });
 
 test('check process.env works', t => {


### PR DESCRIPTION
Fixes #734 

Removes `common.error('internal error')` from `exec`, allowing any internal errors in `exec` to be wrapped by `ShellJSInternalError` instead.