### PR TITLE
refactor(exec): remove paramsFile

### DIFF
--- a/src/exec-child.js
+++ b/src/exec-child.js
@@ -5,10 +5,7 @@ if (require.main !== module) {
 var childProcess = require('child_process');
 var fs = require('fs');
 
-var paramFilePath = process.argv[2];
-
-var serializedParams = fs.readFileSync(paramFilePath, 'utf8');
-var params = JSON.parse(serializedParams);
+var params = JSON.parse(process.argv[2]);
 
 var cmd = params.command;
 var execOptions = params.execOptions;

--- a/src/exec.js
+++ b/src/exec.js
@@ -21,7 +21,6 @@ function execSync(cmd, opts, pipe) {
   }
 
   var tempDir = _tempDir();
-  var paramsFile = path.resolve(tempDir + '/' + common.randomFileName());
   var stderrFile = path.resolve(tempDir + '/' + common.randomFileName());
   var stdoutFile = path.resolve(tempDir + '/' + common.randomFileName());
 
@@ -33,7 +32,6 @@ function execSync(cmd, opts, pipe) {
     encoding: 'utf8',
   }, opts);
 
-  if (fs.existsSync(paramsFile)) common.unlinkSync(paramsFile);
   if (fs.existsSync(stderrFile)) common.unlinkSync(stderrFile);
   if (fs.existsSync(stdoutFile)) common.unlinkSync(stdoutFile);
 
@@ -47,11 +45,9 @@ function execSync(cmd, opts, pipe) {
     stderrFile: stderrFile,
   };
 
-  fs.writeFileSync(paramsFile, JSON.stringify(paramsToSerialize), 'utf8');
-
   var execArgs = [
     path.join(__dirname, 'exec-child.js'),
-    paramsFile,
+    JSON.stringify(paramsToSerialize),
   ];
 
   /* istanbul ignore else */
@@ -88,7 +84,6 @@ function execSync(cmd, opts, pipe) {
   }
 
   // No biggie if we can't erase the files now -- they're in a temp dir anyway
-  try { common.unlinkSync(paramsFile); } catch (e) {}
   try { common.unlinkSync(stderrFile); } catch (e) {}
   try { common.unlinkSync(stdoutFile); } catch (e) {}
 


### PR DESCRIPTION
The `paramsFile` is obsolete now that we use `execFileSync()` for our
internal implementation. Instead, we pass parameters to the child
process directly as a single commandline parameter to reduce file I/O.

Issue #782