### PR TITLE
chore(lint): don't allow excess trailing newlines

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,7 @@
     "consistent-return": "off",
     "no-mixed-operators": "off",
     "no-prototype-builtins": "off",
-    "no-multiple-empty-lines": ["error", { "max": 2, "maxEOF": 0 } ],
+    "no-multiple-empty-lines": ["error", { "max": 2, "maxBOF": 0, "maxEOF": 0 } ],
     "new-cap": ["error", {
       "capIsNewExceptions": [
         "ShellString"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
     "consistent-return": "off",
     "no-mixed-operators": "off",
     "no-prototype-builtins": "off",
+    "no-multiple-empty-lines": ["error", { "max": 2, "maxEOF": 0 } ],
     "new-cap": ["error", {
       "capIsNewExceptions": [
         "ShellString"


### PR DESCRIPTION
This enforces that files should not end with blank lines (i.e. more than
one trailing newline). The `eol-last` rule (inherited from airbnb's
config) already enforces that files end in at least one trailing
newline, so adding this rule enforces that it ends in exactly 1.

See https://eslint.org/docs/rules/no-multiple-empty-lines and
https://eslint.org/docs/rules/eol-last for more information.

Inspired by #809.