### PR TITLE
Revert "refactor(exec): remove paramsFile (#807)"

### DIFF
--- a/src/exec-child.js
+++ b/src/exec-child.js
@@ -5,7 +5,10 @@ if (require.main !== module) {
 var childProcess = require('child_process');
 var fs = require('fs');
 
-var params = JSON.parse(process.argv[2]);
+var paramFilePath = process.argv[2];
+
+var serializedParams = fs.readFileSync(paramFilePath, 'utf8');
+var params = JSON.parse(serializedParams);
 
 var cmd = params.command;
 var execOptions = params.execOptions;

--- a/src/exec.js
+++ b/src/exec.js
@@ -21,6 +21,7 @@ function execSync(cmd, opts, pipe) {
   }
 
   var tempDir = _tempDir();
+  var paramsFile = path.resolve(tempDir + '/' + common.randomFileName());
   var stderrFile = path.resolve(tempDir + '/' + common.randomFileName());
   var stdoutFile = path.resolve(tempDir + '/' + common.randomFileName());
 
@@ -32,6 +33,7 @@ function execSync(cmd, opts, pipe) {
     encoding: 'utf8',
   }, opts);
 
+  if (fs.existsSync(paramsFile)) common.unlinkSync(paramsFile);
   if (fs.existsSync(stderrFile)) common.unlinkSync(stderrFile);
   if (fs.existsSync(stdoutFile)) common.unlinkSync(stdoutFile);
 
@@ -45,9 +47,11 @@ function execSync(cmd, opts, pipe) {
     stderrFile: stderrFile,
   };
 
+  fs.writeFileSync(paramsFile, JSON.stringify(paramsToSerialize), 'utf8');
+
   var execArgs = [
     path.join(__dirname, 'exec-child.js'),
-    JSON.stringify(paramsToSerialize),
+    paramsFile,
   ];
 
   /* istanbul ignore else */
@@ -84,6 +88,7 @@ function execSync(cmd, opts, pipe) {
   }
 
   // No biggie if we can't erase the files now -- they're in a temp dir anyway
+  try { common.unlinkSync(paramsFile); } catch (e) {}
   try { common.unlinkSync(stderrFile); } catch (e) {}
   try { common.unlinkSync(stdoutFile); } catch (e) {}
 


### PR DESCRIPTION
This reverts commit 64d5899abc86dd7b7fa84455c0ce3551786c4b5b.

Reason for revert: If stdin is large, then the param object can become
an extremely long string, exceeding the maximum OS size limit on
commandline parameters.

Original change's description:
> refactor(exec): remove paramsFile (#807)
>
> The `paramsFile` is obsolete now that we use `execFileSync()` for our
> internal implementation. Instead, we pass parameters to the child
> process directly as a single commandline parameter to reduce file I/O.
>
> Issue #782

Fixes #818