### PR TITLE
Allow ln destination to be an existing directory, fixes #832

### DIFF
--- a/src/ln.js
+++ b/src/ln.js
@@ -35,6 +35,10 @@ function _ln(options, source, dest) {
   var isAbsolute = (path.resolve(source) === sourcePath);
   dest = path.resolve(process.cwd(), String(dest));
 
+  if (fs.existsSync(dest) && common.statFollowLinks(dest).isDirectory(dest)) {
+    dest = path.resolve(dest, path.basename(sourcePath))
+  }
+
   if (fs.existsSync(dest)) {
     if (!options.force) {
       common.error('Destination file exists', { continue: true });

--- a/test/ln.js
+++ b/test/ln.js
@@ -48,6 +48,14 @@ test('destination already exists', t => {
   t.is(result.code, 1);
 });
 
+test('destination already exists inside directory', t => {
+  shell.cd(t.context.tmp);
+  let result = shell.ln('-s', 'file1', './');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  shell.cd('..');
+});
+
 test('non-existent source', t => {
   const result = shell.ln(`${t.context.tmp}/noexist`, `${t.context.tmp}/linkfile1`);
   t.truthy(shell.error());
@@ -134,6 +142,19 @@ test('To current directory', t => {
   t.truthy(fs.existsSync('dest/testfile.txt'));
   t.truthy(fs.existsSync('dir1/insideDir.txt'));
   t.falsy(fs.existsSync('dest/insideDir.txt'));
+  shell.cd('..');
+});
+
+test('Inside existing directory', t => {
+  shell.cd(t.context.tmp);
+  let result = shell.ln('-s', 'external/node_script.js', './');
+  t.is(result.code, 0);
+  t.truthy(fs.existsSync('node_script.js'));
+  t.is(
+    fs.readFileSync('external/node_script.js').toString(),
+    fs.readFileSync('node_script.js').toString()
+  );
+  shell.rm('node_script.js');
   shell.cd('..');
 });
 


### PR DESCRIPTION
This allows symlinking destinations to be existing directories. Symlinks will be placed *inside* those, as described in #832.