### PR TITLE
Verify code coverage of ls() on Travis

### DIFF
--- a/src/ls.js
+++ b/src/ls.js
@@ -79,9 +79,11 @@ function _ls(options, paths) {
       stat = options.link ? common.statFollowLinks(p) : common.statNoFollowLinks(p);
       // follow links to directories by default
       if (stat.isSymbolicLink()) {
+        console.log('[795] Follow symlink');
         try {
           var _stat = common.statFollowLinks(p);
           if (_stat.isDirectory()) {
+            console.log('[795] Follow existed symlink of directory');
             stat = _stat;
           }
         } catch (_) {} // bad symlink, treat it like a file


### PR DESCRIPTION
### DON'T MERGE

This is to verify if #795 needs fix or not.
As described [here](https://github.com/shelljs/shelljs/issues/795#issuecomment-382564583), let's see if there are `console.log()` messages get printed out on Travis.

If our assumption is correct, we should see
```
[795] Follow symlink
[795] Follow existed symlink of directory
[795] Follow symlink
```
on travis log.