### PR TITLE
Add '-p' (preserve) option to 'cp', fixes #771

### DIFF
--- a/src/cp.js
+++ b/src/cp.js
@@ -11,6 +11,7 @@ common.register('cp', _cp, {
     'r': 'recursive',
     'L': 'followsymlink',
     'P': 'noFollowsymlink',
+    'p': 'preserve',
   },
   wrapOutput: false,
 });
@@ -51,6 +52,7 @@ function copyFileSync(srcFile, destFile, options) {
     var pos = 0;
     var fdr = null;
     var fdw = null;
+    var srcStat = common.statFollowLinks(srcFile);
 
     try {
       fdr = fs.openSync(srcFile, 'r');
@@ -75,7 +77,11 @@ function copyFileSync(srcFile, destFile, options) {
     fs.closeSync(fdr);
     fs.closeSync(fdw);
 
-    fs.chmodSync(destFile, common.statFollowLinks(srcFile).mode);
+    if (options.preserve) {
+      fs.chownSync(destFile, srcStat.uid, srcStat.gid);
+      fs.utimesSync(destFile, srcStat.atime, srcStat.mtime);
+    }
+    fs.chmodSync(destFile, srcStat.mode);
   }
 }
 

--- a/src/cp.js
+++ b/src/cp.js
@@ -74,13 +74,13 @@ function copyFileSync(srcFile, destFile, options) {
       pos += bytesRead;
     }
 
+    if (options.preserve) {
+      fs.fchownSync(fdw, srcStat.uid, srcStat.gid);
+      fs.futimesSync(fdw, srcStat.atime, srcStat.mtime);
+    }
+
     fs.closeSync(fdr);
     fs.closeSync(fdw);
-
-    if (options.preserve) {
-      fs.chownSync(destFile, srcStat.uid, srcStat.gid);
-      fs.utimesSync(destFile, srcStat.atime, srcStat.mtime);
-    }
   }
 }
 

--- a/src/cp.js
+++ b/src/cp.js
@@ -62,7 +62,7 @@ function copyFileSync(srcFile, destFile, options) {
     }
 
     try {
-      fdw = fs.openSync(destFile, 'w');
+      fdw = fs.openSync(destFile, 'w', srcStat.mode);
     } catch (e) {
       /* istanbul ignore next */
       common.error('copyFileSync: could not write to dest file (code=' + e.code + '):' + destFile);
@@ -81,7 +81,6 @@ function copyFileSync(srcFile, destFile, options) {
       fs.chownSync(destFile, srcStat.uid, srcStat.gid);
       fs.utimesSync(destFile, srcStat.atime, srcStat.mtime);
     }
-    fs.chmodSync(destFile, srcStat.mode);
   }
 }
 

--- a/test/cp.js
+++ b/test/cp.js
@@ -760,9 +760,12 @@ test('should not overwrite recently created files (not give error no-force mode)
 test('cp -p should preserve mode, ownership, and timestamp', t => {
   const result = shell.cp('-p', 'test/resources/file1', `${t.context.tmp}/preservedFile1`);
   const stat = common.statFollowLinks('test/resources/file1');
+  if (process.platform === 'linux') {
+    utils.sleep(1000);
+  }
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/preservedFile1`);
-  t.is(result.code, 0);
 
+  t.is(result.code, 0);
   t.is(stat.mtime.getTime(), statOfResult.mtime.getTime());
   t.is(stat.atime.getTime(), statOfResult.atime.getTime());
   t.is(stat.mode, statOfResult.mode);
@@ -773,9 +776,12 @@ test('cp -p should preserve mode, ownership, and timestamp', t => {
 test('cp -p should preserve mode, ownership, and timestamp of symlink', t => {
   const result = shell.cp('-p', 'test/resources/link', `${t.context.tmp}/copiedLink`);
   const stat = common.statFollowLinks('test/resources/link');
+  if (process.platform === 'linux') {
+    utils.sleep(1000);
+  }
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/copiedLink`);
-  t.is(result.code, 0);
 
+  t.is(result.code, 0);
   t.is(stat.mtime.getTime(), statOfResult.mtime.getTime());
   t.is(stat.atime.getTime(), statOfResult.atime.getTime());
   t.is(stat.mode, statOfResult.mode);

--- a/test/cp.js
+++ b/test/cp.js
@@ -758,8 +758,8 @@ test('should not overwrite recently created files (not give error no-force mode)
 });
 
 test('cp -p should preserve mode, ownership, and timestamp', t => {
-  const result = shell.cp('-p', 'test/resources/file1', `${t.context.tmp}/preservedFile1`);
-  const stat = common.statFollowLinks('test/resources/file1');
+  const result = shell.cp('-p', 'test/resources/cp/file1', `${t.context.tmp}/preservedFile1`);
+  const stat = common.statFollowLinks('test/resources/cp/file1');
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/preservedFile1`);
 
   t.is(result.code, 0);
@@ -772,6 +772,7 @@ test('cp -p should preserve mode, ownership, and timestamp', t => {
 
 test('cp -p should preserve mode, ownership, and timestamp of symlink', t => {
   const result = shell.cp('-p', 'test/resources/link', `${t.context.tmp}/copiedLink`);
+  utils.sleep(1000);
   const stat = common.statFollowLinks('test/resources/link');
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/copiedLink`);
 

--- a/test/cp.js
+++ b/test/cp.js
@@ -756,3 +756,29 @@ test('should not overwrite recently created files (not give error no-force mode)
   // Ensure First file is copied
   t.is(shell.cat(`${t.context.tmp}/file1`).toString(), 'test1');
 });
+
+test('cp -p should preserve mode, ownership, and timestamp', t => {
+  const result = shell.cp('-p', 'test/resources/file1', `${t.context.tmp}/preservedFile1`);
+  const stat = common.statFollowLinks('test/resources/file1');
+  const statOfResult = common.statFollowLinks(`${t.context.tmp}/preservedFile1`);
+  t.is(result.code, 0);
+
+  t.is(stat.mtime.getTime(), statOfResult.mtime.getTime());
+  t.is(stat.atime.getTime(), statOfResult.atime.getTime());
+  t.is(stat.mode, statOfResult.mode);
+  t.is(stat.uid, statOfResult.uid);
+  t.is(stat.gid, statOfResult.gid);
+});
+
+test('cp -p should preserve mode, ownership, and timestamp of symlink', t => {
+  const result = shell.cp('-p', 'test/resources/link', `${t.context.tmp}/copiedLink`);
+  const stat = common.statFollowLinks('test/resources/link');
+  const statOfResult = common.statFollowLinks(`${t.context.tmp}/copiedLink`);
+  t.is(result.code, 0);
+
+  t.is(stat.mtime.getTime(), statOfResult.mtime.getTime());
+  t.is(stat.atime.getTime(), statOfResult.atime.getTime());
+  t.is(stat.mode, statOfResult.mode);
+  t.is(stat.uid, statOfResult.uid);
+  t.is(stat.rid, statOfResult.rid);
+});

--- a/test/cp.js
+++ b/test/cp.js
@@ -760,9 +760,6 @@ test('should not overwrite recently created files (not give error no-force mode)
 test('cp -p should preserve mode, ownership, and timestamp', t => {
   const result = shell.cp('-p', 'test/resources/file1', `${t.context.tmp}/preservedFile1`);
   const stat = common.statFollowLinks('test/resources/file1');
-  if (process.platform === 'linux') {
-    utils.sleep(1000);
-  }
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/preservedFile1`);
 
   t.is(result.code, 0);
@@ -776,9 +773,6 @@ test('cp -p should preserve mode, ownership, and timestamp', t => {
 test('cp -p should preserve mode, ownership, and timestamp of symlink', t => {
   const result = shell.cp('-p', 'test/resources/link', `${t.context.tmp}/copiedLink`);
   const stat = common.statFollowLinks('test/resources/link');
-  if (process.platform === 'linux') {
-    utils.sleep(1000);
-  }
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/copiedLink`);
 
   t.is(result.code, 0);


### PR DESCRIPTION
This fixes #771. 

### WIP
This is still work in progress. But I want to make sure I am on the right track so I just create pull request first.

I don't plan to implement the full `--preserve=ATTR_LIST` feature in this PR. I think that could be a follow-up work.

### TODO
- [ ] Add doc and run `npm run gendocs`
- [ ] Add test for `cp -p` on directory 
- [x] Figure out why tests fail on Travis CI