### PR TITLE
chore: update shelljs-release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-import": "^1.11.1",
     "nyc": "^11.3.0",
     "shelljs-changelog": "^0.2.0",
-    "shelljs-release": "^0.2.0",
+    "shelljs-release": "^0.3.0",
     "shx": "^0.2.0",
     "travis-check-changes": "^0.2.0"
   },


### PR DESCRIPTION
This bumps the version of our dependency, shelljs-release. I just cut
the 3.0 release for shelljs-release, which contains support for the
`--otp` flag, as well as the significant refactoring work we put in.