### PR TITLE
Prevent require-ing bin/shjs

### DIFF
--- a/bin/shjs
+++ b/bin/shjs
@@ -1,19 +1,20 @@
 #!/usr/bin/env node
 
-function exit(msg) {
+if (require.main !== module) {
+  throw new Error('Executable-only module should not be required');
+}
+
+function exitWithErrorMessage(msg) {
   console.log(msg);
   console.log();
   process.exit(1);
 }
 
-if (require.main !== module) {
-  throw new Error('Executable-only module should not be required');
-}
-
 if (process.argv.length < 3) {
-  exit('ShellJS: missing argument (script name)');
+  exitWithErrorMessage('ShellJS: missing argument (script name)');
 }
 
+// we only need ShellJS methods past this point, so require here
 require('../global');
 
 var args,
@@ -28,7 +29,7 @@ if (!scriptName.match(/\.js/) && !scriptName.match(/\.coffee/)) {
 }
 
 if (!test('-f', scriptName)) {
-  exit('ShellJS: script not found ('+scriptName+')');
+  exitWithErrorMessage('ShellJS: script not found ('+scriptName+')');
 }
 
 args = process.argv.slice(3);

--- a/bin/shjs
+++ b/bin/shjs
@@ -4,6 +4,10 @@ if (require.main !== module) {
   throw new Error('Executable-only module should not be required');
 }
 
+// we must import global ShellJS methods after the require.main check to prevent the global
+// namespace from being polluted if the error is caught
+require('../global');
+
 function exitWithErrorMessage(msg) {
   console.log(msg);
   console.log();
@@ -13,9 +17,6 @@ function exitWithErrorMessage(msg) {
 if (process.argv.length < 3) {
   exitWithErrorMessage('ShellJS: missing argument (script name)');
 }
-
-// we only need ShellJS methods past this point, so require here
-require('../global');
 
 var args,
   scriptName = process.argv[2];

--- a/bin/shjs
+++ b/bin/shjs
@@ -1,11 +1,20 @@
 #!/usr/bin/env node
-require('../global');
 
-if (process.argv.length < 3) {
-  console.log('ShellJS: missing argument (script name)');
+function exit(msg) {
+  console.log(msg);
   console.log();
   process.exit(1);
 }
+
+if (require.main !== module) {
+  throw new Error('Executable-only module should not be required');
+}
+
+if (process.argv.length < 3) {
+  exit('ShellJS: missing argument (script name)');
+}
+
+require('../global');
 
 var args,
   scriptName = process.argv[2];
@@ -19,9 +28,7 @@ if (!scriptName.match(/\.js/) && !scriptName.match(/\.coffee/)) {
 }
 
 if (!test('-f', scriptName)) {
-  console.log('ShellJS: script not found ('+scriptName+')');
-  console.log();
-  process.exit(1);
+  exit('ShellJS: script not found ('+scriptName+')');
 }
 
 args = process.argv.slice(3);

--- a/test/shjs.js
+++ b/test/shjs.js
@@ -4,9 +4,10 @@ import test from 'ava';
 
 import shell from '..';
 
+const binPath = path.resolve(__dirname, '../bin/shjs');
+
 function runWithShjs(name) {
   // prefix with 'node ' for Windows, don't prefix for unix
-  const binPath = path.resolve(__dirname, '../bin/shjs');
   const execPath = process.platform === 'win32'
     ? `${JSON.stringify(shell.config.execPath)} `
     : '';
@@ -51,4 +52,12 @@ test('Extension detection', t => {
   t.is(result.code, 0);
   t.is(result.stdout, 'OK!\n');
   t.falsy(result.stderr);
+});
+
+//
+// Invalids
+//
+
+test('disallow require-ing', t => {
+  t.throws(() => require(binPath), 'Executable-only module should not be required');
 });


### PR DESCRIPTION
Fixes #789 

This makes it so that `bin/shjs` cannot be `require`d as a module, and adds a test for this.