### PR TITLE
chore: output npm version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - source ~/.nvm/nvm.sh
   - nvm install $NODE_VERSION
   - node --version
+  - npm --version
   - npm install
 os:
   - linux


### PR DESCRIPTION
Knowing the `npm` version was a huge help to debugging issue #844. For
some reason, we output this on appveyor but not on Travis. This PR fixes
that.