### PR TITLE
chore: bump CI to run against node v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - NODE_VERSION="7"
   - NODE_VERSION="8"
   - NODE_VERSION="9"
+  - NODE_VERSION="10"
 
 # keep this blank to make sure there are no before_install steps
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+    - nodejs_version: '10'
     - nodejs_version: '9'
     - nodejs_version: '8'
     - nodejs_version: '7'


### PR DESCRIPTION
This adds node v10 to both Travis and Appveyor.