### PR TITLE
feat: add shell.cmd to replace exec

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -2,6 +2,8 @@ module.exports = [
   'cat',
   'cd',
   'chmod',
+  // TODO(nfischer): uncomment this when shell.cmd() is finished.
+  // 'cmd',
   'cp',
   'dirs',
   'echo',

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "shjs": "./bin/shjs"
   },
   "dependencies": {
+    "execa": "^1.0.0",
     "glob": "^7.0.0",
     "interpret": "^1.0.0",
     "rechoir": "^0.6.2"

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -1,0 +1,88 @@
+var common = require('./common');
+var execa = require('execa');
+
+var DEFAULT_MAXBUFFER_SIZE = 20 * 1024 * 1024;
+var COMMAND_NOT_FOUND_ERROR_CODE = 127;
+
+common.register('cmd', _cmd, {
+  cmdOptions: null,
+  globStart: 1,
+  canReceivePipe: true,
+  wrapOutput: true,
+});
+
+function commandNotFound(execaResult) {
+  if (process.platform === 'win32') {
+    var str = 'is not recognized as an internal or external command';
+    return execaResult.code && execaResult.stderr.includes(str);
+  } else {
+    return execaResult.code &&
+      execaResult.stdout === null && execaResult.stderr === null;
+  }
+}
+
+function _cmd(options, command, commandArgs, userOptions) {
+  if (!command) {
+    common.error('Must specify a non-empty string as a command');
+  }
+
+  // `options` will usually not have a value: it's added by our commandline flag
+  // parsing engine.
+  commandArgs = [].slice.call(arguments, 2);
+
+  // `userOptions` may or may not be provided. We need to check the last
+  // argument. If it's an object, assume it's meant to be passed as
+  // userOptions (since ShellStrings are already flattened to strings).
+  if (commandArgs.length === 0) {
+    userOptions = {};
+  } else {
+    var lastArg = commandArgs.pop();
+    if (common.isObject(lastArg)) {
+      userOptions = lastArg;
+    } else {
+      userOptions = {};
+      commandArgs.push(lastArg);
+    }
+  }
+
+  var pipe = common.readFromPipe();
+
+  // Some of our defaults differ from execa's defaults. These can be overridden
+  // by the user.
+  var defaultOptions = {
+    maxBuffer: DEFAULT_MAXBUFFER_SIZE,
+    stripEof: false, // Preserve trailing newlines for consistency with unix.
+    reject: false, // Use ShellJS's error handling system.
+  };
+
+  // For other options, we forbid the user from overriding them (either for
+  // correctness or security).
+  var requiredOptions = {
+    input: pipe,
+    shell: false,
+  };
+
+  var execaOptions =
+    Object.assign(defaultOptions, userOptions, requiredOptions);
+
+  var result = execa.sync(command, commandArgs, execaOptions);
+  var stdout;
+  var stderr;
+  var code;
+  if (commandNotFound(result)) {
+    // This can happen if `command` is not an executable binary, or possibly
+    // under other conditions.
+    stdout = '';
+    stderr = "'" + command + "': command not found";
+    code = COMMAND_NOT_FOUND_ERROR_CODE;
+  } else {
+    stdout = result.stdout.toString();
+    stderr = result.stderr.toString();
+    code = result.code;
+  }
+
+  // Pass `continue: true` so we can specify a value for stdout.
+  if (code) common.error(stderr, code, { silent: true, continue: true });
+  return new common.ShellString(stdout, stderr, code);
+}
+module.exports = _cmd;

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,0 +1,258 @@
+import path from 'path';
+
+import test from 'ava';
+
+import shell from '..';
+
+// TODO(nfischer): remove this when shell.cmd() is finished. For now, load it
+// like any other plugin.
+require('../src/cmd');
+
+const CWD = process.cwd();
+
+test.beforeEach(() => {
+  process.chdir(CWD);
+  shell.config.resetForTesting();
+});
+
+//
+// Invalids
+//
+
+test('no args', t => {
+  shell.cmd();
+  t.truthy(shell.error());
+});
+
+test('unknown command', t => {
+  const result = shell.cmd('asdfasdf'); // could not find command
+  t.truthy(result.code > 0);
+  t.is(result.code, 127);
+});
+
+test('config.fatal and unknown command', t => {
+  shell.config.fatal = true;
+  t.throws(() => {
+    shell.cmd('asdfasdf'); // could not find command
+  }, /.*command not found.*/);
+});
+
+// TODO(nfischer): enable only if we implement realtime output + captured
+// output.
+test.skip('cmd exits gracefully if we cannot find the execPath', t => {
+  shell.config.execPath = null;
+  shell.cmd('shx', 'echo', 'foo');
+  t.regex(
+    shell.error(),
+    /Unable to find a path to the node binary\. Please manually set config\.execPath/
+  );
+});
+
+//
+// Valids
+//
+
+//
+// sync
+//
+
+test('check if stdout goes to output', t => {
+  const result = shell.cmd('shx', 'echo', 'this is stdout');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, 'this is stdout\n');
+});
+
+test('check if stderr goes to output', t => {
+  const result = shell.cmd(shell.config.execPath, '-e', 'console.error("1234");');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, '');
+  t.is(result.stderr, '1234\n');
+});
+
+test('check if stdout + stderr go to output', t => {
+  const result = shell.cmd(shell.config.execPath, '-e', 'console.error(1234); console.log(666);');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, '666\n');
+  t.is(result.stderr, '1234\n');
+});
+
+test('check exit code', t => {
+  const result = shell.cmd(shell.config.execPath, '-e', 'process.exit(12);');
+  t.truthy(shell.error());
+  t.is(result.code, 12);
+});
+
+test('interaction with cd', t => {
+  shell.cd('test/resources/external');
+  const result = shell.cmd(shell.config.execPath, 'node_script.js');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, 'node_script_1234\n');
+});
+
+test('no need to escape quotes', t => {
+  const result = shell.cmd(shell.config.execPath, '-e',
+      `console.log("'+'_'+'");`); // eslint-disable-line quotes
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, "'+'_'+'\n");
+});
+
+test('commands can contain newlines', t => {
+  // Github issue #175
+  const result = shell.cmd(shell.config.execPath, '-e', `
+console.log('line1')
+console.log('line2')
+`);
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, 'line1\nline2\n');
+});
+
+test('does not expand shell-style variables', t => {
+  shell.env.FOO = 'Hello world';
+  const result = shell.cmd('shx', 'echo', '$FOO');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, '$FOO\n');
+});
+
+test('does not expand windows-style variables', t => {
+  shell.env.FOO = 'Hello world';
+  let result = shell.cmd('shx', 'echo', '%FOO%');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, '%FOO%\n');
+  result = shell.cmd('shx', 'echo', '!FOO!');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, '!FOO!\n');
+});
+
+test('cannot inject multiple commands', t => {
+  const injection = '; echo semicolon && echo and || echo or';
+  const result = shell.cmd('shx', 'echo', `hi${injection}`);
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, `hi${injection}\n`);
+});
+
+test('supports globbing by default', t => {
+  // `echo` on windows will not glob, so it depends on shell.cmd() to expand the
+  // glob before spawning the subprocess.
+  const result = shell.cmd('shx', 'echo', 'test/resources/*.txt');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  const expectedFiles = [
+    'test/resources/a.txt',
+    'test/resources/file1.txt',
+    'test/resources/file2.txt',
+  ];
+  t.is(result.stdout, `${expectedFiles.join(' ')}\n`);
+});
+
+test('globbing respects config.noglob', t => {
+  shell.config.noglob = true;
+  const result = shell.cmd('shx', 'echo', 'test/resources/*.txt');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, 'test/resources/*.txt\n');
+});
+
+test('set cwd', t => {
+  const result = shell.cmd('shx', 'pwd', { cwd: '..' });
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, path.resolve('..') + '\n');
+});
+
+test('set maxBuffer (very small)', t => {
+  const result = shell.cmd('shx', 'echo', '1234567890'); // default maxBuffer is ok
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, '1234567890\n');
+  shell.cmd('shx', 'echo', '1234567890', { maxBuffer: 6 });
+  t.truthy(shell.error());
+});
+
+test('set timeout option', t => {
+  const result = shell.cmd(shell.config.execPath, 'test/resources/exec/slow.js', '100'); // default timeout is ok
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  shell.cmd(shell.config.execPath, 'test/resources/exec/slow.js', '2000', { timeout: 1000 }); // times out
+  t.truthy(shell.error());
+});
+
+test('check process.env works', t => {
+  shell.env.FOO = 'Hello world';
+  // Launch any sub process, and process.env should be propagated through.
+  const result =
+    shell.cmd(shell.config.execPath, '-p', 'process.env.FOO');
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.is(result.stdout, 'Hello world\n');
+  t.is(result.stderr, '');
+});
+
+test('cmd returns a ShellString', t => {
+  const result = shell.cmd('shx', 'echo', 'foo');
+  t.is(typeof result, 'object');
+  t.truthy(result instanceof String);
+  t.is(typeof result.stdout, 'string');
+  t.is(result.toString(), result.stdout);
+});
+
+//
+// async
+//
+
+// TODO(nfischer): enable after we implement async.
+test.cb.skip('no callback', t => {
+  const c = shell.cmd(shell.config.execPath, '-e', 'console.log(1234)', { async: true });
+  t.falsy(shell.error());
+  t.truthy('stdout' in c, 'async exec returns child process object');
+  t.end();
+});
+
+// TODO(nfischer): enable after we implement async.
+test.cb.skip('callback as 2nd argument', t => {
+  shell.cmd(shell.config.execPath, '-e', 'console.log(5678);', (code, stdout, stderr) => {
+    t.is(code, 0);
+    t.is(stdout, '5678\n');
+    t.is(stderr, '');
+    t.end();
+  });
+});
+
+// TODO(nfischer): enable after we implement async.
+test.cb.skip('callback as end argument', t => {
+  shell.cmd(shell.config.execPath, '-e', 'console.log(5566);', { async: true }, (code, stdout, stderr) => {
+    t.is(code, 0);
+    t.is(stdout, '5566\n');
+    t.is(stderr, '');
+    t.end();
+  });
+});
+
+// TODO(nfischer): enable after we implement async.
+test.cb.skip('callback as 3rd argument (silent:true)', t => {
+  shell.cmd(shell.config.execPath, '-e', 'console.log(5678);', { silent: true }, (code, stdout, stderr) => {
+    t.is(code, 0);
+    t.is(stdout, '5678\n');
+    t.is(stderr, '');
+    t.end();
+  });
+});
+
+// TODO(nfischer): enable after we implement async.
+test.cb.skip('command that fails', t => {
+  shell.cmd('shx', 'cp', 'onlyOneCpArgument.txt', { silent: true }, (code, stdout, stderr) => {
+    t.is(code, 1);
+    t.is(stdout, '');
+    t.is(stderr, 'cp: missing <source> and/or <dest>\n');
+    t.end();
+  });
+});


### PR DESCRIPTION
This adds an initial implementation of shell.cmd(), which is intended as
the eventual replacement for shell.exec(). This PR does not fully
implement the API, but demonstrates a simple and secure alternative, and
will allow further iteration to cover other use cases in follow-up PRs.

Design doc: https://shelljs.page.link/cmd-design

Issue #495
Test: automated test suite