### PR TITLE
Add preserve option to cp

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Available options:
 + `-r`, `-R`: recursive
 + `-L`: follow symlinks
 + `-P`: don't follow symlinks
++ `-p`: preserve file mode, ownership, and timestamps
 
 Examples:
 

--- a/src/cp.js
+++ b/src/cp.js
@@ -76,6 +76,8 @@ function copyFileSync(srcFile, destFile, options) {
 
     if (options.preserve) {
       fs.fchownSync(fdw, srcStat.uid, srcStat.gid);
+      // Note: utimesSync does not work (rounds to seconds), but futimesSync has
+      // millisecond precision.
       fs.futimesSync(fdw, srcStat.atime, srcStat.mtime);
     }
 
@@ -201,6 +203,7 @@ function cpcheckcycle(sourceDir, srcFile) {
 //@ + `-r`, `-R`: recursive
 //@ + `-L`: follow symlinks
 //@ + `-P`: don't follow symlinks
+//@ + `-p`: preserve file mode, ownership, and timestamps
 //@
 //@ Examples:
 //@

--- a/src/cp.js
+++ b/src/cp.js
@@ -11,6 +11,7 @@ common.register('cp', _cp, {
     'r': 'recursive',
     'L': 'followsymlink',
     'P': 'noFollowsymlink',
+    'p': 'preserve',
   },
   wrapOutput: false,
 });
@@ -51,6 +52,7 @@ function copyFileSync(srcFile, destFile, options) {
     var pos = 0;
     var fdr = null;
     var fdw = null;
+    var srcStat = common.statFollowLinks(srcFile);
 
     try {
       fdr = fs.openSync(srcFile, 'r');
@@ -75,7 +77,11 @@ function copyFileSync(srcFile, destFile, options) {
     fs.closeSync(fdr);
     fs.closeSync(fdw);
 
-    fs.chmodSync(destFile, common.statFollowLinks(srcFile).mode);
+    if (options.preserve) {
+      fs.chownSync(destFile, srcStat.uid, srcStat.gid);
+      fs.utimesSync(destFile, srcStat.atime, srcStat.mtime);
+    }
+    fs.chmodSync(destFile, srcStat.mode);
   }
 }
 

--- a/src/cp.js
+++ b/src/cp.js
@@ -74,13 +74,13 @@ function copyFileSync(srcFile, destFile, options) {
       pos += bytesRead;
     }
 
+    if (options.preserve) {
+      fs.fchownSync(fdw, srcStat.uid, srcStat.gid);
+      fs.futimesSync(fdw, srcStat.atime, srcStat.mtime);
+    }
+
     fs.closeSync(fdr);
     fs.closeSync(fdw);
-
-    if (options.preserve) {
-      fs.chownSync(destFile, srcStat.uid, srcStat.gid);
-      fs.utimesSync(destFile, srcStat.atime, srcStat.mtime);
-    }
   }
 }
 

--- a/src/cp.js
+++ b/src/cp.js
@@ -62,7 +62,7 @@ function copyFileSync(srcFile, destFile, options) {
     }
 
     try {
-      fdw = fs.openSync(destFile, 'w');
+      fdw = fs.openSync(destFile, 'w', srcStat.mode);
     } catch (e) {
       /* istanbul ignore next */
       common.error('copyFileSync: could not write to dest file (code=' + e.code + '):' + destFile);
@@ -81,7 +81,6 @@ function copyFileSync(srcFile, destFile, options) {
       fs.chownSync(destFile, srcStat.uid, srcStat.gid);
       fs.utimesSync(destFile, srcStat.atime, srcStat.mtime);
     }
-    fs.chmodSync(destFile, srcStat.mode);
   }
 }
 

--- a/test/cp.js
+++ b/test/cp.js
@@ -826,8 +826,7 @@ test('cp -p should preserve mode, ownership, and timestamp (regular file)', t =>
 
   // Original file should be unchanged:
   t.is(stat.mtime.getTime(), newModifyTimeMs);
-  // TODO(nfischer): 'cp -p' incorrectly modifies atime of the original file.
-  // t.is(stat.atime.getTime(), newAccessTimeMs);
+  // cp appears to update the atime, but only of the srcFile
   t.is(stat.mode.toString(8), '100' + mode);
 
   // New file should keep same attributes
@@ -864,8 +863,7 @@ test('cp -p should preserve mode, ownership, and timestamp (symlink)', t => {
 
     // Original file should be unchanged:
     t.is(stat.mtime.getTime(), newModifyTimeMs);
-    // TODO(nfischer): 'cp -p' appears to modify atime of the original file.
-    // t.is(stat.atime.getTime(), newAccessTimeMs);
+    // cp appears to update the atime, but only of the srcFile
     t.is(stat.mode.toString(8), '100' + mode);
 
     // New file should keep same attributes

--- a/test/cp.js
+++ b/test/cp.js
@@ -838,6 +838,48 @@ test('cp -p should preserve mode, ownership, and timestamp (regular file)', t =>
   t.is(stat.gid, statOfResult.gid);
 });
 
+test('cp -p should preserve mode, ownership, and timestamp (directory)', t => {
+  // Setup: copy to srcFile and modify mode and timestamp
+  const srcDir = `${t.context.tmp}/srcDir`;
+  const srcFile = `${srcDir}/srcFile`;
+  shell.mkdir(srcDir);
+  shell.cp('test/resources/cp/file1', srcFile);
+  // Make this a round number of seconds, since the underlying system may not
+  // have millisecond precision.
+  const newModifyTimeMs = 12345000;
+  const newAccessTimeMs = 67890000;
+  shell.touch({ '-d': new Date(newModifyTimeMs), '-m': true }, srcFile);
+  shell.touch({ '-d': new Date(newAccessTimeMs), '-a': true }, srcFile);
+  fs.utimesSync(srcDir, new Date(newAccessTimeMs), new Date(newModifyTimeMs));
+  const mode = '444';
+  shell.chmod(mode, srcFile);
+
+  // Now re-copy (the whole dir) with '-p' and verify metadata of file contents.
+  const result = shell.cp('-pr', srcDir, `${t.context.tmp}/preservedDir`);
+  const stat = common.statFollowLinks(srcFile);
+  const statDir = common.statFollowLinks(srcDir);
+  const statOfResult = common.statFollowLinks(`${t.context.tmp}/preservedDir/srcFile`);
+  const statOfResultDir = common.statFollowLinks(`${t.context.tmp}/preservedDir`);
+
+  t.is(result.code, 0);
+
+  // Both original file and original dir should be unchanged:
+  t.is(statDir.mtime.getTime(), newModifyTimeMs);
+  t.is(stat.mtime.getTime(), newModifyTimeMs);
+  // cp appears to update the atime, but only of the srcFile & srcDir
+  t.is(stat.mode.toString(8), '100' + mode);
+
+  // Both new file and new dir should keep same attributes
+  t.is(statOfResultDir.mtime.getTime(), newModifyTimeMs);
+  t.is(statOfResultDir.atime.getTime(), newAccessTimeMs);
+  t.is(statOfResult.mtime.getTime(), newModifyTimeMs);
+  t.is(statOfResult.atime.getTime(), newAccessTimeMs);
+  t.is(statOfResult.mode.toString(8), '100' + mode);
+
+  t.is(stat.uid, statOfResult.uid);
+  t.is(stat.gid, statOfResult.gid);
+});
+
 test('cp -p should preserve mode, ownership, and timestamp (symlink)', t => {
   // Skip in Windows because symlinks require elevated permissions.
   utils.skipOnWin(t, () => {

--- a/test/cp.js
+++ b/test/cp.js
@@ -807,9 +807,12 @@ test('cp -R should be able to copy a readonly src. issue #98; (Non window platfo
 test('cp -p should preserve mode, ownership, and timestamp', t => {
   const result = shell.cp('-p', 'test/resources/file1', `${t.context.tmp}/preservedFile1`);
   const stat = common.statFollowLinks('test/resources/file1');
+  if (process.platform === 'linux') {
+    utils.sleep(1000);
+  }
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/preservedFile1`);
-  t.is(result.code, 0);
 
+  t.is(result.code, 0);
   t.is(stat.mtime.getTime(), statOfResult.mtime.getTime());
   t.is(stat.atime.getTime(), statOfResult.atime.getTime());
   t.is(stat.mode, statOfResult.mode);
@@ -820,9 +823,12 @@ test('cp -p should preserve mode, ownership, and timestamp', t => {
 test('cp -p should preserve mode, ownership, and timestamp of symlink', t => {
   const result = shell.cp('-p', 'test/resources/link', `${t.context.tmp}/copiedLink`);
   const stat = common.statFollowLinks('test/resources/link');
+  if (process.platform === 'linux') {
+    utils.sleep(1000);
+  }
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/copiedLink`);
-  t.is(result.code, 0);
 
+  t.is(result.code, 0);
   t.is(stat.mtime.getTime(), statOfResult.mtime.getTime());
   t.is(stat.atime.getTime(), statOfResult.atime.getTime());
   t.is(stat.mode, statOfResult.mode);

--- a/test/cp.js
+++ b/test/cp.js
@@ -808,9 +808,11 @@ test('cp -p should preserve mode, ownership, and timestamp (regular file)', t =>
   // Setup: copy to srcFile and modify mode and timestamp
   const srcFile = `${t.context.tmp}/srcFile`;
   shell.cp('test/resources/cp/file1', srcFile);
-  const newModifyTimeMs = 12345;
+  // Make this a round number of seconds, since the underlying system may not
+  // have millisecond precision.
+  const newModifyTimeMs = 12345000;
+  const newAccessTimeMs = 67890000;
   shell.touch({ '-d': new Date(newModifyTimeMs), '-m': true }, srcFile);
-  const newAccessTimeMs = 67890;
   shell.touch({ '-d': new Date(newAccessTimeMs), '-a': true }, srcFile);
   const mode = '444';
   shell.chmod(mode, srcFile);
@@ -844,9 +846,11 @@ test('cp -p should preserve mode, ownership, and timestamp (symlink)', t => {
     shell.cp('test/resources/cp/file1', `${t.context.tmp}/srcFile`);
     const srcLink = `${t.context.tmp}/srcLink`;
     shell.ln('-s', 'srcFile', `${t.context.tmp}/srcLink`);
-    const newModifyTimeMs = 12345;
+    // Make this a round number of seconds, since the underlying system may not
+    // have millisecond precision.
+    const newModifyTimeMs = 12345000;
+    const newAccessTimeMs = 67890000;
     shell.touch({ '-d': new Date(newModifyTimeMs), '-m': true }, srcLink);
-    const newAccessTimeMs = 67890;
     shell.touch({ '-d': new Date(newAccessTimeMs), '-a': true }, srcLink);
     const mode = '444';
     shell.chmod(mode, srcLink);

--- a/test/cp.js
+++ b/test/cp.js
@@ -803,3 +803,29 @@ test('cp -R should be able to copy a readonly src. issue #98; (Non window platfo
     shell.chmod('-R', '755', t.context.tmp);
   });
 });
+
+test('cp -p should preserve mode, ownership, and timestamp', t => {
+  const result = shell.cp('-p', 'test/resources/file1', `${t.context.tmp}/preservedFile1`);
+  const stat = common.statFollowLinks('test/resources/file1');
+  const statOfResult = common.statFollowLinks(`${t.context.tmp}/preservedFile1`);
+  t.is(result.code, 0);
+
+  t.is(stat.mtime.getTime(), statOfResult.mtime.getTime());
+  t.is(stat.atime.getTime(), statOfResult.atime.getTime());
+  t.is(stat.mode, statOfResult.mode);
+  t.is(stat.uid, statOfResult.uid);
+  t.is(stat.gid, statOfResult.gid);
+});
+
+test('cp -p should preserve mode, ownership, and timestamp of symlink', t => {
+  const result = shell.cp('-p', 'test/resources/link', `${t.context.tmp}/copiedLink`);
+  const stat = common.statFollowLinks('test/resources/link');
+  const statOfResult = common.statFollowLinks(`${t.context.tmp}/copiedLink`);
+  t.is(result.code, 0);
+
+  t.is(stat.mtime.getTime(), statOfResult.mtime.getTime());
+  t.is(stat.atime.getTime(), statOfResult.atime.getTime());
+  t.is(stat.mode, statOfResult.mode);
+  t.is(stat.uid, statOfResult.uid);
+  t.is(stat.rid, statOfResult.rid);
+});

--- a/test/cp.js
+++ b/test/cp.js
@@ -805,8 +805,8 @@ test('cp -R should be able to copy a readonly src. issue #98; (Non window platfo
 });
 
 test('cp -p should preserve mode, ownership, and timestamp', t => {
-  const result = shell.cp('-p', 'test/resources/file1', `${t.context.tmp}/preservedFile1`);
-  const stat = common.statFollowLinks('test/resources/file1');
+  const result = shell.cp('-p', 'test/resources/cp/file1', `${t.context.tmp}/preservedFile1`);
+  const stat = common.statFollowLinks('test/resources/cp/file1');
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/preservedFile1`);
 
   t.is(result.code, 0);
@@ -819,6 +819,7 @@ test('cp -p should preserve mode, ownership, and timestamp', t => {
 
 test('cp -p should preserve mode, ownership, and timestamp of symlink', t => {
   const result = shell.cp('-p', 'test/resources/link', `${t.context.tmp}/copiedLink`);
+  utils.sleep(1000);
   const stat = common.statFollowLinks('test/resources/link');
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/copiedLink`);
 

--- a/test/cp.js
+++ b/test/cp.js
@@ -807,9 +807,6 @@ test('cp -R should be able to copy a readonly src. issue #98; (Non window platfo
 test('cp -p should preserve mode, ownership, and timestamp', t => {
   const result = shell.cp('-p', 'test/resources/file1', `${t.context.tmp}/preservedFile1`);
   const stat = common.statFollowLinks('test/resources/file1');
-  if (process.platform === 'linux') {
-    utils.sleep(1000);
-  }
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/preservedFile1`);
 
   t.is(result.code, 0);
@@ -823,9 +820,6 @@ test('cp -p should preserve mode, ownership, and timestamp', t => {
 test('cp -p should preserve mode, ownership, and timestamp of symlink', t => {
   const result = shell.cp('-p', 'test/resources/link', `${t.context.tmp}/copiedLink`);
   const stat = common.statFollowLinks('test/resources/link');
-  if (process.platform === 'linux') {
-    utils.sleep(1000);
-  }
   const statOfResult = common.statFollowLinks(`${t.context.tmp}/copiedLink`);
 
   t.is(result.code, 0);


### PR DESCRIPTION
This is a redo of #841.

This adds the `-p` flag to `cp()` to preserve certain attributes, such as timestamps.

Fixes #771