### PR TITLE
Fix cp from readonly source

### DIFF
--- a/src/cp.js
+++ b/src/cp.js
@@ -99,8 +99,7 @@ function cpdirSyncRecursive(sourceDir, destDir, currentDepth, opts) {
   // Create the directory where all our junk is moving to; read the mode of the
   // source directory and mirror it
   try {
-    var checkDir = common.statFollowLinks(sourceDir);
-    fs.mkdirSync(destDir, checkDir.mode);
+    fs.mkdirSync(destDir);
   } catch (e) {
     // if the directory already exists, that's okay
     if (e.code !== 'EEXIST') throw e;
@@ -151,6 +150,10 @@ function cpdirSyncRecursive(sourceDir, destDir, currentDepth, opts) {
       }
     }
   } // for files
+
+  // finally change the mode for the newly created directory.
+  var checkDir = common.statFollowLinks(sourceDir);
+  fs.chmod(destDir, checkDir.mode);
 } // cpdirSyncRecursive
 
 // Checks if cureent file was created recently

--- a/src/cp.js
+++ b/src/cp.js
@@ -151,7 +151,8 @@ function cpdirSyncRecursive(sourceDir, destDir, currentDepth, opts) {
     }
   } // for files
 
-  // finally change the mode for the newly created directory.
+  // finally change the mode for the newly created directory (otherwise, we
+  // couldn't add files to a read-only directory).
   var checkDir = common.statFollowLinks(sourceDir);
   fs.chmodSync(destDir, checkDir.mode);
 } // cpdirSyncRecursive

--- a/src/cp.js
+++ b/src/cp.js
@@ -153,7 +153,7 @@ function cpdirSyncRecursive(sourceDir, destDir, currentDepth, opts) {
 
   // finally change the mode for the newly created directory.
   var checkDir = common.statFollowLinks(sourceDir);
-  fs.chmod(destDir, checkDir.mode);
+  fs.chmodSync(destDir, checkDir.mode);
 } // cpdirSyncRecursive
 
 // Checks if cureent file was created recently

--- a/test/cp.js
+++ b/test/cp.js
@@ -760,7 +760,7 @@ test('should not overwrite recently created files (not give error no-force mode)
 // cp -R should be able to copy a readonly src (issue #98).
 // On Windows, chmod acts VERY differently so skip these tests for now
 test('cp -R should be able to copy a readonly src. issue #98; (Non window platforms only)', t => {
-  if (common.platform !== 'win') {
+  utils.skipOnWin(t, () => {
     shell.cp('-r', 'test/resources/cp', t.context.tmp);
     shell.chmod('555', `${t.context.tmp}/cp/`);
     shell.chmod('555', `${t.context.tmp}/cp/dir_a`);
@@ -778,5 +778,5 @@ test('cp -R should be able to copy a readonly src. issue #98; (Non window platfo
     t.is(fs.statSync(`${t.context.tmp}/cp_cp/a`).mode & parseInt('777', 8), parseInt('555', 8));
 
     shell.chmod('-R', '755', t.context.tmp);
-  }
+  });
 });

--- a/test/cp.js
+++ b/test/cp.js
@@ -756,3 +756,27 @@ test('should not overwrite recently created files (not give error no-force mode)
   // Ensure First file is copied
   t.is(shell.cat(`${t.context.tmp}/file1`).toString(), 'test1');
 });
+
+// cp -R should be able to copy a readonly src (issue #98).
+// On Windows, chmod acts VERY differently so skip these tests for now
+test('cp -R should be able to copy a readonly src. issue #98; (Non window platforms only)', t => {
+  if (common.platform !== 'win') {
+    shell.cp('-r', 'test/resources/cp', t.context.tmp);
+    shell.chmod('555', `${t.context.tmp}/cp/`);
+    shell.chmod('555', `${t.context.tmp}/cp/dir_a`);
+    shell.chmod('555', `${t.context.tmp}/cp/dir_b`);
+    shell.chmod('555', `${t.context.tmp}/cp/a`);
+
+    const result = shell.cp('-r', `${t.context.tmp}/cp`, `${t.context.tmp}/cp_cp`);
+    t.falsy(shell.error());
+    t.falsy(result.stderr);
+    t.is(result.code, 0);
+
+    t.is(shell.ls('-R', `${t.context.tmp}/cp`) + '', shell.ls('-R', `${t.context.tmp}/cp_cp`) + '');
+    t.is(fs.statSync(`${t.context.tmp}/cp_cp`).mode & parseInt('777', 8), parseInt('555', 8));
+    t.is(fs.statSync(`${t.context.tmp}/cp_cp/dir_a`).mode & parseInt('777', 8), parseInt('555', 8));
+    t.is(fs.statSync(`${t.context.tmp}/cp_cp/a`).mode & parseInt('777', 8), parseInt('555', 8));
+
+    shell.chmod('-R', '755', t.context.tmp);
+  }
+});


### PR DESCRIPTION
This is a redo of PR #555.

This rebases, cleans up a test, and fixes a bug (the original PR uses `fs.chown()` instead of `fs.chownSync()`).

Fixes #98