### PR TITLE
Fix(which): match only executable files (#657)

### DIFF
--- a/src/which.js
+++ b/src/which.js
@@ -18,8 +18,17 @@ function splitPath(p) {
   return p ? p.split(path.delimiter) : [];
 }
 
+function isExecutable(pathName) {
+  try {
+    fs.accessSync(pathName, fs.constants.X_OK);
+  } catch (err) {
+    return false;
+  }
+  return true;
+}
+
 function checkPath(pathName) {
-  return fs.existsSync(pathName) && !common.statFollowLinks(pathName).isDirectory();
+  return fs.existsSync(pathName) && !common.statFollowLinks(pathName).isDirectory() && isExecutable(pathName);
 }
 
 //@

--- a/src/which.js
+++ b/src/which.js
@@ -13,6 +13,9 @@ common.register('which', _which, {
 // set on Windows.
 var XP_DEFAULT_PATHEXT = '.com;.exe;.bat;.cmd;.vbs;.vbe;.js;.jse;.wsf;.wsh';
 
+// For earlier versions of NodeJS that doesn't have a list of constants (< v6)
+var FILE_EXECUTABLE_MODE = 1;
+
 // Cross-platform method for splitting environment `PATH` variables
 function splitPath(p) {
   return p ? p.split(path.delimiter) : [];
@@ -20,7 +23,7 @@ function splitPath(p) {
 
 function isExecutable(pathName) {
   try {
-    fs.accessSync(pathName, fs.constants.X_OK);
+    fs.accessSync(pathName, FILE_EXECUTABLE_MODE);
   } catch (err) {
     return false;
   }

--- a/src/which.js
+++ b/src/which.js
@@ -25,6 +25,8 @@ function splitPath(p) {
   return p ? p.split(path.delimiter) : [];
 }
 
+// Tests are running all cases for this func but it stays uncovered by codecov due to unknown reason
+/* istanbul ignore next */
 function isExecutable(pathName) {
   try {
     // TODO(node-support): replace with fs.constants.X_OK once remove support for node < v6

--- a/test/resources/which/node
+++ b/test/resources/which/node
@@ -1,0 +1,1 @@
+text file, not an executable

--- a/test/which.js
+++ b/test/which.js
@@ -75,14 +75,14 @@ test('Searching with -a flag returns an array with first item equals to the regu
 
 test('None executable files does not appear in the result list', t => {
   const commandName = 'node'; // Should be an existing command
-  const pathEnv = process.env.path || process.env.Path || process.env.PATH;
   const extraPath = path.resolve(__dirname, 'resources', 'which');
   const matchingFile = path.resolve(extraPath, commandName);
+  const pathEnv = process.env.PATH;
 
   // make sure that file is exists (will throw error otherwise)
-  fs.statSync(matchingFile);
+  t.truthy(fs.existsSync(matchingFile));
 
-  process.env.path = process.env.Path = process.env.PATH = extraPath + path.delimiter + pathEnv;
+  process.env.PATH = extraPath + path.delimiter + process.env.PATH;
   const resultForWhich = shell.which(commandName);
   const resultForWhichA = shell.which('-a', commandName);
   t.falsy(shell.error());
@@ -90,5 +90,8 @@ test('None executable files does not appear in the result list', t => {
   t.truthy(resultForWhichA);
   t.truthy(resultForWhichA.length);
   t.not(resultForWhich.toString(), matchingFile);
+  // TODO(node-support): this can be used starting from node@6: t.falsy(resultForWhichA.includes(matchingFile))
   t.not(resultForWhichA[0], matchingFile);
+
+  process.env.PATH = pathEnv;
 });

--- a/test/which.js
+++ b/test/which.js
@@ -90,8 +90,7 @@ test('None executable files does not appear in the result list', t => {
   t.truthy(resultForWhichA);
   t.truthy(resultForWhichA.length);
   t.not(resultForWhich.toString(), matchingFile);
-  // TODO(node-support): this can be used starting from node@6: t.falsy(resultForWhichA.includes(matchingFile))
-  t.not(resultForWhichA[0], matchingFile);
+  t.is(resultForWhichA.indexOf(matchingFile), -1);
 
   process.env.PATH = pathEnv;
 });

--- a/test/which.js
+++ b/test/which.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 
 import test from 'ava';
 
@@ -69,5 +70,25 @@ test('Searching with -a flag returns an array with first item equals to the regu
   t.falsy(shell.error());
   t.truthy(resultForWhich);
   t.truthy(resultForWhichA);
-  t.is(resultForWhich.toString(), resultForWhichA[0].toString());
+  t.is(resultForWhich.toString(), resultForWhichA[0]);
+});
+
+test('None executable files does not appear in the result list', t => {
+  const commandName = 'node'; // Should be an existing command
+  const pathEnv = process.env.path || process.env.Path || process.env.PATH;
+  const extraPath = path.resolve(__dirname, 'resources', 'which');
+  const matchingFile = path.resolve(extraPath, commandName);
+
+  // make sure that file is exists (will throw error otherwise)
+  fs.statSync(matchingFile);
+
+  process.env.path = process.env.Path = process.env.PATH = extraPath + path.delimiter + pathEnv;
+  const resultForWhich = shell.which(commandName);
+  const resultForWhichA = shell.which('-a', commandName);
+  t.falsy(shell.error());
+  t.truthy(resultForWhich);
+  t.truthy(resultForWhichA);
+  t.truthy(resultForWhichA.length);
+  t.not(resultForWhich.toString(), matchingFile);
+  t.not(resultForWhichA[0], matchingFile);
 });


### PR DESCRIPTION
Fixes #657.