### PR TITLE
docs: remove gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ShellJS - Unix shell commands for Node.js
 
-[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg?style=flat-square)](https://gitter.im/shelljs/shelljs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Travis](https://img.shields.io/travis/shelljs/shelljs/master.svg?style=flat-square&label=unix)](https://travis-ci.org/shelljs/shelljs)
 [![AppVeyor](https://img.shields.io/appveyor/ci/shelljs/shelljs/master.svg?style=flat-square&label=windows)](https://ci.appveyor.com/project/shelljs/shelljs/branch/master)
 [![Codecov](https://img.shields.io/codecov/c/github/shelljs/shelljs/master.svg?style=flat-square&label=coverage)](https://codecov.io/gh/shelljs/shelljs)


### PR DESCRIPTION
No change to logic.

We don't really use the gitter chatroom right now, so we shouldn't
direct users to chat there. It's best to have issues reported directly
on Github.

This PR removes the gitter badge from the README.