### PR TITLE
feat(cp): support update flag when recursing

### DIFF
--- a/src/cp.js
+++ b/src/cp.js
@@ -260,7 +260,7 @@ function _cp(options, sources, dest) {
 
         try {
           common.statFollowLinks(path.dirname(dest));
-          cpdirSyncRecursive(src, newDest, 0, { no_force: options.no_force, followsymlink: options.followsymlink });
+          cpdirSyncRecursive(src, newDest, 0, { no_force: options.no_force, followsymlink: options.followsymlink, update: options.update });
         } catch (e) {
           /* istanbul ignore next */
           common.error("cannot create directory '" + dest + "': No such file or directory");

--- a/test/cp.js
+++ b/test/cp.js
@@ -463,7 +463,6 @@ test('-Ru respects the -u flag recursively (don\'t update newer file)', t => {
   shell.ShellString('Source File Contents\n').to(sourceFile);
   shell.ShellString('Destination File Contents\n').to(destFile);
   // End setup
-  
   // Get the old mtime for dest
   const oldTime = fs.statSync(destFile).mtimeMs;
   // Set the source file to be older than the destination file
@@ -486,7 +485,6 @@ test('-Ru respects the -u flag recursively (update older file)', t => {
   shell.ShellString('Source File Contents\n').to(sourceFile);
   shell.ShellString('Destination File Contents\n').to(destFile);
   // End setup
-  
   // Get the old mtime for dest
   const oldTime = fs.statSync(destFile).mtimeMs;
   // Set the destination file to be older than the source file

--- a/test/cp.js
+++ b/test/cp.js
@@ -458,8 +458,8 @@ test('-Ru respects the -u flag recursively (don\'t update newer file)', t => {
   const destDir    = `${dir}/new`;
   const destFile   = `${destDir}/file`;
   [sourceDir, destDir].forEach(d => shell.mkdir('-p', d));
-  ShellString('foo\n').to(sourceFile);
-  ShellString('bar\n').to(destFile);
+  shell.ShellString('foo\n').to(sourceFile);
+  shell.ShellString('bar\n').to(destFile);
   // Get the old mtime for dest
   const oldTime = fs.statSync(destFile).mtimeMs;
   // Send the old file to two days ago
@@ -477,8 +477,8 @@ test('-Ru respects the -u flag recursively (update older file)', t => {
   const destDir    = `${dir}/new`;
   const destFile   = `${destDir}/file`;
   [sourceDir, destDir].forEach(d => shell.mkdir('-p', d));
-  ShellString('foo\n').to(sourceFile);
-  ShellString('bar\n').to(destFile);
+  shell.ShellString('foo\n').to(sourceFile);
+  shell.ShellString('bar\n').to(destFile);
   // Get the old mtime for dest
   const oldTime = fs.statSync(destFile).mtimeMs;
   // Send the source file to two days ahead

--- a/test/cp.js
+++ b/test/cp.js
@@ -458,16 +458,16 @@ test('-Ru respects the -u flag recursively (don\'t update newer file)', t => {
   const destDir = `${dir}/new`;
   const destFile = `${destDir}/file`;
   [sourceDir, destDir].forEach(d => shell.mkdir('-p', d));
-  shell.ShellString('foo\n').to(sourceFile);
-  shell.ShellString('bar\n').to(destFile);
+  shell.ShellString('Source File Contents\n').to(sourceFile);
+  shell.ShellString('Destination File Contents\n').to(destFile);
   // Get the old mtime for dest
   const oldTime = fs.statSync(destFile).mtimeMs;
-  // Send the old file to two days ago
+  // Send the source file to be older than the destination file
   shell.touch('-m', oldTime - (2 * 24 * 60 * 60 * 1000), sourceFile);
   // Now, copy the old dir to the new one
   shell.cp('-Ru', sourceDir, destDir);
   // Check that dest has not been updated
-  t.is(shell.cat(destFile).stdout, 'bar\n');
+  t.is(shell.cat(destFile).stdout, 'Destination File Contents\n');
 });
 
 test('-Ru respects the -u flag recursively (update older file)', t => {
@@ -477,17 +477,16 @@ test('-Ru respects the -u flag recursively (update older file)', t => {
   const destDir = `${dir}/new`;
   const destFile = `${destDir}/file`;
   [sourceDir, destDir].forEach(d => shell.mkdir('-p', d));
-  shell.ShellString('foo\n').to(sourceFile);
-  shell.ShellString('bar\n').to(destFile);
+  shell.ShellString('Source File Contents\n').to(sourceFile);
+  shell.ShellString('Destination File Contents\n').to(destFile);
   // Get the old mtime for dest
   const oldTime = fs.statSync(destFile).mtimeMs;
   // Send the source file to two days ahead
   shell.touch('-m', oldTime + (2 * 24 * 60 * 60 * 1000), sourceFile);
   // Now, copy the old dir to the new one
   shell.cp('-Ru', sourceDir, destDir);
-  // Get the new mtime for dest
   // Check that dest has been updated
-  t.is(shell.cat(sourceFile).stdout, 'foo\n');
+  t.is(shell.cat(sourceFile).stdout, 'Source File Contents\n');
 });
 
 test('using -P explicitly works', t => {

--- a/test/cp.js
+++ b/test/cp.js
@@ -451,6 +451,19 @@ test('-R implies -P', t => {
   });
 });
 
+test('-Ru no longer ignores -u', t => {
+  const [source, dest] = ['foo', 'bar'].map(s => `test/resources/cp/cp-Ru/${s}/file`);
+  // First, update the dest file
+  shell.touch(dest);
+  // Get the old mtime for dest
+  const oldTime = fs.statSync(dest).mtimeMs;
+  // Now, copy the old dir to the new one 
+  shell.cp('-Ru', source, dest);
+  // Get the new mtime for dest
+  const newTime = fs.statSync(dest).mtimeMs;
+  t.is(oldTime, newTime);
+});
+
 test('using -P explicitly works', t => {
   utils.skipOnWin(t, () => {
     shell.cp('-P', 'test/resources/cp/links/sym.lnk', t.context.tmp);

--- a/test/cp.js
+++ b/test/cp.js
@@ -452,6 +452,8 @@ test('-R implies -P', t => {
 });
 
 test('-Ru respects the -u flag recursively (don\'t update newer file)', t => {
+  // Setup code
+  const TWO_DAYS_IN_MS = 2 * 24 * 60 * 60 * 1000;
   const dir = `${t.context.tmp}/cp-Ru`;
   const sourceDir = `${dir}/old`;
   const sourceFile = `${sourceDir}/file`;
@@ -460,10 +462,12 @@ test('-Ru respects the -u flag recursively (don\'t update newer file)', t => {
   [sourceDir, destDir].forEach(d => shell.mkdir('-p', d));
   shell.ShellString('Source File Contents\n').to(sourceFile);
   shell.ShellString('Destination File Contents\n').to(destFile);
+  // End setup
+  
   // Get the old mtime for dest
   const oldTime = fs.statSync(destFile).mtimeMs;
-  // Send the source file to be older than the destination file
-  shell.touch('-m', oldTime - (2 * 24 * 60 * 60 * 1000), sourceFile);
+  // Set the source file to be older than the destination file
+  shell.touch('-m', oldTime - TWO_DAYS_IN_MS, sourceFile);
   // Now, copy the old dir to the new one
   shell.cp('-Ru', sourceDir, destDir);
   // Check that dest has not been updated
@@ -471,6 +475,8 @@ test('-Ru respects the -u flag recursively (don\'t update newer file)', t => {
 });
 
 test('-Ru respects the -u flag recursively (update older file)', t => {
+  // Setup code
+  const TWO_DAYS_IN_MS = 2 * 24 * 60 * 60 * 1000;
   const dir = `${t.context.tmp}/cp-Ru`;
   const sourceDir = `${dir}/old`;
   const sourceFile = `${sourceDir}/file`;
@@ -479,10 +485,12 @@ test('-Ru respects the -u flag recursively (update older file)', t => {
   [sourceDir, destDir].forEach(d => shell.mkdir('-p', d));
   shell.ShellString('Source File Contents\n').to(sourceFile);
   shell.ShellString('Destination File Contents\n').to(destFile);
+  // End setup
+  
   // Get the old mtime for dest
   const oldTime = fs.statSync(destFile).mtimeMs;
-  // Send the source file to two days ahead
-  shell.touch('-m', oldTime + (2 * 24 * 60 * 60 * 1000), sourceFile);
+  // Set the destination file to be older than the source file
+  shell.touch('-m', oldTime + TWO_DAYS_IN_MS, sourceFile);
   // Now, copy the old dir to the new one
   shell.cp('-Ru', sourceDir, destDir);
   // Check that dest has been updated

--- a/test/cp.js
+++ b/test/cp.js
@@ -457,7 +457,7 @@ test('-Ru no longer ignores -u', t => {
   shell.touch(dest);
   // Get the old mtime for dest
   const oldTime = fs.statSync(dest).mtimeMs;
-  // Now, copy the old dir to the new one 
+  // Now, copy the old dir to the new one
   shell.cp('-Ru', source, dest);
   // Get the new mtime for dest
   const newTime = fs.statSync(dest).mtimeMs;

--- a/test/cp.js
+++ b/test/cp.js
@@ -451,7 +451,7 @@ test('-R implies -P', t => {
   });
 });
 
-test('-Ru no longer ignores -u', t => {
+test('-Ru respects the -u flag recursively', t => {
   const [source, dest] = ['foo', 'bar'].map(s => `test/resources/cp/cp-Ru/${s}/file`);
   // First, update the dest file
   shell.touch(dest);

--- a/test/cp.js
+++ b/test/cp.js
@@ -453,10 +453,10 @@ test('-R implies -P', t => {
 
 test('-Ru respects the -u flag recursively (don\'t update newer file)', t => {
   const dir = `${t.context.tmp}/cp-Ru`;
-  const sourceDir  = `${dir}/old`;
+  const sourceDir = `${dir}/old`;
   const sourceFile = `${sourceDir}/file`;
-  const destDir    = `${dir}/new`;
-  const destFile   = `${destDir}/file`;
+  const destDir = `${dir}/new`;
+  const destFile = `${destDir}/file`;
   [sourceDir, destDir].forEach(d => shell.mkdir('-p', d));
   shell.ShellString('foo\n').to(sourceFile);
   shell.ShellString('bar\n').to(destFile);
@@ -472,10 +472,10 @@ test('-Ru respects the -u flag recursively (don\'t update newer file)', t => {
 
 test('-Ru respects the -u flag recursively (update older file)', t => {
   const dir = `${t.context.tmp}/cp-Ru`;
-  const sourceDir  = `${dir}/old`;
+  const sourceDir = `${dir}/old`;
   const sourceFile = `${sourceDir}/file`;
-  const destDir    = `${dir}/new`;
-  const destFile   = `${destDir}/file`;
+  const destDir = `${dir}/new`;
+  const destFile = `${destDir}/file`;
   [sourceDir, destDir].forEach(d => shell.mkdir('-p', d));
   shell.ShellString('foo\n').to(sourceFile);
   shell.ShellString('bar\n').to(destFile);


### PR DESCRIPTION
Fixed `cp -Ru` ignoring `-u`, and added a test.

Fixes #808