### PR TITLE
chore(ci): fix codecov on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - npm run gendocs
   - npm run after-travis "Make sure to generate docs!"
 after_success:
-  - codecov
+  - npm run codecov -- -f coverage/lcov.info
 
 # Gitter
 notifications:


### PR DESCRIPTION
Apparently, travis hasn't been uploading any coverage data this whole
time. This fixes the command (copied from appveyor).