### PR TITLE
Add test case for sed on empty file

### DIFF
--- a/test/sed.js
+++ b/test/sed.js
@@ -174,3 +174,9 @@ test('glob file names, with in-place-replacement', t => {
   t.is(shell.cat(`${t.context.tmp}/file1.txt`).toString(), 'hello1\n');
   t.is(shell.cat(`${t.context.tmp}/file2.txt`).toString(), 'hello2\n');
 });
+
+test('empty file', t => {
+  const result = shell.sed('widget', 'wizzle', 'test/resources/sed/empty.txt');
+  t.is(result.code, 0);
+  t.is(result.toString(), '');
+});


### PR DESCRIPTION
As discussed as an aside in #900, add test case with an empty file.