### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,16 @@
-language: c++
+language: node_js
 sudo: false
-env:
-  - NODE_VERSION="4"
-  - NODE_VERSION="5"
-  - NODE_VERSION="6"
-  - NODE_VERSION="7"
-  - NODE_VERSION="8"
-  - NODE_VERSION="9"
+node_js:
+  - "6"
+  - "8"
+  - "10"
+  - "node"
 
 # keep this blank to make sure there are no before_install steps
 before_install:
 
 install:
-  - rm -rf ~/.nvm
-  - git clone https://github.com/creationix/nvm.git ~/.nvm
-  - source ~/.nvm/nvm.sh
-  - nvm install $NODE_VERSION
-  - node --version
-  - npm --version
-  - npm run ci-or-install
+  - npm install
 os:
   - linux
   - osx


### PR DESCRIPTION
Test only Node.js 6, 8, 10 (LTS) and stable (11).

https://github.com/nodejs/Release/blob/master/README.md