### PR TITLE
ci: change language to node_js and remove obsolete scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,14 @@
-language: c++
+language: node_js
 sudo: false
-env:
-  - NODE_VERSION="4"
-  - NODE_VERSION="5"
-  - NODE_VERSION="6"
-  - NODE_VERSION="7"
-  - NODE_VERSION="8"
-  - NODE_VERSION="9"
-
-# keep this blank to make sure there are no before_install steps
-before_install:
+node_js:
+  - 4
+  - 5
+  - 6
+  - 7
+  - 8
+  - 9
 
 install:
-  - rm -rf ~/.nvm
-  - git clone https://github.com/creationix/nvm.git ~/.nvm
-  - source ~/.nvm/nvm.sh
-  - nvm install $NODE_VERSION
-  - node --version
-  - npm --version
   - npm run ci-or-install
 os:
   - linux


### PR DESCRIPTION
We can safely use `node_js` on all three supported platforms on Travis CI and remove the obsolete scripts.

See https://github.com/shelljs/shelljs/pull/908#issuecomment-442732567