### PR TITLE
chore: script to bump supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - npm test
   # make sure when the docs are generated nothing changes (a.k.a. the docs have already been generated)
   - npm run gendocs
+  - npm run check-node-support
   - npm run after-travis "Make sure to generate docs!"
 after_success:
   - npm run codecov -- -f coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ script's dependency on Unix while still keeping its familiar and powerful
 commands. You can also install it globally so you can run it from outside Node
 projects - say goodbye to those gnarly Bash scripts!
 
-ShellJS is proudly tested on every node release since `v4`!
+ShellJS is proudly tested on every node release since <!-- start minVersion -->`v4`<!-- stop minVersion -->!
 
 The project is [unit-tested](http://travis-ci.org/shelljs/shelljs) and battle-tested in projects like:
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "src"
   ],
   "scripts": {
+    "check-node-support": "node scripts/check-node-support",
     "posttest": "npm run lint",
     "test": "nyc --reporter=text --reporter=lcov ava test/*.js",
     "test-no-coverage": "ava test/*.js",
@@ -65,6 +66,7 @@
     "eslint": "^2.0.0",
     "eslint-config-airbnb-base": "^3.0.0",
     "eslint-plugin-import": "^1.11.1",
+    "js-yaml": "^3.12.0",
     "nyc": "^11.3.0",
     "shelljs-changelog": "^0.2.0",
     "shelljs-release": "^0.3.0",

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+var assert = require('assert');
+var path = require('path');
+
+var yaml = require('js-yaml');
+
+var shell = require('..');
+
+// This is the authoritative list of supported node versions.
+var MIN_NODE_VERSION = 4;
+var MAX_NODE_VERSION = 9;
+
+function checkReadme(minNodeVersion) {
+  var start = '<!-- start minVersion -->';
+  var stop = '<!-- stop minVersion -->';
+  var formattedMinVersion = '`v' + minNodeVersion + '`';
+  var expectedReadmeRegex = new RegExp(
+      start + '\\s*' + formattedMinVersion + '\\s*' + stop, '');
+  var readme = path.join(__dirname, '..', 'README.md');
+  var match = shell.grep(expectedReadmeRegex, readme);
+  if (!match.toString()) {
+    var msg = 'Update README to specify the min supported version. Look for "'
+        + start + '"';
+    throw new Error(msg);
+  }
+}
+
+function checkEngines(minNodeVersion, package) {
+  var expectedEnginesNode = '>=' + minNodeVersion;
+  if (package.engines.node !== expectedEnginesNode) {
+    var msg = 'Update package.json to fix the "engines" attribute';
+    throw new Error(msg);
+  }
+}
+
+function assertDeepEquals(arr1, arr2, msg) {
+  try {
+    assert.deepStrictEqual(arr1, arr2);
+  } catch (e) {
+    throw new Error(msg + '\n' + e);
+  }
+}
+
+function range(start, stop) {
+  var ret = [];
+  for (var i = start; i <= stop; i++) {
+    ret.push(i);
+  }
+  return ret;
+}
+
+function checkTravis(minNodeVersion, maxNodeVersion, travisYaml) {
+  var expectedTravisVersions = range(minNodeVersion, maxNodeVersion);
+  var msg = 'Check Travis node_js versions';
+  assertDeepEquals(travisYaml.node_js, expectedTravisVersions, msg);
+}
+
+function checkAppveyor(minNodeVersion, maxNodeVersion, appveyorYaml) {
+  var expectedAppveyorVersions = range(minNodeVersion, maxNodeVersion)
+      .map(function (num) {
+        return { nodejs_version: num.toString() };
+      })
+      .reverse(); // Arbitrarily, we store appveyor in reverse order.
+  var msg = 'Check Appveyor environment.matrix versions';
+  assertDeepEquals(appveyorYaml.environment.matrix, expectedAppveyorVersions,
+      msg);
+}
+
+try {
+  checkReadme(MIN_NODE_VERSION);
+
+  var package = require('../package.json');
+  checkEngines(MIN_NODE_VERSION, package);
+
+  var travisFileName = path.join(__dirname, '..', '.travis.yml');
+  var travisYaml = yaml.safeLoad(shell.cat(travisFileName));
+  checkTravis(MIN_NODE_VERSION, MAX_NODE_VERSION, travisYaml);
+
+  var appveyorFileName = path.join(__dirname, '..', 'appveyor.yml');
+  var appveyorYaml = yaml.safeLoad(shell.cat(appveyorFileName));
+  checkAppveyor(MIN_NODE_VERSION, MAX_NODE_VERSION, appveyorYaml);
+} catch (e) {
+  console.error('Please check the files which declare our Node version');
+  console.error('support, as something is out-of-sync. This script failed');
+  console.error('specificaly because:');
+  throw e;
+}


### PR DESCRIPTION
No change to node support, this just adds a script.

This adds a script to check that we correctly configure all supported
node versions, since we need to update quite a few spots (README.md,
package.json, travis, appveyor).

Issue #873
Test: manual