### PR TITLE
chore(node): drop node v4 and v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - 4
-  - 5
   - 6
   - 7
   - 8

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ script's dependency on Unix while still keeping its familiar and powerful
 commands. You can also install it globally so you can run it from outside Node
 projects - say goodbye to those gnarly Bash scripts!
 
-ShellJS is proudly tested on every node release since <!-- start minVersion -->`v4`<!-- stop minVersion -->!
+ShellJS is proudly tested on every node release since <!-- start minVersion -->`v6`<!-- stop minVersion -->!
 
 The project is [unit-tested](http://travis-ci.org/shelljs/shelljs) and battle-tested in projects like:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@ environment:
     - nodejs_version: '8'
     - nodejs_version: '7'
     - nodejs_version: '6'
-    - nodejs_version: '5'
-    - nodejs_version: '4'
 
 version: '{build}'
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
   },
   "optionalDependencies": {},
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   }
 }

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -8,7 +8,7 @@ var yaml = require('js-yaml');
 var shell = require('..');
 
 // This is the authoritative list of supported node versions.
-var MIN_NODE_VERSION = 4;
+var MIN_NODE_VERSION = 6;
 var MAX_NODE_VERSION = 9;
 
 function checkReadme(minNodeVersion) {


### PR DESCRIPTION
This drops support for node v4 and v5. Neither is currently supported by
the Node.js team, nor by the `npm` CLI team, so it's hard to justify we
continue to support it.

The new minimum supported version is v6.

Fixes #873