### PR TITLE
fix(exec): consistent error message for maxBuffer

### DIFF
--- a/src/exec-child.js
+++ b/src/exec-child.js
@@ -16,18 +16,39 @@ var pipe = params.pipe;
 var stdoutFile = params.stdoutFile;
 var stderrFile = params.stderrFile;
 
+function isMaxBufferError(err) {
+  var maxBufferErrorPattern = /^.*\bmaxBuffer\b.*exceeded.*$/;
+  if (err instanceof Error && err.message &&
+        err.message.match(maxBufferErrorPattern)) {
+    // < v10
+    // Error: stdout maxBuffer exceeded
+    return true;
+  } else if (err instanceof RangeError && err.message &&
+        err.message.match(maxBufferErrorPattern)) {
+    // >= v10
+    // RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stdout maxBuffer length
+    // exceeded
+    return true;
+  }
+  return false;
+}
+
+var stdoutStream = fs.createWriteStream(stdoutFile);
+var stderrStream = fs.createWriteStream(stderrFile);
+
 var c = childProcess.exec(cmd, execOptions, function (err) {
   if (!err) {
     process.exitCode = 0;
+  } else if (isMaxBufferError(err)) {
+    console.warn('I hit the case I want to hit.');
+    stderrStream.write('maxBuffer exceeded');
+    process.exitCode = 1;
   } else if (err.code === undefined) {
     process.exitCode = 1;
   } else {
     process.exitCode = err.code;
   }
 });
-
-var stdoutStream = fs.createWriteStream(stdoutFile);
-var stderrStream = fs.createWriteStream(stderrFile);
 
 c.stdout.pipe(stdoutStream);
 c.stderr.pipe(stderrStream);

--- a/test/exec.js
+++ b/test/exec.js
@@ -133,8 +133,12 @@ test('set maxBuffer (very small)', t => {
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.stdout, '1234567890' + os.EOL);
-  shell.exec('echo 1234567890', { maxBuffer: 6 });
+  const result2 = shell.exec('echo 1234567890', { maxBuffer: 6 });
   t.truthy(shell.error());
+  t.is(result2.code, 1);
+  t.is(result2.stdout, '1234567890' + os.EOL);
+  const maxBufferErrorPattern = /.*\bmaxBuffer\b.*\bexceeded\b.*/;
+  t.regex(result2.stderr, maxBufferErrorPattern);
 });
 
 test('set timeout option', t => {


### PR DESCRIPTION
This explicitly checks for maxBuffer errors in exec-child.js and
provides a consistent error message. This modifies the test to verify
this.

Although the error message is now explicit, this is not part of our API,
since it's just tacked onto the end of exec's stderr.

Fixes #915