### PR TITLE
chore(test): no coverage by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
   - linux
   - osx
 script:
-  - npm test
+  - npm run test-with-coverage
   # make sure when the docs are generated nothing changes (a.k.a. the docs have already been generated)
   - npm run gendocs
   - npm run check-node-support

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ matrix:
 build: off
 
 test_script:
-  - npm test
+  - npm run test-with-coverage
 
 on_success:
   - npm run codecov -- -f coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "scripts": {
     "check-node-support": "node scripts/check-node-support",
     "posttest": "npm run lint",
-    "test": "nyc --reporter=text --reporter=lcov ava test/*.js",
-    "test-no-coverage": "ava test/*.js",
+    "test": "ava test/*.js",
+    "test-with-coverage": "nyc --reporter=text --reporter=lcov ava test/*.js",
     "gendocs": "node scripts/generate-docs",
     "lint": "eslint .",
     "after-travis": "travis-check-changes",


### PR DESCRIPTION
NYC takes forever on my local machine, and I generally prefer to look at
coverage reports on the website anyway.

This changes `npm test` to run without coverage, and changes our CI to
run `npm run test-with-coverage` instead.