### PR TITLE
test(touch): add coverage for -d option

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,19 +647,20 @@ Available options:
 + `-a`: Change only the access time
 + `-c`: Do not create any files
 + `-m`: Change only the modification time
-+ `-d DATE`: Parse `DATE` and use it instead of current time
-+ `-r FILE`: Use `FILE`'s times instead of current time
++ `{'-d': date}`: Use `date` (instance of `Date`) instead of current time
++ `{'-r': file}`: Use `file`'s times instead of current time
 
 Examples:
 
 ```javascript
 touch('source.js');
-touch('-c', '/path/to/some/dir/source.js');
-touch({ '-r': FILE }, '/path/to/some/dir/source.js');
+touch('-c', 'path/to/file.js');
+touch({ '-r': 'referenceFile.txt' }, 'path/to/file.js');
+touch({ '-d': new Date('December 17, 1995 03:24:00') }, 'path/to/file.js');
 ```
 
-Update the access and modification times of each `FILE` to the current time.
-A `FILE` argument that does not exist is created empty, unless `-c` is supplied.
+Update the access and modification times of each file to the current time.
+A file argument that does not exist is created empty, unless `-c` is supplied.
 This is a partial implementation of [`touch(1)`](http://linux.die.net/man/1/touch).
 
 

--- a/src/touch.js
+++ b/src/touch.js
@@ -20,19 +20,20 @@ common.register('touch', _touch, {
 //@ + `-a`: Change only the access time
 //@ + `-c`: Do not create any files
 //@ + `-m`: Change only the modification time
-//@ + `-d DATE`: Parse `DATE` and use it instead of current time
-//@ + `-r FILE`: Use `FILE`'s times instead of current time
+//@ + `{'-d': date}`: Use `date` (instance of `Date`) instead of current time
+//@ + `{'-r': file}`: Use `file`'s times instead of current time
 //@
 //@ Examples:
 //@
 //@ ```javascript
 //@ touch('source.js');
-//@ touch('-c', '/path/to/some/dir/source.js');
-//@ touch({ '-r': FILE }, '/path/to/some/dir/source.js');
+//@ touch('-c', 'path/to/file.js');
+//@ touch({ '-r': 'referenceFile.txt' }, 'path/to/file.js');
+//@ touch({ '-d': new Date('December 17, 1995 03:24:00') }, 'path/to/file.js');
 //@ ```
 //@
-//@ Update the access and modification times of each `FILE` to the current time.
-//@ A `FILE` argument that does not exist is created empty, unless `-c` is supplied.
+//@ Update the access and modification times of each file to the current time.
+//@ A file argument that does not exist is created empty, unless `-c` is supplied.
 //@ This is a partial implementation of [`touch(1)`](http://linux.die.net/man/1/touch).
 function _touch(opts, files) {
   if (!files) {

--- a/test/touch.js
+++ b/test/touch.js
@@ -119,6 +119,17 @@ test('uses a reference file for mtime', t => {
   );
 });
 
+test('accepts -d flag', t => {
+  const testFile = tmpFile(t);
+  const oldStat = resetUtimes(testFile);
+  const date = new Date('December 17, 1995 03:24:00');
+  const result = shell.touch({'-d': date}, testFile);
+  t.is(result.code, 0);
+  // Compare getTime(), because Date can't be compared with triple-equals.
+  t.is(common.statFollowLinks(testFile).mtime.getTime(), date.getTime());
+  t.is(common.statFollowLinks(testFile).atime.getTime(), date.getTime());
+});
+
 test('sets mtime and atime by default', t => {
   const testFile = tmpFile(t);
   const oldStat = resetUtimes(testFile);


### PR DESCRIPTION
No change to production logic.

We never had coverage for `touch({'-d': ...})`, so this adds test
coverage. This also updates documentation to clarify the parameter
should be an instance of the `Date` type.

Test: `handles date argument` case