### PR TITLE
docs(exec): document security concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,11 @@ Not seeing the behavior you want? `exec()` runs everything through `sh`
 by default (or `cmd.exe` on Windows), which differs from `bash`. If you
 need bash-specific behavior, try out the `{shell: 'path/to/bash'}` option.
 
+**Note:** as `shell.exec()` executes an arbitrary string in the system
+shell, it is **critical** to properly sanitize user input to avoid command
+execution. For more context, consult the [Security
+guidelines](https://github.com/shelljs/shelljs/wiki/Security-guidelines).
+
 
 ### find(path [, path ...])
 ### find(path_array)

--- a/src/exec.js
+++ b/src/exec.js
@@ -177,6 +177,11 @@ function execAsync(cmd, opts, pipe, callback) {
 //@ Not seeing the behavior you want? `exec()` runs everything through `sh`
 //@ by default (or `cmd.exe` on Windows), which differs from `bash`. If you
 //@ need bash-specific behavior, try out the `{shell: 'path/to/bash'}` option.
+//@
+//@ **Note:** as `shell.exec()` executes an arbitrary string in the system
+//@ shell, it is **critical** to properly sanitize user input to avoid command
+//@ execution. For more context, consult the [Security
+//@ guidelines](https://github.com/shelljs/shelljs/wiki/Security-guidelines).
 function _exec(command, options, callback) {
   options = options || {};
   if (!command) common.error('must specify command');


### PR DESCRIPTION
No change to logic.

This adds documentation about `shell.exec()`'s inherent vulnerability to
command injection and links to a more detailed security notice.

Issue #103, #143, #495, #765, #766, #810, #842, #938, #945