### PR TITLE
Add boolean `fatal` option to `exec()` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Available options:
 
 + `async`: Asynchronous execution. If a callback is provided, it will be set to
   `true`, regardless of the passed value (default: `false`).
++ `fatal`: Exit upon error (default: `false`).
 + `silent`: Do not echo program output to console (default: `false`).
 + `encoding`: Character encoding to use. Affects the values returned to stdout and stderr, and
   what is written to stdout and stderr when not in silent mode (default: `'utf8'`).

--- a/src/common.js
+++ b/src/common.js
@@ -98,6 +98,7 @@ function error(msg, _code, options) {
     code: 1,
     prefix: state.currentCmd + ': ',
     silent: false,
+    fatal: config.fatal,
   };
 
   if (typeof _code === 'number' && isObject(options)) {
@@ -118,7 +119,7 @@ function error(msg, _code, options) {
   state.error += logEntry;
 
   // Throw an error, or log the entry
-  if (config.fatal && options.fatal !== false) throw new Error(logEntry);
+  if (config.fatal) throw new Error(logEntry);
   if (msg.length > 0 && !options.silent) log(logEntry);
 
   if (!options.continue) {

--- a/src/common.js
+++ b/src/common.js
@@ -118,7 +118,7 @@ function error(msg, _code, options) {
   state.error += logEntry;
 
   // Throw an error, or log the entry
-  if (config.fatal) throw new Error(logEntry);
+  if (config.fatal && options.fatal !== false) throw new Error(logEntry);
   if (msg.length > 0 && !options.silent) log(logEntry);
 
   if (!options.continue) {

--- a/src/common.js
+++ b/src/common.js
@@ -119,7 +119,7 @@ function error(msg, _code, options) {
   state.error += logEntry;
 
   // Throw an error, or log the entry
-  if (config.fatal) throw new Error(logEntry);
+  if (options.fatal) throw new Error(logEntry);
   if (msg.length > 0 && !options.silent) log(logEntry);
 
   if (!options.continue) {

--- a/src/common.js
+++ b/src/common.js
@@ -425,7 +425,7 @@ function wrap(cmd, fn, options) {
         e.name = 'ShellJSInternalError';
         throw e;
       }
-      if (config.fatal) throw e;
+      if (config.fatal || options.handlesFatalDynamically) throw e;
     }
 
     if (options.wrapOutput &&
@@ -451,6 +451,7 @@ var DEFAULT_WRAP_OPTIONS = {
   canReceivePipe: false,
   cmdOptions: null,
   globStart: 1,
+  handlesFatalDynamically: false,
   pipeOnly: false,
   wrapOutput: true,
   unix: true,

--- a/src/common.js
+++ b/src/common.js
@@ -88,7 +88,7 @@ CommandError.prototype = Object.create(Error.prototype);
 CommandError.prototype.constructor = CommandError;
 exports.CommandError = CommandError; // visible for testing
 
-// Shows error message. Throws if config.fatal is true
+// Shows error message. Throws if fatal is true (defaults to config.fatal, overridable with options.fatal)
 function error(msg, _code, options) {
   // Validate input
   if (typeof msg !== 'string') throw new Error('msg must be a string');

--- a/src/exec.js
+++ b/src/exec.js
@@ -12,13 +12,14 @@ common.register('exec', _exec, {
   unix: false,
   canReceivePipe: true,
   wrapOutput: false,
+  handlesFatalDynamically: true,
 });
 
 // We use this function to run `exec` synchronously while also providing realtime
 // output.
 function execSync(cmd, opts, pipe) {
   if (!common.config.execPath) {
-    common.error('Unable to find a path to the node binary. Please manually set config.execPath');
+    common.error('Unable to find a path to the node binary. Please manually set config.execPath', { continue: true, fatal: opts.fatal });
   }
 
   var tempDir = _tempDir();
@@ -187,7 +188,6 @@ function execAsync(cmd, opts, pipe, callback) {
 //@ Guidelines](https://github.com/shelljs/shelljs/wiki/Security-guidelines).
 function _exec(command, options, callback) {
   options = options || {};
-  if (!command) common.error('must specify command');
 
   var pipe = common.readFromPipe();
 
@@ -207,6 +207,8 @@ function _exec(command, options, callback) {
     fatal: common.config.fatal,
     async: false,
   }, options);
+  
+  if (!command) common.error('must specify command', { continue: true, fatal: options.fatal });
 
   if (options.async) {
     return execAsync(command, options, pipe, callback);

--- a/src/exec.js
+++ b/src/exec.js
@@ -28,7 +28,7 @@ function execSync(cmd, opts, pipe) {
 
   opts = common.extend({
     silent: common.config.silent,
-    fatal: common.config.fatal, // TODO(nfischer)
+    fatal: common.config.fatal, // TODO(nfischer): this and the line above are probably unnecessary
     cwd: _pwd().toString(),
     env: process.env,
     maxBuffer: DEFAULT_MAXBUFFER_SIZE,
@@ -110,7 +110,7 @@ function execSync(cmd, opts, pipe) {
 function execAsync(cmd, opts, pipe, callback) {
   opts = common.extend({
     silent: common.config.silent,
-    fatal: common.config.fatal, // TODO(nfischer)
+    fatal: common.config.fatal, // TODO(nfischer): this and the line above are probably unnecessary
     cwd: _pwd().toString(),
     env: process.env,
     maxBuffer: DEFAULT_MAXBUFFER_SIZE,

--- a/src/exec.js
+++ b/src/exec.js
@@ -207,7 +207,7 @@ function _exec(command, options, callback) {
     fatal: common.config.fatal,
     async: false,
   }, options);
-  
+
   if (!command) common.error('must specify command', { continue: true, fatal: options.fatal });
 
   if (options.async) {

--- a/src/exec.js
+++ b/src/exec.js
@@ -19,8 +19,15 @@ common.register('exec', _exec, {
 // output.
 function execSync(cmd, opts, pipe) {
   if (!common.config.execPath) {
-    common.error('Unable to find a path to the node binary. Please manually set config.execPath', { continue: true, fatal: opts.fatal });
-    return;
+    try {
+        common.error('Unable to find a path to the node binary. Please manually set config.execPath');
+    } catch (e) {
+      if (opts.fatal) {
+        throw e;
+      }
+
+      return;
+    }
   }
 
   var tempDir = _tempDir();
@@ -210,8 +217,15 @@ function _exec(command, options, callback) {
   }, options);
 
   if (!command) {
-    common.error('must specify command', { continue: true, fatal: options.fatal });
-    return;
+    try {
+      common.error('must specify command');
+    } catch (e) {
+      if (options.fatal) {
+        throw e;
+      }
+
+      return;
+    }
   }
 
   if (options.async) {

--- a/src/exec.js
+++ b/src/exec.js
@@ -28,6 +28,7 @@ function execSync(cmd, opts, pipe) {
 
   opts = common.extend({
     silent: common.config.silent,
+    fatal: common.config.fatal,
     cwd: _pwd().toString(),
     env: process.env,
     maxBuffer: DEFAULT_MAXBUFFER_SIZE,
@@ -99,7 +100,7 @@ function execSync(cmd, opts, pipe) {
     // Note: `silent` should be unconditionally true to avoid double-printing
     // the command's stderr, and to avoid printing any stderr when the user has
     // set `shell.config.silent`.
-    common.error(stderr, code, { continue: true, silent: true });
+    common.error(stderr, code, { continue: true, silent: true, fatal: opts.fatal });
   }
   var obj = common.ShellString(stdout, stderr, code);
   return obj;
@@ -109,6 +110,7 @@ function execSync(cmd, opts, pipe) {
 function execAsync(cmd, opts, pipe, callback) {
   opts = common.extend({
     silent: common.config.silent,
+    fatal: common.config.fatal,
     cwd: _pwd().toString(),
     env: process.env,
     maxBuffer: DEFAULT_MAXBUFFER_SIZE,
@@ -201,6 +203,7 @@ function _exec(command, options, callback) {
 
   options = common.extend({
     silent: common.config.silent,
+    fatal: common.config.fatal,
     async: false,
   }, options);
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -28,7 +28,7 @@ function execSync(cmd, opts, pipe) {
 
   opts = common.extend({
     silent: common.config.silent,
-    fatal: common.config.fatal,
+    fatal: common.config.fatal, // TODO(nfischer)
     cwd: _pwd().toString(),
     env: process.env,
     maxBuffer: DEFAULT_MAXBUFFER_SIZE,
@@ -110,7 +110,7 @@ function execSync(cmd, opts, pipe) {
 function execAsync(cmd, opts, pipe, callback) {
   opts = common.extend({
     silent: common.config.silent,
-    fatal: common.config.fatal,
+    fatal: common.config.fatal, // TODO(nfischer)
     cwd: _pwd().toString(),
     env: process.env,
     maxBuffer: DEFAULT_MAXBUFFER_SIZE,

--- a/src/exec.js
+++ b/src/exec.js
@@ -20,6 +20,7 @@ common.register('exec', _exec, {
 function execSync(cmd, opts, pipe) {
   if (!common.config.execPath) {
     common.error('Unable to find a path to the node binary. Please manually set config.execPath', { continue: true, fatal: opts.fatal });
+    return;
   }
 
   var tempDir = _tempDir();
@@ -208,7 +209,10 @@ function _exec(command, options, callback) {
     async: false,
   }, options);
 
-  if (!command) common.error('must specify command', { continue: true, fatal: options.fatal });
+  if (!command) {
+    common.error('must specify command', { continue: true, fatal: options.fatal });
+    return;
+  }
 
   if (options.async) {
     return execAsync(command, options, pipe, callback);

--- a/src/exec.js
+++ b/src/exec.js
@@ -148,6 +148,7 @@ function execAsync(cmd, opts, pipe, callback) {
 //@
 //@ + `async`: Asynchronous execution. If a callback is provided, it will be set to
 //@   `true`, regardless of the passed value (default: `false`).
+//@ + `fatal`: Exit upon error (default: `false`).
 //@ + `silent`: Do not echo program output to console (default: `false`).
 //@ + `encoding`: Character encoding to use. Affects the values returned to stdout and stderr, and
 //@   what is written to stdout and stderr when not in silent mode (default: `'utf8'`).

--- a/test/exec.js
+++ b/test/exec.js
@@ -51,7 +51,7 @@ test('options.fatal = true and unknown command', t => {
   t.throws(() => {
     shell.exec('asdfasdf', { fatal: true }); // could not find command
   }, /asdfasdf/); // name of command should be in error message
-  shell.config.fatal = oldFatal;
+  shell.config.fatal = oldFatal; // TODO(nfischer): this setting won't get reset if the assertion above fails
 });
 
 test('exec exits gracefully if we cannot find the execPath', t => {

--- a/test/exec.js
+++ b/test/exec.js
@@ -45,6 +45,15 @@ test('config.fatal and unknown command', t => {
   shell.config.fatal = oldFatal;
 });
 
+test('options.fatal = true and unknown command', t => {
+  const oldFatal = shell.config.fatal;
+  shell.config.fatal = false;
+  t.throws(() => {
+    shell.exec('asdfasdf', { fatal: true }); // could not find command
+  }, /asdfasdf/); // name of command should be in error message
+  shell.config.fatal = oldFatal;
+});
+
 test('exec exits gracefully if we cannot find the execPath', t => {
   shell.config.execPath = null;
   shell.exec('echo foo');
@@ -191,6 +200,15 @@ test('encoding option works', t => {
   t.truthy(Buffer.isBuffer(result.stderr));
   t.is(result.stdout.toString(), '1234\n');
   t.is(result.stderr.toString(), '');
+});
+
+test('options.fatal = false and unknown command', t => {
+  const oldFatal = shell.config.fatal;
+  shell.config.fatal = true;
+  const result = shell.exec('asdfasdf', { fatal: false }); // could not find command
+  shell.config.fatal = oldFatal;
+  t.truthy(shell.error());
+  t.is(result.code, 127);
 });
 
 //

--- a/test/exec.js
+++ b/test/exec.js
@@ -208,7 +208,7 @@ test('options.fatal = false and unknown command', t => {
   const result = shell.exec('asdfasdf', { fatal: false }); // could not find command
   shell.config.fatal = oldFatal;
   t.truthy(shell.error());
-  t.is(result.code, 127);
+  t.is(result.code > 0, true);
 });
 
 //

--- a/test/exec.js
+++ b/test/exec.js
@@ -208,7 +208,7 @@ test('options.fatal = false and unknown command', t => {
   const result = shell.exec('asdfasdf', { fatal: false }); // could not find command
   shell.config.fatal = oldFatal;
   t.truthy(shell.error());
-  t.is(result.code > 0, true);
+  t.truthy(result.code);
 });
 
 //


### PR DESCRIPTION
This PR introduces a new boolean `fatal` option for the `exec()` function. Like the existing `silent` option, this new option allows you to override the global `fatal` configuration parameter on a per-command basis, like:

```js
exec('example command', {
    fatal: true|false,
});
```

This eliminates the need for the following pattern:

```js
const oldFatal = shell.config.fatal;
shell.config.fatal = false;
exec('some command that might fail');
shell.config.fatal = oldFatal;
```

The old pattern can introduce race conditions in `async` functions, an issue that was surfaced in our code with the new ESLint rule, [require-atomic-updates](https://eslint.org/docs/rules/require-atomic-updates).