### PR TITLE
test: misc test changes

### DIFF
--- a/test/cp.js
+++ b/test/cp.js
@@ -421,17 +421,10 @@ test('Make sure hidden files are copied recursively', t => {
 });
 
 test('no-recursive will copy regular files only', t => {
-  const result = shell.cp('test/resources/file1.txt', 'test/resources/ls/', t.context.tmp);
-  t.is(result.code, 1);
-  t.truthy(shell.error());
-  t.falsy(fs.existsSync(`${t.context.tmp}/.hidden_file`)); // doesn't copy dir contents
-  t.falsy(fs.existsSync(`${t.context.tmp}/ls`)); // doesn't copy dir itself
-  t.truthy(fs.existsSync(`${t.context.tmp}/file1.txt`));
-});
-
-test('no-recursive will copy regular files only', t => {
-  const result = shell.cp('test/resources/file1.txt', 'test/resources/file2.txt', 'test/resources/cp',
-    'test/resources/ls/', t.context.tmp);
+  const result = shell.cp(
+    'test/resources/file1.txt', 'test/resources/file2.txt', 'test/resources/cp',
+    'test/resources/ls/', t.context.tmp
+  );
 
   t.is(result.code, 1);
   t.truthy(shell.error());

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -145,7 +145,7 @@ test('-p flag', t => {
   shell.rm('-Rf', `${t.context.tmp}/a`); // revert
 });
 
-test('multiple dirs', t => {
+test('-p flag: multiple dirs', t => {
   const result = shell.mkdir('-p', `${t.context.tmp}/zzza`,
     `${t.context.tmp}/zzzb`, `${t.context.tmp}/zzzc`);
   t.falsy(shell.error());
@@ -155,7 +155,7 @@ test('multiple dirs', t => {
   t.truthy(fs.existsSync(`${t.context.tmp}/zzzc`));
 });
 
-test('multiple dirs, array syntax', t => {
+test('-p flag: multiple dirs, array syntax', t => {
   const result = shell.mkdir('-p', [`${t.context.tmp}/yyya`,
     `${t.context.tmp}/yyyb`, `${t.context.tmp}/yyyc`]);
   t.falsy(shell.error());

--- a/test/utils/utils.js
+++ b/test/utils/utils.js
@@ -61,7 +61,7 @@ function skipIfTrue(booleanValue, t, closure) {
   if (booleanValue) {
     _processStderrWrite(
       chalk.yellow('Warning: skipping platform-dependent test ') +
-      chalk.bold.white(`'${t._test.title}'`) +
+      chalk.bold.white(`'${t.title}'`) +
       '\n'
     );
     t.truthy(true); // dummy assertion to satisfy ava v0.19+


### PR DESCRIPTION
No change to production logic.

This renames test cases with duplicate names, deletes a redundant test,
and uses the public `t.title` API in favor of `t._test.title`.

This is a prerequisite for updating ava.

Issue #969