### PR TITLE
chore: update dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "powerAssert": false
   },
   "devDependencies": {
-    "ava": "^0.21.0",
+    "ava": "^1.4.1",
     "chalk": "^1.1.3",
     "codecov": "^3.0.2",
     "coffee-script": "^1.10.0",
@@ -67,7 +67,7 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
     "js-yaml": "^3.12.0",
-    "nyc": "^11.3.0",
+    "nyc": "^14.1.1",
     "shelljs-changelog": "^0.2.0",
     "shelljs-release": "^0.3.0",
     "shx": "^0.2.0",


### PR DESCRIPTION
No change to logic.

This updates ava and nyc, to suppress npm audit error messages.

Fixes #969