### PR TITLE
Silence potentially upcoming circular dependency warning

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -478,7 +478,7 @@ function _register(name, implementation, wrapOptions) {
   // If an option isn't specified, use the default
   wrapOptions = Object.assign({}, DEFAULT_WRAP_OPTIONS, wrapOptions);
 
-  if (shell[name]) {
+  if (shell.hasOwnProperty(name)) {
     throw new Error('Command `' + name + '` already exists');
   }
 


### PR DESCRIPTION
Node.js is currently considering printing a warning when a non-existent
property of `module.exports` is accessed while in a circular `require()`
dependency, in order to make it easier to catch issues with circular
dependencies.

In order to avoid printing these warnings for shelljs, checking for the
property’s existence rather than its truthiness suffices.

Refs: https://github.com/nodejs/node/pull/29935