### PR TITLE
fix(exec): join paths correctly

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -31,9 +31,9 @@ function execSync(cmd, opts, pipe) {
   }
 
   var tempDir = _tempDir();
-  var paramsFile = path.resolve(tempDir + '/' + common.randomFileName());
-  var stderrFile = path.resolve(tempDir + '/' + common.randomFileName());
-  var stdoutFile = path.resolve(tempDir + '/' + common.randomFileName());
+  var paramsFile = path.join(tempDir, common.randomFileName());
+  var stderrFile = path.join(tempDir, common.randomFileName());
+  var stdoutFile = path.join(tempDir, common.randomFileName());
 
   opts = common.extend({
     silent: common.config.silent,


### PR DESCRIPTION
Previously, we just concatenated _tempDir() with '/' and a random
filename. Instead, we should join paths with path.join() to use the OS
path separator.

This is a speculative fix for issue #974, although this may not be
enough to actually make Windows happy.

Issue #974