### PR TITLE
fix(mv): Fix moving files across volumes

### DIFF
--- a/src/mv.js
+++ b/src/mv.js
@@ -109,8 +109,8 @@ function _mv(options, sources, dest) {
         // to perform a copy and then clean up the original file. If either the
         // copy or the rm fails with an exception, we should allow this
         // exception to pass up to the top level.
-        cp('-r', src, thisDest);
-        rm('-rf', src);
+        cp({ recursive: true }, src, thisDest);
+        rm({ recursive: true, force: true }, src);
       }
     }
   }); // forEach(src)


### PR DESCRIPTION
At some point options parsing happened inside `_mv()` and `_cp()` but that is no longer the case so a parsed options object should be used instead.