### PR TITLE
find() - use default platform path separators

### DIFF
--- a/src/find.js
+++ b/src/find.js
@@ -30,13 +30,6 @@ function _find(options, paths) {
 
   var list = [];
 
-  function pushFile(file) {
-    if (process.platform === 'win32') {
-      file = file.replace(/\\/g, '/');
-    }
-    list.push(file);
-  }
-
   // why not simply do `ls('-R', paths)`? because the output wouldn't give the base dirs
   // to get the base dir in the output, we need instead `ls('-R', 'dir/*')` for every directory
 
@@ -48,11 +41,14 @@ function _find(options, paths) {
       common.error('no such file or directory: ' + file);
     }
 
-    pushFile(file);
+    // Node's path.join() below will return platform-appropriate paths,
+    // but on Windows paths with POSIX separators may be provided to this function.
+    // So normalize:
+    list.push(path.normalize(file));
 
     if (stat.isDirectory()) {
       _ls({ recursive: true, all: true }, file).forEach(function (subfile) {
-        pushFile(path.join(file, subfile));
+        list.push(path.join(file, subfile));
       });
     }
   });

--- a/test/find.js
+++ b/test/find.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import path from 'path';
 
 import shell from '..';
 
@@ -28,8 +29,8 @@ test('current path', t => {
   const result = shell.find('.');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('.hidden') > -1);
-  t.truthy(result.indexOf('dir1/dir11/a_dir11') > -1);
+  t.truthy(result.indexOf(path.normalize('.hidden')) > -1);
+  t.truthy(result.indexOf(path.normalize('dir1/dir11/a_dir11')) > -1);
   t.is(result.length, 11);
   shell.cd('../..');
 });
@@ -38,8 +39,19 @@ test('simple path', t => {
   const result = shell.find('test/resources/find');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/find/.hidden') > -1);
-  t.truthy(result.indexOf('test/resources/find/dir1/dir11/a_dir11') > -1);
+  t.truthy(result.indexOf(path.normalize('test/resources/find/.hidden')) > -1);
+  t.truthy(result.indexOf(path.normalize('test/resources/find/dir1/dir11/a_dir11')) > -1);
+  t.is(result.length, 11);
+});
+
+test('simple path - current platform delimiters', t => {
+  // Normalize the path argument to test Windows delimiters on Windows,
+  // while not making POSIX platforms encounter them.
+  const result = shell.find(path.normalize('test/resources/find'));
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.truthy(result.indexOf(path.normalize('test/resources/find/.hidden')) > -1);
+  t.truthy(result.indexOf(path.normalize('test/resources/find/dir1/dir11/a_dir11')) > -1);
   t.is(result.length, 11);
 });
 
@@ -47,8 +59,8 @@ test('multiple paths - comma', t => {
   const result = shell.find('test/resources/find/dir1', 'test/resources/find/dir2');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/find/dir1/dir11/a_dir11') > -1);
-  t.truthy(result.indexOf('test/resources/find/dir2/a_dir1') > -1);
+  t.truthy(result.indexOf(path.normalize('test/resources/find/dir1/dir11/a_dir11')) > -1);
+  t.truthy(result.indexOf(path.normalize('test/resources/find/dir2/a_dir1')) > -1);
   t.is(result.length, 6);
 });
 
@@ -56,8 +68,8 @@ test('multiple paths - array', t => {
   const result = shell.find(['test/resources/find/dir1', 'test/resources/find/dir2']);
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/find/dir1/dir11/a_dir11') > -1);
-  t.truthy(result.indexOf('test/resources/find/dir2/a_dir1') > -1);
+  t.truthy(result.indexOf(path.normalize('test/resources/find/dir1/dir11/a_dir11')) > -1);
+  t.truthy(result.indexOf(path.normalize('test/resources/find/dir2/a_dir1')) > -1);
   t.is(result.length, 6);
 });
 


### PR DESCRIPTION
I encountered an issue where [paths were assumed to be delimited with the current platforms path delimiter](https://github.com/banyudu/find-git-root/pull/5), and as such the output of shelljs's `find` - which currently returns paths with POSIX delimiters on all platforms - produced unexpected results.
The current `if (process.platform === 'win32') { file = file.replace(/\\/g, '/'); }` code seems to have been added as part of the initial implementation of `find` without a reason why.

I figure this may be a chance to review that behaviour.

I realise `/` is a suitable delimiter for all platforms, but I feel requiring an additional call to `path.normalize` for each path when using shelljs's `find` a bit odd. Especially considering the opening statement
> ShellJS is a portable (Windows/Linux/macOS) implementation of Unix shell commands on top of the Node.js API

It seems like expecting `/` delimiters when dealing with paths on Windows would be less intuitive than `\`, so those requiring such output would be prepared to intentionally check for & replace the delimiters as appropriate.

It would be in line with [Node.js](https://nodejs.org/api/path.html#path_path_sep) to return paths using the current platforms default delimiter.
>On Windows, both the forward slash (`/`) and backward slash (`\`) are accepted as path segment separators; however, the path methods only add backward slashes (`\`).