### PR TITLE
chore: change supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: node_js
 sudo: false
 node_js:
-  - 6
-  - 7
   - 8
   - 9
   - 10
   - 11
   - 12
   - 13
+  - 14
 
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ script's dependency on Unix while still keeping its familiar and powerful
 commands. You can also install it globally so you can run it from outside Node
 projects - say goodbye to those gnarly Bash scripts!
 
-ShellJS is proudly tested on every node release since <!-- start minVersion -->`v6`<!-- stop minVersion -->!
+ShellJS is proudly tested on every node release since <!-- start minVersion -->`v8`<!-- stop minVersion -->!
 
 The project is [unit-tested](http://travis-ci.org/shelljs/shelljs) and battle-tested in projects like:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,12 @@
 environment:
   matrix:
+    - nodejs_version: '14'
     - nodejs_version: '13'
     - nodejs_version: '12'
     - nodejs_version: '11'
     - nodejs_version: '10'
     - nodejs_version: '9'
     - nodejs_version: '8'
-    - nodejs_version: '7'
-    - nodejs_version: '6'
 
 version: '{build}'
 

--- a/package.json
+++ b/package.json
@@ -71,11 +71,11 @@
     "nyc": "^14.1.1",
     "shelljs-changelog": "^0.2.0",
     "shelljs-release": "^0.3.0",
-    "shx": "^0.2.0",
+    "shx": "^0.3.3",
     "travis-check-changes": "^0.2.0"
   },
   "optionalDependencies": {},
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   }
 }

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -8,8 +8,8 @@ var yaml = require('js-yaml');
 var shell = require('..');
 
 // This is the authoritative list of supported node versions.
-var MIN_NODE_VERSION = 6;
-var MAX_NODE_VERSION = 13;
+var MIN_NODE_VERSION = 8;
+var MAX_NODE_VERSION = 14;
 
 function checkReadme(minNodeVersion) {
   var start = '<!-- start minVersion -->';
@@ -20,7 +20,7 @@ function checkReadme(minNodeVersion) {
   );
   var readme = path.join(__dirname, '..', 'README.md');
   var match = shell.grep(expectedReadmeRegex, readme);
-  if (!match.toString()) {
+  if (!match.toString().trim()) {
     var msg = 'Update README to specify the min supported version. Look for "'
         + start + '"';
     throw new Error(msg);
@@ -81,6 +81,8 @@ try {
   var appveyorFileName = path.join(__dirname, '..', 'appveyor.yml');
   var appveyorYaml = yaml.safeLoad(shell.cat(appveyorFileName));
   checkAppveyor(MIN_NODE_VERSION, MAX_NODE_VERSION, appveyorYaml);
+  console.log('All files look good (this project supports v'
+      + MIN_NODE_VERSION + '-v' + MAX_NODE_VERSION + ')!');
 } catch (e) {
   console.error('Please check the files which declare our Node version');
   console.error('support, as something is out-of-sync. This script failed');


### PR DESCRIPTION
This adds testing for node v14. This removes testing for node v6 and v7
because codecov breaks on these versions. This omits node v15 because
appveyor doesn't seem to support this version. The nodejs org currently
supports [10, 12, 14, 15].

This makes a couple minor edits to the check-node-support script for
consistency with shelljs/shx#186.

Test: npm run check-node-support