### PR TITLE
Added mkdir -p tests for subdirectories

### DIFF
--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -165,6 +165,16 @@ test('-p flag: multiple dirs, array syntax', t => {
   t.truthy(fs.existsSync(`${t.context.tmp}/yyyc`));
 });
 
+test('-p flag: subdirectory already exists', t => {
+  t.falsy(fs.existsSync(`${t.context.tmp}/d1`));
+  shell.mkdir('-p', `${t.context.tmp}/d1/d2/d3`);
+  t.truthy(fs.existsSync(`${t.context.tmp}/d1/d2/d3`));
+  const result = shell.mkdir('-p', `${t.context.tmp}/d1/d2`);
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.truthy(fs.existsSync(`${t.context.tmp}/d1/d2/d3`));
+});
+
 test('globbed dir', t => {
   let result = shell.mkdir('-p', `${t.context.tmp}/mydir`);
   t.falsy(shell.error());

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -175,6 +175,16 @@ test('-p flag: subdirectory already exists', t => {
   t.truthy(fs.existsSync(`${t.context.tmp}/d1/d2/d3`));
 });
 
+test('-p flag: create directory in subdirectory', t => {
+  t.falsy(fs.existsSync(`${t.context.tmp}/d1`));
+  shell.mkdir('-p', `${t.context.tmp}/d1/d2`);
+  t.truthy(fs.existsSync(`${t.context.tmp}/d1/d2`));
+  const result = shell.mkdir('-p', `${t.context.tmp}/d1/d2/d3`);
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.truthy(fs.existsSync(`${t.context.tmp}/d1/d2/d3`));
+});
+
 test('globbed dir', t => {
   let result = shell.mkdir('-p', `${t.context.tmp}/mydir`);
   t.falsy(shell.error());


### PR DESCRIPTION
This PR is for [#1022](https://github.com/shelljs/shelljs/issues/1022), and aims to expand testing for mkdir -p when (1) a sub-directory already exists, and (2) the sub-directory does not exist. Please let me know if you'd like me to change something, and thank you for the opportunity to work on this issue!