### PR TITLE
remove file extension

### DIFF
--- a/test/exec.js
+++ b/test/exec.js
@@ -65,7 +65,7 @@ test('exec exits gracefully if we cannot find the execPath', t => {
 
 test('cannot require exec-child.js', t => {
   t.throws(() => {
-    require('../src/exec-child.js');
+    require('../src/exec-child');
   }, /This file should not be required/);
 });
 


### PR DESCRIPTION
This PR is for [#1032](https://github.com/shelljs/shelljs/issues/1032), and removes a .js file extension as a quick fix for a linting error that seems to have appeared recently on ```npm run lint```. Please let me know if you'd like me to change something, and thank you for the opportunity to work on another issue! 