### PR TITLE
Removed mentions of documentup website 

### DIFF
--- a/.documentup.json
+++ b/.documentup.json
@@ -1,6 +1,0 @@
-{
-  "name": "ShellJS",
-  "twitter": [
-    "r2r"
-  ]
-}

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ wiki](https://github.com/shelljs/shelljs/wiki/Using-ShellJS-Plugins).
 For documentation on all the latest features, check out our
 [README](https://github.com/shelljs/shelljs). To read docs that are consistent
 with the latest release, check out [the npm
-page](https://www.npmjs.com/package/shelljs) or
-[shelljs.org](http://documentup.com/shelljs/shelljs).
+page](https://www.npmjs.com/package/shelljs).
 
 ## Installing
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,5 +10,3 @@
   - `$ npm run changelog`
   - Manually verify that the changelog makes sense
   - `$ git push`
-4. Generate the documentup website by visiting
-  http://documentup.com/shelljs/shelljs/__recompile in your browser


### PR DESCRIPTION
Since documentup website is no longer available, I have removed all mentions of it in README.md and RELEASE.md

Current documentation is generated using `npm run gendocs` to pull annotated comments and append in README.md. 

`npm test` and `npm run lint` passed. 

Let me know if you have any questions. 