### PR TITLE
chore(ci): bump CI to include node v15/16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
           - 12
           - 13
           - 14
+          - 15
+          - 16
         os:
           - ubuntu-latest
           - macos-latest

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -9,7 +9,7 @@ var shell = require('..');
 
 // This is the authoritative list of supported node versions.
 var MIN_NODE_VERSION = 8;
-var MAX_NODE_VERSION = 14;
+var MAX_NODE_VERSION = 16;
 
 function checkReadme(minNodeVersion) {
   var start = '<!-- start minVersion -->';


### PR DESCRIPTION
No change to logic. This bumps the CI to include node v15 and v16 when
testing. No change to minimum node version.