### PR TITLE
chore: remove codecov devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "lint": "eslint .",
     "after-travis": "travis-check-changes",
     "changelog": "shelljs-changelog",
-    "codecov": "codecov",
     "release:major": "shelljs-release major",
     "release:minor": "shelljs-release minor",
     "release:patch": "shelljs-release patch"
@@ -62,7 +61,6 @@
   "devDependencies": {
     "ava": "^1.4.1",
     "chalk": "^1.1.3",
-    "codecov": "^3.0.2",
     "coffee-script": "^1.10.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",


### PR DESCRIPTION
No change to logic. This removes the codecov package dependency because
this is provided through GitHub Actions now.