### PR TITLE
docs(import): document es6 import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ var shell = require('shelljs');
 shell.echo('hello world');
 ```
 
+Alternatively, we also support importing as a module with:
+
+```javascript
+import shell from 'shelljs';
+shell.echo('hello world');
+```
+
 <!-- DO NOT MODIFY BEYOND THIS POINT - IT'S AUTOMATICALLY GENERATED -->
 
 


### PR DESCRIPTION
No change to logic. This documents that we support importing via
`import shell from 'shelljs'`.

Related to issue #1071, although some more investigation is required to
understand why the other syntax doesn't work.