### PR TITLE
docs(touch): clarify docs for touch() command

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,10 +681,10 @@ Available options:
 + `-a`: Change only the access time
 + `-c`: Do not create any files
 + `-m`: Change only the modification time
-+ `{'-d': someDate}`, `{date: someDate}`: Use `someDate` (instance of
-  `Date`) instead of current time
++ `{'-d': someDate}`, `{date: someDate}`: Use a `Date` instance (ex. `someDate`)
+  instead of current time
 + `{'-r': file}`, `{reference: file}`: Use `file`'s times instead of current
-   time
+  time
 
 Examples:
 
@@ -692,6 +692,7 @@ Examples:
 touch('source.js');
 touch('-c', 'path/to/file.js');
 touch({ '-r': 'referenceFile.txt' }, 'path/to/file.js');
+touch({ '-d': new Date('December 17, 1995 03:24:00'), '-m': true }, 'path/to/file.js');
 touch({ date: new Date('December 17, 1995 03:24:00') }, 'path/to/file.js');
 ```
 

--- a/src/touch.js
+++ b/src/touch.js
@@ -20,10 +20,10 @@ common.register('touch', _touch, {
 //@ + `-a`: Change only the access time
 //@ + `-c`: Do not create any files
 //@ + `-m`: Change only the modification time
-//@ + `{'-d': someDate}`, `{date: someDate}`: Use `someDate` (instance of
-//@   `Date`) instead of current time
+//@ + `{'-d': someDate}`, `{date: someDate}`: Use a `Date` instance (ex. `someDate`)
+//@   instead of current time
 //@ + `{'-r': file}`, `{reference: file}`: Use `file`'s times instead of current
-//@    time
+//@   time
 //@
 //@ Examples:
 //@
@@ -31,6 +31,7 @@ common.register('touch', _touch, {
 //@ touch('source.js');
 //@ touch('-c', 'path/to/file.js');
 //@ touch({ '-r': 'referenceFile.txt' }, 'path/to/file.js');
+//@ touch({ '-d': new Date('December 17, 1995 03:24:00'), '-m': true }, 'path/to/file.js');
 //@ touch({ date: new Date('December 17, 1995 03:24:00') }, 'path/to/file.js');
 //@ ```
 //@

--- a/test/touch.js
+++ b/test/touch.js
@@ -129,14 +129,14 @@ test('accepts -d flag', t => {
   t.is(common.statFollowLinks(testFile).atime.getTime(), date.getTime());
 });
 
-test('accepts long option (date)', t => {
+test('accepts long option (--date)', t => {
   const testFile = tmpFile(t);
-  const date = new Date('December 17, 1995 03:24:00');
-  const result = shell.touch({ date }, testFile);
+  const someDate = new Date('December 17, 1995 03:24:00');
+  const result = shell.touch({ date: someDate }, testFile);
   t.is(result.code, 0);
   // Compare getTime(), because Date can't be compared with triple-equals.
-  t.is(common.statFollowLinks(testFile).mtime.getTime(), date.getTime());
-  t.is(common.statFollowLinks(testFile).atime.getTime(), date.getTime());
+  t.is(common.statFollowLinks(testFile).mtime.getTime(), someDate.getTime());
+  t.is(common.statFollowLinks(testFile).atime.getTime(), someDate.getTime());
 });
 
 test('sets mtime and atime by default', t => {


### PR DESCRIPTION
No change to logic. This expands on the `touch()` command documentation
to make it more obvious how to use multiple options, long options, etc.
This also renames a variable in a test case to make the usage more
obvious.