### PR TITLE
Explicitly require commands

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -21,9 +21,40 @@ var common = require('./src/common');
 //@commands
 
 // Load all default commands
-require('./commands').forEach(function (command) {
-  require('./src/' + command);
-});
+require('./src/cat');
+require('./src/cd');
+require('./src/chmod');
+require('./src/cmd');
+require('./src/common');
+require('./src/cp');
+require('./src/dirs');
+require('./src/echo');
+require('./src/error');
+require('./src/errorCode');
+require('./src/exec-child');
+require('./src/exec');
+require('./src/find');
+require('./src/grep');
+require('./src/head');
+require('./src/ln');
+require('./src/ls');
+require('./src/mkdir');
+require('./src/mv');
+require('./src/popd');
+require('./src/pushd');
+require('./src/pwd');
+require('./src/rm');
+require('./src/sed');
+require('./src/set');
+require('./src/sort');
+require('./src/tail');
+require('./src/tempdir');
+require('./src/test');
+require('./src/to');
+require('./src/toEnd');
+require('./src/touch');
+require('./src/unique');
+require('./src/which');
 
 //@
 //@ ### exit(code)


### PR DESCRIPTION
Currently anything that includes `shelljs` in it's chain cannot be bundled into a singular file due to the dynamic require. By explicitly requiring everything in src, this allows singular bundles through things like esbuild.