### PR TITLE
docs: add description of the exec callback execute timing

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -202,7 +202,7 @@ function execAsync(cmd, opts, pipe, callback) {
 //@ Executes the given `command` _synchronously_, unless otherwise specified.
 //@ When in synchronous mode, this returns a [ShellString](#shellstringstr).
 //@ Otherwise, this returns the child process object, and the `callback`
-//@ receives the arguments `(code, stdout, stderr)`.
+//@ receives the arguments `(code, stdout, stderr)` when the process terminates.
 //@
 //@ Not seeing the behavior you want? `exec()` runs everything through `sh`
 //@ by default (or `cmd.exe` on Windows), which differs from `bash`. If you


### PR DESCRIPTION
Hello everyone, I noticed that the documentation for the exec function in the library does not specify when the callback function is executed. As I found this information unclear, I took the initiative to add a note inside the source code explaining the timing of the callback function's execution arrcoding docs here: [child_process.exec(command[, options][, callback])](https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback).