### PR TITLE
fix: shell.errorCode() honors shell.exit(code)

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -29,7 +29,20 @@ require('./commands').forEach(function (command) {
 //@ ### exit(code)
 //@
 //@ Exits the current process with the given exit `code`.
-exports.exit = process.exit;
+exports.exit = function exit(code) {
+  if (code) {
+    common.error('exit', {
+      continue: true,
+      code: code,
+      prefix: '',
+      silent: true,
+      fatal: false,
+    });
+    process.exit(code);
+  } else {
+    process.exit();
+  }
+};
 
 //@include ./src/error.js
 exports.error = require('./src/error');


### PR DESCRIPTION
This changes shell.exit() to use a wrapper function. This is so that shell.errorCode() will have the correct error code after invoking shell.exit(code). This isn't normally relevant, however a caller may be listening for the exit status:

```js
process.on('exit', code => {
  shell.exit(shell.errorCode());
});
```

Issue #1013