### PR TITLE
chore: update CI to test against node v20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
           - 16
           - 17
           - 18
+          - 19
+          - 20
         os:
           - ubuntu-latest
           - macos-latest

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -9,7 +9,7 @@ var shell = require('..');
 
 // This is the authoritative list of supported node versions.
 var MIN_NODE_VERSION = 8;
-var MAX_NODE_VERSION = 18;
+var MAX_NODE_VERSION = 20;
 
 function checkReadme(minNodeVersion) {
   var start = '<!-- start minVersion -->';


### PR DESCRIPTION
No change to logic. This updates GitHub actions CI to test on node v19 and v20.