### PR TITLE
Added verbosity flag (-v) for cp, mv and rm commands

### DIFF
--- a/src/cp.js
+++ b/src/cp.js
@@ -12,6 +12,7 @@ common.register('cp', _cp, {
     'L': 'followsymlink',
     'P': 'noFollowsymlink',
     'p': 'preserve',
+    'v': 'verbose',
   },
   wrapOutput: false,
 });
@@ -84,6 +85,10 @@ function copyFileSync(srcFile, destFile, options) {
     fs.closeSync(fdr);
     fs.closeSync(fdw);
   }
+
+  if (options.verbose) {
+    console.log("copied '" + srcFile + "' -> '" + destFile + "'");
+  }
 }
 
 // Recursively copies 'sourceDir' into 'destDir'
@@ -108,6 +113,9 @@ function cpdirSyncRecursive(sourceDir, destDir, currentDepth, opts) {
   var checkDir = common.statFollowLinks(sourceDir);
   try {
     fs.mkdirSync(destDir);
+    if (opts.verbose) {
+      console.log("created directory '" + sourceDir + "' -> '" + destDir + "'");
+    }
   } catch (e) {
     // if the directory already exists, that's okay
     if (e.code !== 'EEXIST') throw e;

--- a/src/mv.js
+++ b/src/mv.js
@@ -8,6 +8,7 @@ common.register('mv', _mv, {
   cmdOptions: {
     'f': '!no_force',
     'n': 'no_force',
+    'v': 'verbose',
   },
 });
 
@@ -102,6 +103,9 @@ function _mv(options, sources, dest) {
 
     try {
       fs.renameSync(src, thisDest);
+      if (options.verbose) {
+        console.log("renamed '" + src + "' -> '" + thisDest + "'");
+      }
     } catch (e) {
       /* istanbul ignore next */
       if (e.code === 'EXDEV') {
@@ -109,8 +113,8 @@ function _mv(options, sources, dest) {
         // to perform a copy and then clean up the original file. If either the
         // copy or the rm fails with an exception, we should allow this
         // exception to pass up to the top level.
-        cp({ recursive: true }, src, thisDest);
-        rm({ recursive: true, force: true }, src);
+        cp({ recursive: true, verbose: options.verbose }, src, thisDest);
+        rm({ recursive: true, force: true, verbose: options.verbose }, src);
       }
     }
   }); // forEach(src)


### PR DESCRIPTION
Closes #1127

The suggested verbose output is **not** claimed to be fully identical to the corresponding output in the original commands from coreutils. Though it is very similar, I also tried to make as few edits as possible.