### PR TITLE
chore: fix test coverage parsing bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
     "js-yaml": "^3.14.1",
-    "nyc": "^14.1.1",
+    "nyc": "^15.1.0",
     "shelljs-changelog": "^0.2.6",
     "shelljs-release": "^0.5.2",
     "shx": "^0.3.4",


### PR DESCRIPTION
For some reason it seems like `nyc` v14 is incompatible with node v16/v18/v20. See this CI run as an example:
https://github.com/shelljs/shelljs/actions/runs/5956710281/job/16287478757?pr=1129

This updates `nyc` to v15 which should fix the issue.

Fixes #1130
Test: nvm use v16.20.2
Test: npm run test-with-coverage