### PR TITLE
Exports shell.js and make.js on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "main": "./shell.js",
   "exports": {
     ".": "./shell.js",
-    "./make": "./make.js"
+    "./make": "./make.js",
+    "./make.js": "./make.js"
   },
   "files": [
     "commands.js",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
   "license": "BSD-3-Clause",
   "homepage": "http://github.com/shelljs/shelljs",
   "main": "./shell.js",
+  "exports": {
+    ".": "./shell.js",
+    "./make": "./make.js"
+  },
   "files": [
     "commands.js",
     "global.js",


### PR DESCRIPTION
Exports shell.js and make.js on package.json so make.js can be imported as "shelljs/make" without require file extension when using ESM.