### PR TITLE
chore: remove codecov token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,5 +49,4 @@ jobs:
         if: matrix.node-version >= 10
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
It looks like 1a1a820569f0883a317944973c15cf34431dd6c2 actually broke codecov. Codecov is currently trying to diff all PRs against the commit before that one, which leads to flagging previously-added lines of code as needing coverage in the current PR.

Let's try removing the token and see if codecov is happy again.

Fixes #1124