### PR TITLE
chore: update nyc to v15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm run test-with-coverage
+      - name: test with coverage
+        run: npm run test-with-coverage
+        if: matrix.node-version >= 10
+      - name: test without coverage (coverage broken on node < 10)
+        run: npm run test
+        if: matrix.node-version < 10
       - run: npm run lint
       - run: npm run gendocs
       - run: npm run check-node-support
@@ -41,6 +46,7 @@ jobs:
         run: npm run after-travis
         if: matrix.os != 'windows-latest'
       - name: Upload coverage reports to Codecov
+        if: matrix.node-version >= 10
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -66,13 +66,12 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
     "js-yaml": "^3.14.1",
-    "nyc": "^14.1.1",
+    "nyc": "^15.1.0",
     "shelljs-changelog": "^0.2.6",
     "shelljs-release": "^0.5.2",
     "shx": "^0.3.4",
     "travis-check-changes": "^0.4.0"
   },
-  "optionalDependencies": {},
   "engines": {
     "node": ">=8"
   }


### PR DESCRIPTION
No change to logic. This updates nyc (code coverage tool) to version 15. The main goal is to work around a bug on the latest nodejs LTS versions.

This change indicates it only supports nodejs >= 8.9. Hopefully this is good enough for our purposes since ShellJS currently supports nodejs >= 8.

Fixes #1130