### PR TITLE
chore: keep node < 16 around longer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   - push
   - pull_request
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:
   test:
     name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}


### PR DESCRIPTION
GitHub is removing all versions < v16 from GitHub actions. I'm trying to keep Node coverage for as long as possible.

Issue #1140