### PR TITLE
test: add coverage for exit function

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -30,6 +30,8 @@ require('./commands').forEach(function (command) {
 //@
 //@ Exits the current process with the given exit `code`.
 exports.exit = function exit(code) {
+  common.state.error = null;
+  common.state.errorCode = 0;
   if (code) {
     common.error('exit', {
       continue: true,

--- a/test/echo.js
+++ b/test/echo.js
@@ -8,12 +8,14 @@ shell.config.silent = true;
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();
-  mocks.init();
+  mocks.stdout.init();
+  mocks.stderr.init();
 });
 
 test.afterEach.always(t => {
   shell.rm('-rf', t.context.tmp);
-  mocks.restore();
+  mocks.stdout.restore();
+  mocks.stderr.restore();
 });
 
 //
@@ -22,8 +24,8 @@ test.afterEach.always(t => {
 
 test('simple test with defaults', t => {
   const result = shell.echo('hello', 'world');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'hello world\n');
@@ -33,8 +35,8 @@ test('simple test with defaults', t => {
 test('allow arguments to begin with a hyphen', t => {
   // Github issue #20
   const result = shell.echo('-asdf', '111');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.falsy(shell.error());
   t.is(result.code, 1);
   t.is(stdout, '-asdf 111\n');
@@ -43,8 +45,8 @@ test('allow arguments to begin with a hyphen', t => {
 
 test("using null as an explicit argument doesn't crash the function", t => {
   const result = shell.echo(null);
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'null\n');
@@ -53,8 +55,8 @@ test("using null as an explicit argument doesn't crash the function", t => {
 
 test('-e option', t => {
   const result = shell.echo('-e', '\tmessage');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, '\tmessage\n');
@@ -72,8 +74,8 @@ test('piping to a file', t => {
   t.falsy(shell.error());
   t.is(resultB.code, 0);
   const result = shell.cat(tmp);
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.falsy(shell.error());
   t.is(stdout, 'A\nB\n');
   t.is(stderr, '');
@@ -82,8 +84,8 @@ test('piping to a file', t => {
 
 test('-n option', t => {
   const result = shell.echo('-n', 'message');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'message');
@@ -92,8 +94,8 @@ test('-n option', t => {
 
 test('-ne option', t => {
   const result = shell.echo('-ne', 'message');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'message');
@@ -102,8 +104,8 @@ test('-ne option', t => {
 
 test('-en option', t => {
   const result = shell.echo('-en', 'message');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, 'message');
@@ -112,8 +114,8 @@ test('-en option', t => {
 
 test('-en option with escaped characters', t => {
   const result = shell.echo('-en', '\tmessage\n');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(stdout, '\tmessage\n');
@@ -131,8 +133,8 @@ test('piping to a file with -n', t => {
   t.falsy(shell.error());
   t.is(resultB.code, 0);
   const result = shell.cat(tmp);
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.falsy(shell.error());
   t.is(stdout, 'AB');
   t.is(stderr, '');
@@ -141,8 +143,8 @@ test('piping to a file with -n', t => {
 
 test('stderr with unrecognized options is empty', t => {
   const result = shell.echo('-asdf');
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.falsy(shell.error());
   t.is(result.code, 1);
   t.falsy(result.stderr);

--- a/test/exec.js
+++ b/test/exec.js
@@ -13,13 +13,15 @@ const ORIG_EXEC_PATH = shell.config.execPath;
 shell.config.silent = true;
 
 test.beforeEach(() => {
-  mocks.init();
+  mocks.stdout.init();
+  mocks.stderr.init();
 });
 
 test.afterEach.always(() => {
   process.chdir(CWD);
   shell.config.execPath = ORIG_EXEC_PATH;
-  mocks.restore();
+  mocks.stdout.restore();
+  mocks.stderr.restore();
 });
 
 //
@@ -102,8 +104,8 @@ test('check if stdout + stderr go to output', t => {
 
 test('check if stdout + stderr should not be printed to console if silent', t => {
   shell.exec(`${JSON.stringify(shell.config.execPath)} -e "console.error(1234); console.log(666); process.exit(12);"`, { silent: true });
-  const stdout = mocks.stdout();
-  const stderr = mocks.stderr();
+  const stdout = mocks.stdout.getValue();
+  const stderr = mocks.stderr.getValue();
   t.is(stdout, '');
   t.is(stderr, '');
 });

--- a/test/exit.js
+++ b/test/exit.js
@@ -1,0 +1,57 @@
+import test from 'ava';
+
+import shell from '..';
+
+import mocks from './utils/mocks';
+
+//
+// Valids
+//
+
+function runExitInSubprocess(code) {
+  const script = code !== undefined
+    ? `var shell = require("."); shell.exit(${code});`
+    : 'var shell = require("."); shell.exit();';
+  const result = shell.exec(
+      `${JSON.stringify(shell.config.execPath)} -e ${JSON.stringify(script)}`
+  );
+  const actualReturnCode = result.code;
+  return actualReturnCode;
+}
+
+test('exit with success status code', t => {
+  t.is(runExitInSubprocess(0), 0);
+});
+
+test('exit without explicit code should be success', t => {
+  t.is(runExitInSubprocess(), 0);
+});
+
+test('exit with failure status code', t => {
+  t.is(runExitInSubprocess(5), 5);
+  t.is(runExitInSubprocess(2), 2);
+  t.is(runExitInSubprocess(25), 25);
+});
+
+test('exit correctly sets the shell.errorCode()', t => {
+  try {
+    mocks.exit.init();
+    shell.exit(5); // Safe to call shell.exit() because it's mocked.
+    t.is(shell.errorCode(), 5);
+    t.is(mocks.exit.getValue(), 5);
+    t.truthy(shell.error());
+
+    shell.exit(0); // Safe to call shell.exit() because it's mocked.
+    t.is(shell.errorCode(), 0);
+    t.falsy(mocks.exit.getValue());
+    t.falsy(shell.error());
+
+    // Also try it without an explicit argument.
+    shell.exit(); // Safe to call shell.exit() because it's mocked.
+    t.is(shell.errorCode(), 0);
+    t.falsy(mocks.exit.getValue());
+    t.falsy(shell.error());
+  } finally {
+    mocks.exit.restore();
+  }
+});

--- a/test/popd.js
+++ b/test/popd.js
@@ -120,10 +120,11 @@ test('quiet mode off', t => {
   try {
     shell.pushd('test/resources/pushd');
     shell.config.silent = false;
-    mocks.init();
+    mocks.stdout.init();
+    mocks.stderr.init();
     const trail = shell.popd();
-    const stdout = mocks.stdout();
-    const stderr = mocks.stderr();
+    const stdout = mocks.stdout.getValue();
+    const stderr = mocks.stderr.getValue();
     t.falsy(shell.error());
     t.is(stdout, '');
     t.is(stderr, `${rootDir}\n`);
@@ -131,7 +132,8 @@ test('quiet mode off', t => {
     t.deepEqual(trail, [rootDir]);
   } finally {
     shell.config.silent = true;
-    mocks.restore();
+    mocks.stdout.restore();
+    mocks.stderr.restore();
   }
 });
 
@@ -139,10 +141,11 @@ test('quiet mode on', t => {
   try {
     shell.pushd('test/resources/pushd');
     shell.config.silent = false;
-    mocks.init();
+    mocks.stdout.init();
+    mocks.stderr.init();
     const trail = shell.popd('-q');
-    const stdout = mocks.stdout();
-    const stderr = mocks.stderr();
+    const stdout = mocks.stdout.getValue();
+    const stderr = mocks.stderr.getValue();
     t.falsy(shell.error());
     t.is(stdout, '');
     t.is(stderr, '');
@@ -150,6 +153,7 @@ test('quiet mode on', t => {
     t.deepEqual(trail, [rootDir]);
   } finally {
     shell.config.silent = true;
-    mocks.restore();
+    mocks.stdout.restore();
+    mocks.stderr.restore();
   }
 });

--- a/test/pushd.js
+++ b/test/pushd.js
@@ -333,10 +333,11 @@ test('Push without arguments invalid when stack is empty', t => {
 test('quiet mode off', t => {
   try {
     shell.config.silent = false;
-    mocks.init();
+    mocks.stdout.init();
+    mocks.stderr.init();
     const trail = shell.pushd('test/resources/pushd');
-    const stdout = mocks.stdout();
-    const stderr = mocks.stderr();
+    const stdout = mocks.stdout.getValue();
+    const stderr = mocks.stderr.getValue();
     t.falsy(shell.error());
     t.is(stdout, '');
     t.is(stderr, `${path.resolve(rootDir, 'test/resources/pushd')} ${rootDir}\n`);
@@ -347,17 +348,19 @@ test('quiet mode off', t => {
     ]);
   } finally {
     shell.config.silent = true;
-    mocks.restore();
+    mocks.stdout.restore();
+    mocks.stderr.restore();
   }
 });
 
 test('quiet mode on', t => {
   try {
     shell.config.silent = false;
-    mocks.init();
+    mocks.stdout.init();
+    mocks.stderr.init();
     const trail = shell.pushd('-q', 'test/resources/pushd');
-    const stdout = mocks.stdout();
-    const stderr = mocks.stderr();
+    const stdout = mocks.stdout.getValue();
+    const stderr = mocks.stderr.getValue();
     t.falsy(shell.error());
     t.is(stdout, '');
     t.is(stderr, '');
@@ -368,6 +371,7 @@ test('quiet mode on', t => {
     ]);
   } finally {
     shell.config.silent = true;
-    mocks.restore();
+    mocks.stdout.restore();
+    mocks.stderr.restore();
   }
 });


### PR DESCRIPTION
This adds test coverage for the shell.exit() function. This also refactors how we mock stdout/stderr and adds support for mocking process.exit() (which was needed for this change).

While I was writing these tests, I realized there was an edge case I missed in PR #1122. This change fixes that edge case.

Issue #1013