### PR TITLE
test: make a test more forgiving for systems with non-standard bash and sh paths

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -71,7 +71,6 @@ function execSync(cmd, opts, pipe) {
     fs.writeFileSync(filePath, data, {
       encoding: 'utf8',
       mode: parseInt('600', 8),
-      flag: 'w',
     });
   }
   writeFileLockedDown(stdoutFile, '');

--- a/src/exec.js
+++ b/src/exec.js
@@ -71,6 +71,7 @@ function execSync(cmd, opts, pipe) {
     fs.writeFileSync(filePath, data, {
       encoding: 'utf8',
       mode: parseInt('600', 8),
+      flag: 'w',
     });
   }
   writeFileLockedDown(stdoutFile, '');

--- a/test/exec.js
+++ b/test/exec.js
@@ -178,10 +178,10 @@ test('set shell option (TODO: add tests for Windows)', t => {
     t.is(result.stdout, '/bin/sh\n'); // sh by default
     const bashPath = shell.which('bash').trim();
     if (bashPath) {
-      result = shell.exec('echo $0', { shell: '/bin/bash' });
+      result = shell.exec('echo $0', { shell: bashPath });
       t.falsy(shell.error());
       t.is(result.code, 0);
-      t.is(result.stdout, '/bin/bash\n');
+      t.is(result.stdout, `${bashPath}\n`);
     }
   });
 });


### PR DESCRIPTION
test: make a test more forgiving for systems with non-standard bash and sh paths

*Edit from @nfischer: this was originally to address #1143, however it appears that bug was fixed in Node.js 21.4 instead. Original PR description below:*

---

By adding a [`w` flag to the write call](https://github.com/nodejs/node/issues/50989). Also made a test more forgiving so it passes on systems that have non-standard `bash` and `sh` binary paths.

This fixes #1143 .