### PR TITLE
test: create test files inside temp directory

### DIFF
--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -87,7 +87,7 @@ test('try to make a subdirectory of a file', t => {
 test('Check for invalid permissions', t => {
   utils.skipOnWin(t, () => {
     // This test case only works on unix, but should work on Windows as well
-    const dirName = 'nowritedir';
+    const dirName = `${t.context.tmp}/nowritedir`;
     shell.mkdir(dirName);
     t.falsy(shell.error());
     shell.chmod('-w', dirName);
@@ -95,11 +95,10 @@ test('Check for invalid permissions', t => {
     t.is(result.code, 1);
     t.is(
       result.stderr,
-      'mkdir: cannot create directory nowritedir/foo: Permission denied'
+      `mkdir: cannot create directory ${t.context.tmp}/nowritedir/foo: Permission denied`
     );
     t.truthy(shell.error());
     t.falsy(fs.existsSync(dirName + '/foo'));
-    shell.rm('-rf', dirName); // clean up
   });
 });
 
@@ -142,7 +141,6 @@ test('-p flag', t => {
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.truthy(fs.existsSync(`${t.context.tmp}/a/b/c`));
-  shell.rm('-Rf', `${t.context.tmp}/a`); // revert
 });
 
 test('-p flag: multiple dirs', t => {

--- a/test/touch.js
+++ b/test/touch.js
@@ -186,10 +186,10 @@ test('file array', t => {
 
 test('touching broken link creates a new file', t => {
   utils.skipOnWin(t, () => {
-    const result = shell.touch('test/resources/badlink');
+    shell.ln('-s', 'not_existed_file', `${t.context.tmp}/badlink2`);
+    const result = shell.touch(`${t.context.tmp}/badlink2`);
     t.is(result.code, 0);
     t.falsy(shell.error());
-    t.truthy(fs.existsSync('test/resources/not_existed_file'));
-    shell.rm('test/resources/not_existed_file');
+    t.truthy(fs.existsSync(`${t.context.tmp}/not_existed_file`));
   });
 });


### PR DESCRIPTION
No change to logic. This updates some test cases to create the files
they need inside the temp directory instead of in the repo itself. This
is helpful in case the test case fails early, that way we don't leave
this file behind.

This contributes toward #828, since the change to fast-glob made it
clear that this test was mishandling link files and leaving side effects
in the git repo. However this change is desirably independent of
fast-glob.