### PR TITLE
chore: try codecov token again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,4 +51,5 @@ jobs:
         if: matrix.node-version >= 10
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
I tried this recently in 1a1a820569f0883a317944973c15cf34431dd6c2 and then reverted in b8b1c4224d0ec7d631d26c78922c018dd5b895f5. Unfortunately I'm still seeing spurious failures from codecov, so let's try the token one more time.

This time I double checked the token is provided by https://app.codecov.io/gh/shelljs/shelljs/settings. I regenerated the token for good measure.