### PR TITLE
deprecate config.globOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,7 +854,11 @@ rm -rf foo.txt bar.txt
 exec echo hello
 ```
 
-### config.globOptions
+### config.globOptions (deprecated)
+
+**Deprecated**: we recommend that you do not edit `config.globOptions`.
+Support for this configuration option may be changed or removed in a future
+ShellJS release.
 
 Example:
 
@@ -862,7 +866,11 @@ Example:
 config.globOptions = {nodir: true};
 ```
 
-Use this value for calls to `glob.sync()` instead of the default options.
+`config.globOptions` changes how ShellJS expands glob (wildcard)
+expressions. See
+[node-glob](https://github.com/isaacs/node-glob?tab=readme-ov-file#options)
+for available options. Be aware that modifying `config.globOptions` **may
+break ShellJS functionality.**
 
 ### config.reset()
 

--- a/shell.js
+++ b/shell.js
@@ -136,7 +136,11 @@ exports.config = common.config;
 //@ ```
 
 //@
-//@ ### config.globOptions
+//@ ### config.globOptions (deprecated)
+//@
+//@ **Deprecated**: we recommend that you do not edit `config.globOptions`.
+//@ Support for this configuration option may be changed or removed in a future
+//@ ShellJS release.
 //@
 //@ Example:
 //@
@@ -144,7 +148,11 @@ exports.config = common.config;
 //@ config.globOptions = {nodir: true};
 //@ ```
 //@
-//@ Use this value for calls to `glob.sync()` instead of the default options.
+//@ `config.globOptions` changes how ShellJS expands glob (wildcard)
+//@ expressions. See
+//@ [node-glob](https://github.com/isaacs/node-glob?tab=readme-ov-file#options)
+//@ for available options. Be aware that modifying `config.globOptions` **may
+//@ break ShellJS functionality.**
 
 //@
 //@ ### config.reset()

--- a/src/common.js
+++ b/src/common.js
@@ -247,6 +247,12 @@ function parseOptions(opt, map, errorOptions) {
 }
 exports.parseOptions = parseOptions;
 
+function globOptions() {
+  // TODO(nfischer): if this changes glob implementation in the future, convert
+  // options back to node-glob's option format for backward compatibility.
+  return config.globOptions;
+}
+
 // Expands wildcards with matching (ie. existing) file names.
 // For example:
 //   expand(['file*.js']) = ['file1.js', 'file2.js', ...]
@@ -263,7 +269,7 @@ function expand(list) {
     } else {
       var ret;
       try {
-        ret = glob.sync(listEl, config.globOptions);
+        ret = glob.sync(listEl, globOptions());
         // if nothing matched, interpret the string literally
         ret = ret.length > 0 ? ret : [listEl];
       } catch (e) {


### PR DESCRIPTION
This removes support for configuring `config.globOptions`. Exposing this variable makes it difficult to change (or upgrade) our glob library. It's best to consider our choice of glob library to be an implementation detail.

As far as I know, this is not a commonly used option: https://github.com/shelljs/shelljs/issues?q=globOptions currently shows no GitHub issues of users using this option, and there was never really a motivation for why this needed to be exposed (#400 exposed the option just because we could, not because we should).

This is one step toward supporting Issue #828.