### PR TITLE
refactor: switch to fast-glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ shell.echo('hello world');
 
 All commands run synchronously, unless otherwise stated.
 All commands accept standard bash globbing characters (`*`, `?`, etc.),
-compatible with the [node `glob` module](https://github.com/isaacs/node-glob).
+compatible with [`fast-glob`](https://www.npmjs.com/package/fast-glob).
 
 For less-commonly used commands and features, please check out our [wiki
 page](https://github.com/shelljs/shelljs/wiki).
@@ -860,6 +860,9 @@ exec echo hello
 Support for this configuration option may be changed or removed in a future
 ShellJS release.
 
+**Breaking change**: ShellJS v0.8.x uses `node-glob`. Starting with ShellJS
+v0.9.x, `config.globOptions` is compatible with `fast-glob`.
+
 Example:
 
 ```javascript
@@ -868,7 +871,7 @@ config.globOptions = {nodir: true};
 
 `config.globOptions` changes how ShellJS expands glob (wildcard)
 expressions. See
-[node-glob](https://github.com/isaacs/node-glob?tab=readme-ov-file#options)
+[fast-glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#options-3)
 for available options. Be aware that modifying `config.globOptions` **may
 break ShellJS functionality.**
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "execa": "^1.0.0",
-    "glob": "^7.0.0",
+    "fast-glob": "^3.3.2",
     "interpret": "^1.0.0",
     "rechoir": "^0.6.2"
   },

--- a/shell.js
+++ b/shell.js
@@ -11,7 +11,7 @@ var common = require('./src/common');
 //@
 //@ All commands run synchronously, unless otherwise stated.
 //@ All commands accept standard bash globbing characters (`*`, `?`, etc.),
-//@ compatible with the [node `glob` module](https://github.com/isaacs/node-glob).
+//@ compatible with [`fast-glob`](https://www.npmjs.com/package/fast-glob).
 //@
 //@ For less-commonly used commands and features, please check out our [wiki
 //@ page](https://github.com/shelljs/shelljs/wiki).
@@ -142,6 +142,9 @@ exports.config = common.config;
 //@ Support for this configuration option may be changed or removed in a future
 //@ ShellJS release.
 //@
+//@ **Breaking change**: ShellJS v0.8.x uses `node-glob`. Starting with ShellJS
+//@ v0.9.x, `config.globOptions` is compatible with `fast-glob`.
+//@
 //@ Example:
 //@
 //@ ```javascript
@@ -150,7 +153,7 @@ exports.config = common.config;
 //@
 //@ `config.globOptions` changes how ShellJS expands glob (wildcard)
 //@ expressions. See
-//@ [node-glob](https://github.com/isaacs/node-glob?tab=readme-ov-file#options)
+//@ [fast-glob](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#options-3)
 //@ for available options. Be aware that modifying `config.globOptions` **may
 //@ break ShellJS functionality.**
 

--- a/src/common.js
+++ b/src/common.js
@@ -6,7 +6,7 @@
 
 var os = require('os');
 var fs = require('fs');
-var glob = require('glob');
+var glob = require('fast-glob');
 var shell = require('..');
 
 var shellMethods = Object.create(shell);
@@ -252,9 +252,39 @@ function parseOptions(opt, map, errorOptions) {
 exports.parseOptions = parseOptions;
 
 function globOptions() {
-  // TODO(nfischer): if this changes glob implementation in the future, convert
-  // options back to node-glob's option format for backward compatibility.
-  return config.globOptions;
+  // These options are just to make fast-glob be compatible with POSIX (bash)
+  // wildcard behavior.
+  var defaultGlobOptions = {
+    onlyFiles: false,
+    followSymbolicLinks: false,
+  };
+
+  var newGlobOptions = Object.assign({}, config.globOptions);
+  var optionRenames = {
+    // node-glob's 'nodir' is not quote the same as fast-glob's 'onlyFiles'.
+    // Compatibility for this is implemented at the call site.
+    mark: 'markDirectories',
+    matchBase: 'baseNameMatch',
+  };
+  Object.keys(optionRenames).forEach(function (oldKey) {
+    var newKey = optionRenames[oldKey];
+    if (oldKey in config.globOptions) {
+      newGlobOptions[newKey] = config.globOptions[oldKey];
+    }
+  });
+  var invertedOptionRenames = {
+    nobrace: 'braceExpansion',
+    noglobstar: 'globstar',
+    noext: 'extglob',
+    nocase: 'caseSensitiveMatch',
+  };
+  Object.keys(invertedOptionRenames).forEach(function (oldKey) {
+    var newKey = invertedOptionRenames[oldKey];
+    if (oldKey in config.globOptions) {
+      newGlobOptions[newKey] = !config.globOptions[oldKey];
+    }
+  });
+  return Object.assign({}, defaultGlobOptions, newGlobOptions);
 }
 
 // Expands wildcards with matching (ie. existing) file names.
@@ -272,13 +302,19 @@ function expand(list) {
       expanded.push(listEl);
     } else {
       var ret;
+      var globOpts = globOptions();
       try {
-        ret = glob.sync(listEl, globOptions());
-        // if nothing matched, interpret the string literally
-        ret = ret.length > 0 ? ret : [listEl];
+        ret = glob.sync(listEl, globOpts);
       } catch (e) {
         // if glob fails, interpret the string literally
         ret = [listEl];
+      }
+      // if nothing matched, interpret the string literally
+      ret = ret.length > 0 ? ret.sort() : [listEl];
+      if (globOpts.nodir) {
+        ret = ret.filter(function (file) {
+          return !statNoFollowLinks(file).isDirectory();
+        });
       }
       expanded = expanded.concat(ret);
     }


### PR DESCRIPTION
This removes `node-glob` in favor of `fast-glob`. The main motivation
for this is because `node-glob` has a security warning and I can't
update to `node-glob@9` unless we drop compatibility for node v8.

Switching to `fast-glob` seems to be fairly straightforward, although
some options need to be changed by default for bash compatibility.

Fixes #828
Fixes #1149
Fixes #1148