### PR TITLE
chore: remove unsupported node configs from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,29 @@ jobs:
           - 18
           - 19
           - 20
+          - 21
+          - 22
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        exclude:
+          - node-version: 8
+            os: macos-latest
+          - node-version: 9
+            os: macos-latest
+          - node-version: 10
+            os: macos-latest
+          - node-version: 11
+            os: macos-latest
+          - node-version: 12
+            os: macos-latest
+          - node-version: 13
+            os: macos-latest
+          - node-version: 14
+            os: macos-latest
+          - node-version: 15
+            os: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -9,7 +9,7 @@ var shell = require('..');
 
 // This is the authoritative list of supported node versions.
 var MIN_NODE_VERSION = 8;
-var MAX_NODE_VERSION = 20;
+var MAX_NODE_VERSION = 22;
 
 function checkReadme(minNodeVersion) {
   var start = '<!-- start minVersion -->';


### PR DESCRIPTION
No change to logic. GitHub Actions recently dropped some NodeJS configurations from their service. This excludes those configs from our CI.

This also adds Node versions up through v22.

Test: npm run check-node-support