### PR TITLE
Fix shelljs compatibility with esbuild bundler

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -22,7 +22,7 @@ var common = require('./src/common');
 
 // Load all default commands
 require('./commands').forEach(function (command) {
-  require('./src/' + command);
+  require('./src/' + command + '.js');
 });
 
 //@


### PR DESCRIPTION
## Summary

Fixes https://github.com/shelljs/shelljs/issues/1160
- Add explicit file extension to dynamic command import.
- This call to require() is dynamic and does not add the file extension.
- Esbuild resolves files with their explicit file extension (eg './src/cat.js').
- Esbuild automatically adds .js extension in imports when not present but can't modify dynamic imports. For dynamic imports, file extension needs to be explicitly specified prior to bundling.

## Test

Here is a script to reproduce (to be run in the repository root):
```bash
# Prepare
rm -rf test-esbuild && mkdir test-esbuild && cd test-esbuild
npm init --yes
echo "console.log(require('../shell.js').pwd().stdout && '\n OK');" > index.js
npm i -D esbuild

# Run
npx esbuild --platform=node --bundle index.js --outfile=out.js; node out.js
```

In the current master branch of this repository:
```text
  out.js  230.5kb

⚡ Done in 10ms
/.../shelljs/test-esbuild/out.js:5
  throw new Error("Module not found in bundle: " + path);
  ^

Error: Module not found in bundle: ./src/cat
    at /.../

Node.js v20.3.1
```

In this branch
```text
  out.js  230.5kb

⚡ Done in 9ms

 OK
```

The bundle size doesn't change because all deps are already in the bundle, it's a resolution issue, as discussed in https://github.com/shelljs/shelljs/issues/1160