### PR TITLE
test: add test coverage for some globOptions

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import test from 'ava';
 
 import shell from '..';
@@ -51,25 +53,88 @@ test.cb('config.fatal = true', t => {
 // config.globOptions
 //
 
-test('Expands to directories by default', t => {
+test('config.globOptions expands directories by default', t => {
   const result = common.expand(['test/resources/*a*']);
-  t.is(result.length, 5);
-  t.truthy(result.indexOf('test/resources/a.txt') > -1);
-  t.truthy(result.indexOf('test/resources/badlink') > -1);
-  t.truthy(result.indexOf('test/resources/cat') > -1);
-  t.truthy(result.indexOf('test/resources/head') > -1);
-  t.truthy(result.indexOf('test/resources/external') > -1);
+  const expected = [
+    'test/resources/a.txt',
+    'test/resources/badlink',
+    'test/resources/cat',
+    'test/resources/external',
+    'test/resources/head',
+  ];
+  t.deepEqual(result, expected);
 });
 
-test(
-  'Check to make sure options get passed through (nodir is an example)',
-  t => {
-    shell.config.globOptions = { nodir: true };
-    const result = common.expand(['test/resources/*a*']);
-    t.is(result.length, 2);
-    t.truthy(result.indexOf('test/resources/a.txt') > -1);
-    t.truthy(result.indexOf('test/resources/badlink') > -1);
-    t.truthy(result.indexOf('test/resources/cat') < 0);
-    t.truthy(result.indexOf('test/resources/external') < 0);
+test('config.globOptions respects cwd', t => {
+  // Both node-glob and fast-glob call this option 'cwd'.
+  shell.config.globOptions = { cwd: 'test' };
+  const result = common.expand(['resources/*a*']);
+  const expected = [
+    'resources/a.txt',
+    'resources/badlink',
+    'resources/cat',
+    'resources/external',
+    'resources/head',
+  ];
+  t.deepEqual(result, expected);
+});
+
+test('config.globOptions respects dot', t => {
+  // Both node-glob and fast-glob call this option 'dot'.
+  shell.config.globOptions = { dot: true };
+  const result = common.expand(['test/resources/ls/*']);
+  t.is(result.length, 8);
+  t.truthy(result.indexOf('test/resources/ls/.hidden_dir') > -1);
+  t.truthy(result.indexOf('test/resources/ls/.hidden_file') > -1);
+});
+
+test('config.globOptions respects ignore', t => {
+  // Both node-glob and fast-glob call this option 'ignore'.
+  shell.config.globOptions = { ignore: ['test/resources/external'] };
+  const result = common.expand(['test/resources/*a*']);
+  const expected = [
+    'test/resources/a.txt',
+    'test/resources/badlink',
+    'test/resources/cat',
+    'test/resources/head',
+  ];
+  t.deepEqual(result, expected);
+  // Does not include the result that we chose to ignore
+  t.truthy(result.indexOf('test/resources/external') < 0);
+});
+
+test('config.globOptions respects absolute', t => {
+  // Both node-glob and fast-glob call this option 'absolute'.
+  shell.config.globOptions = { absolute: true };
+  const result = common.expand(['test/resources/*a*']);
+  function abs(file) {
+    // Normalize to posix-style path separators on all platforms.
+    const CWD = process.platform === 'win32' ?
+        process.cwd().replace(/\\/g, '/') :
+        process.cwd();
+    return path.posix.join(CWD, file);
   }
-);
+  const expected = [
+    abs('test/resources/a.txt'),
+    abs('test/resources/badlink'),
+    abs('test/resources/cat'),
+    abs('test/resources/external'),
+    abs('test/resources/head'),
+  ];
+  t.deepEqual(result, expected);
+});
+
+test('config.globOptions respects nodir', t => {
+  shell.config.globOptions = { nodir: true };
+  const result = common.expand(['test/resources/*a*']);
+  // Includes files and symlinks.
+  const expected = [
+    'test/resources/a.txt',
+    'test/resources/badlink',
+  ];
+  t.deepEqual(result, expected);
+  // Does not include the directories.
+  t.truthy(result.indexOf('test/resources/cat') < 0);
+  t.truthy(result.indexOf('test/resources/head') < 0);
+  t.truthy(result.indexOf('test/resources/external') < 0);
+});


### PR DESCRIPTION
No change to logic. This adds test coverage support for all of the globOptions which share the same name between node-glob and fast-glob.

See https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#compatible-with-node-glob

Issue #828