### PR TITLE
Fix Windows test errors in src/ls.js and test/cp.js.

### DIFF
--- a/src/ls.js
+++ b/src/ls.js
@@ -3,7 +3,8 @@ var fs = require('fs');
 var common = require('./common');
 var glob = require('glob');
 
-var globPatternRecursive = path.sep + '**';
+// glob patterns use the UNIX path seperator
+var globPatternRecursive = '/**';
 
 common.register('ls', _ls, {
   cmdOptions: {

--- a/test/cp.js
+++ b/test/cp.js
@@ -873,7 +873,10 @@ test('cp -p should preserve mode, ownership, and timestamp (directory)', t => {
 
   // Both new file and new dir should keep same attributes
   t.is(statOfResultDir.mtime.getTime(), newModifyTimeMs);
-  t.is(statOfResultDir.atime.getTime(), newAccessTimeMs);
+  utils.skipOnWin(t, () => {
+    // The resultDir atime may be updated on Windows as a side-effect, e.g. chmod().
+    t.is(statOfResultDir.atime.getTime(), newAccessTimeMs);
+  });
   t.is(statOfResult.mtime.getTime(), newModifyTimeMs);
   t.is(statOfResult.atime.getTime(), newAccessTimeMs);
   t.is(statOfResult.mode.toString(8), '100' + mode);


### PR DESCRIPTION
Fix Windows test errors in src/ls.js and test/cp.js.  Full `npm run test` now runs clean on Windows 10.
Relates to preparing for fast-glob, https://github.com/shelljs/shelljs/pull/1153 .