### PR TITLE
chore: switch to codecov v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
         if: matrix.os != 'windows-latest'
       - name: Upload coverage reports to Codecov
         if: matrix.node-version >= 10
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
No change to logic. This updates codecov/codecov-action to v4. This
version supposedly has better support for external contributors working
from repository forks.

Tested this out with PR #1168.