### PR TITLE
Do not submit: trying codecov token from a fork

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
         if: matrix.os != 'windows-latest'
       - name: Upload coverage reports to Codecov
         if: matrix.node-version >= 10
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![npm version](https://img.shields.io/npm/v/shelljs.svg?style=flat-square)](https://www.npmjs.com/package/shelljs)
 [![npm downloads](https://img.shields.io/npm/dm/shelljs.svg?style=flat-square)](https://www.npmjs.com/package/shelljs)
 
+Some minor change
+
 ShellJS is a portable **(Windows/Linux/macOS)** implementation of Unix shell
 commands on top of the Node.js API. You can use it to eliminate your shell
 script's dependency on Unix while still keeping its familiar and powerful


### PR DESCRIPTION
No change to logic. I'm trying a minor change in order to test out codecov from within a fork. I want to see if codecov will upload using the CODECOV_TOKEN or not.