### PR TITLE
chore(dependencies): update js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
-    "js-yaml": "^3.14.1",
+    "js-yaml": "^4.1.0",
     "nyc": "^15.1.0",
     "shelljs-changelog": "^0.2.6",
     "shelljs-release": "^0.5.2",

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -66,7 +66,7 @@ try {
 
   var githubActionsFileName = path.join(__dirname, '..', '.github', 'workflows',
       'main.yml');
-  var githubActionsYaml = yaml.safeLoad(shell.cat(githubActionsFileName));
+  var githubActionsYaml = yaml.load(shell.cat(githubActionsFileName));
   checkGithubActions(MIN_NODE_VERSION, MAX_NODE_VERSION, githubActionsYaml);
 
   console.log('All files look good (this project supports v'


### PR DESCRIPTION
This updates js-yaml to 4.1.0 and swaps out `yaml.safeLoad()` for `yaml.load()` because the `safe*` functions are deprecated starting in 4.0.0 (the "regular" functions are considered safe).