### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,24 +54,24 @@
     "shjs": "./bin/shjs"
   },
   "dependencies": {
-    "execa": "^1.0.0",
-    "glob": "^7.0.0",
-    "interpret": "^1.0.0",
-    "rechoir": "^0.6.2"
+    "execa": "^9.3.0",
+    "glob": "^11.0.0",
+    "interpret": "^3.1.1",
+    "rechoir": "^0.8.0"
   },
   "ava": {
     "serial": true,
     "powerAssert": false
   },
   "devDependencies": {
-    "ava": "^1.4.1",
-    "chalk": "^1.1.3",
+    "ava": "^6.1.3",
+    "chalk": "^5.3.0",
     "coffee-script": "^1.12.7",
-    "eslint": "^5.16.0",
-    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint": "^9.9.0",
+    "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.17.3",
     "js-yaml": "^4.1.0",
-    "nyc": "^15.1.0",
+    "nyc": "^17.0.0",
     "shelljs-changelog": "^0.2.6",
     "shelljs-release": "^0.5.2",
     "shx": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ava": "^6.1.3",
     "chalk": "^5.3.0",
     "coffee-script": "^1.12.7",
-    "eslint": "^9.9.0",
+    "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.17.3",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
It looks like shelljs is still getting _lots_ of usage, even though several of the core dependencies are _very_ out of date.
![image](https://github.com/user-attachments/assets/8b74e353-42ec-48b7-bf51-cd03c9d32184)

Output from `npm outdated`:
![image](https://github.com/user-attachments/assets/7714939c-af1a-404a-95e6-c5802e8a0502)

I'm not sure if this initial bump works -- I need to test it -- but I thought I'd get the ball rolling with a PR.