### PR TITLE
chore: switch to testing LTS releases only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,19 +13,12 @@ jobs:
       matrix:
         node-version:
           - 8
-          - 9
           - 10
-          - 11
           - 12
-          - 13
           - 14
-          - 15
           - 16
-          - 17
           - 18
-          - 19
           - 20
-          - 21
           - '22.9.0'
         os:
           - ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ script's dependency on Unix while still keeping its familiar and powerful
 commands. You can also install it globally so you can run it from outside Node
 projects - say goodbye to those gnarly Bash scripts!
 
-ShellJS is proudly tested on every node release since <!-- start minVersion -->`v8`<!-- stop minVersion -->!
+ShellJS is proudly tested on every LTS node release since <!-- start minVersion -->`v8`<!-- stop minVersion -->!
 
 The project is unit-tested and battle-tested in projects like:
 

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -54,7 +54,10 @@ function assertDeepEquals(arr1, arr2, msg) {
 
 function range(start, stop) {
   var ret = [];
-  for (var i = start; i <= stop; i++) {
+  for (var i = start; i <= stop; i += 2) {
+    if (i % 2 !== 0) {
+      console.warn('Warning: testing a non-LTS nodejs release: ' + i);
+    }
     ret.push(i);
   }
   return ret;
@@ -81,7 +84,7 @@ try {
   var githubActionsYaml = yaml.load(shell.cat(githubActionsFileName));
   checkGithubActions(MIN_NODE_VERSION, MAX_NODE_VERSION, githubActionsYaml);
 
-  console.log('All files look good (this project supports v'
+  console.log('All files look good (this project supports LTS releases v'
       + MIN_NODE_VERSION + '-v' + MAX_NODE_VERSION + ')!');
 } catch (e) {
   console.error('Please check the files which declare our Node version');


### PR DESCRIPTION
No change to official support. We will still accept patches for non-LTS versions when it's reasonable to support them, especially for the most recent Node release (whether that is odd-numbered or even-numbered). This just lightens up the workload on CI because most of our users are probably running node LTS.