### PR TITLE
refactor: unescape quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ Examples:
 
 ```javascript
 grep('foo', 'file1.txt', 'file2.txt').sed(/o/g, 'a').to('output.txt');
-echo('files with o\'s in the name:\n' + ls().grep('o'));
+echo("files with o's in the name:\n" + ls().grep('o'));
 cat('test.js').exec('node'); // pipe to exec() call
 ```
 

--- a/shell.js
+++ b/shell.js
@@ -69,7 +69,7 @@ exports.env = process.env;
 //@
 //@ ```javascript
 //@ grep('foo', 'file1.txt', 'file2.txt').sed(/o/g, 'a').to('output.txt');
-//@ echo('files with o\'s in the name:\n' + ls().grep('o'));
+//@ echo("files with o's in the name:\n" + ls().grep('o'));
 //@ cat('test.js').exec('node'); // pipe to exec() call
 //@ ```
 //@

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -32,7 +32,11 @@
     "new-cap": ["error", {
       "capIsNewExceptions": [
         "ShellString"
-      ]}
-    ]
+      ]
+    }],
+    "quotes": ["error", "single", {
+      "avoidEscape": true,
+      "allowTemplateLiterals": true
+    }]
   }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -311,7 +311,7 @@ test('Some basic tests on the ShellString type', t => {
 });
 
 test.cb('Commands that fail will still output error messages to stderr', t => {
-  const script = 'require(\'./global\'); ls(\'noexist\'); cd(\'noexist\');';
+  const script = "require('./global'); ls('noexist'); cd('noexist');";
   utils.runScript(script, (err, stdout, stderr) => {
     t.is(stdout, '');
     t.is(

--- a/test/config.js
+++ b/test/config.js
@@ -34,7 +34,7 @@ test('config.silent can be set to false', t => {
 
 test.cb('config.fatal = false', t => {
   t.falsy(shell.config.fatal);
-  const script = 'require(\'./global.js\'); config.silent=true; config.fatal=false; cp("this_file_doesnt_exist", "."); echo("got here");';
+  const script = `require('./global.js'); config.silent=true; config.fatal=false; cp("this_file_doesnt_exist", "."); echo("got here");`;
   utils.runScript(script, (err, stdout) => {
     t.truthy(stdout.match('got here'));
     t.end();
@@ -42,7 +42,7 @@ test.cb('config.fatal = false', t => {
 });
 
 test.cb('config.fatal = true', t => {
-  const script = 'require(\'./global.js\'); config.silent=true; config.fatal=true; cp("this_file_doesnt_exist", "."); echo("got here");';
+  const script = `require('./global.js'); config.silent=true; config.fatal=true; cp("this_file_doesnt_exist", "."); echo("got here");`;
   utils.runScript(script, (err, stdout) => {
     t.falsy(stdout.match('got here'));
     t.end();

--- a/test/cp.js
+++ b/test/cp.js
@@ -443,7 +443,7 @@ test('-R implies -P', t => {
   });
 });
 
-test('-Ru respects the -u flag recursively (don\'t update newer file)', t => {
+test("-Ru respects the -u flag recursively (don't update newer file)", t => {
   // Setup code
   const dir = `${t.context.tmp}/cp-Ru`;
   const sourceDir = `${dir}/original`;
@@ -521,7 +521,7 @@ test('Recursive, copies entire directory with no symlinks and -L option does not
   });
 });
 
-test('-u flag won\'t overwrite newer files', t => {
+test("-u flag won't overwrite newer files", t => {
   shell.touch(`${t.context.tmp}/file1.js`);
   shell.cp('-u', 'test/resources/file1.js', t.context.tmp);
   t.falsy(shell.error());
@@ -535,7 +535,7 @@ test('-u flag does overwrite older files', t => {
   t.is(shell.cat('test/resources/file1.js').toString(), shell.cat(`${t.context.tmp}/file1.js`).toString());
 });
 
-test('-u flag works even if it\'s not overwriting a file', t => {
+test("-u flag works even if it's not overwriting a file", t => {
   t.falsy(fs.existsSync(`${t.context.tmp}/file1.js`));
   shell.cp('-u', 'test/resources/file1.js', t.context.tmp);
   t.falsy(shell.error());

--- a/test/head.js
+++ b/test/head.js
@@ -100,7 +100,7 @@ test('Globbed file', t => {
     .join('\n') + '\n');
 });
 
-test('With `\'-n\' <num>` option', t => {
+test("With '-n <num>' option", t => {
   const result = shell.head('-n', 4, 'test/resources/head/file2.txt',
     'test/resources/head/file1.txt');
   t.falsy(shell.error());
@@ -111,7 +111,7 @@ test('With `\'-n\' <num>` option', t => {
     .join('\n') + '\n');
 });
 
-test('With `{\'-n\': <num>}` option', t => {
+test("With '{-n: <num>}' option", t => {
   const result = shell.head({ '-n': 4 }, 'test/resources/head/file2.txt',
     'test/resources/head/file1.txt');
   t.falsy(shell.error());

--- a/test/ls.js
+++ b/test/ls.js
@@ -36,7 +36,7 @@ test('no such file or dir', t => {
 // Valids
 //
 
-test('it\'s ok to use no arguments', t => {
+test("it's ok to use no arguments", t => {
   const result = shell.ls();
   t.falsy(shell.error());
   t.is(result.code, 0);
@@ -205,7 +205,7 @@ test('wildcard, mid-file with dot (should escape dot for regex)', t => {
   t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
 });
 
-test('one file that exists, one that doesn\'t', t => {
+test("one file that exists, one that doesn't", t => {
   const result = shell.ls('test/resources/ls/file1.js', 'test/resources/ls/thisdoesntexist');
   t.truthy(shell.error());
   t.is(result.code, 2);
@@ -213,7 +213,7 @@ test('one file that exists, one that doesn\'t', t => {
   t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
 });
 
-test('one file that exists, one that doesn\'t (other order)', t => {
+test("one file that exists, one that doesn't (other order)", t => {
   const result = shell.ls('test/resources/ls/thisdoesntexist', 'test/resources/ls/file1.js');
   t.truthy(shell.error());
   t.is(result.code, 2);
@@ -364,7 +364,7 @@ test('directory option, single arg', t => {
   t.is(result.length, 1);
 });
 
-test('directory option, single arg with trailing \'/\'', t => {
+test("directory option, single arg with trailing '/'", t => {
   const result = shell.ls('-d', 'test/resources/ls/');
   t.falsy(shell.error());
   t.is(result.code, 0);

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -37,7 +37,7 @@ test('dir already exists', t => {
   t.is(common.statFollowLinks(t.context.tmp).mtime.toString(), mtime); // didn't mess with dir
 });
 
-test('Can\'t overwrite a broken link', t => {
+test("Can't overwrite a broken link", t => {
   const mtime = common.statNoFollowLinks('test/resources/badlink').mtime.toString();
   const result = shell.mkdir('test/resources/badlink');
   t.truthy(shell.error());

--- a/test/mv.js
+++ b/test/mv.js
@@ -121,7 +121,7 @@ test('too many sources (exist, but dest is file)', t => {
   t.is(result.stderr, 'mv: dest is not a directory (too many sources)');
 });
 
-test('can\'t use wildcard when dest is file', t => {
+test("can't use wildcard when dest is file", t => {
   const result = shell.mv('file*', 'file1');
   t.truthy(shell.error());
   t.truthy(fs.existsSync('file1'));

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -70,7 +70,7 @@ test('All plugin utils exist', t => {
   t.is(typeof plugin.register, 'function');
 });
 
-test('The plugin does not exist before it\'s registered', t => {
+test("The plugin does not exist before it's registered", t => {
   t.falsy(shell.foo);
 });
 

--- a/test/set.js
+++ b/test/set.js
@@ -28,21 +28,21 @@ test('initial values', t => {
 });
 
 test('default behavior', t => {
-  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'./global\'); ls(\'file_doesnt_exist\'); echo(1234);"');
+  const result = shell.exec(JSON.stringify(shell.config.execPath) + ` -e "require('./global'); ls('file_doesnt_exist'); echo(1234);"`);
   t.is(result.code, 0);
   t.is(result.stdout, '1234\n');
   t.is(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');
 });
 
 test('set -e', t => {
-  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'./global\'); set(\'-e\'); ls(\'file_doesnt_exist\'); echo(1234);"');
+  const result = shell.exec(JSON.stringify(shell.config.execPath) + ` -e "require('./global'); set('-e'); ls('file_doesnt_exist'); echo(1234);"`);
   t.is(result.code, uncaughtErrorExitCode);
   t.is(result.stdout, '');
   t.truthy(result.stderr.indexOf('Error: ls: no such file or directory: file_doesnt_exist') >= 0);
 });
 
 test('set -v', t => {
-  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'./global\'); set(\'-v\'); ls(\'file_doesnt_exist\'); echo(1234);"');
+  const result = shell.exec(JSON.stringify(shell.config.execPath) + ` -e "require('./global'); set('-v'); ls('file_doesnt_exist'); echo(1234);"`);
   t.is(result.code, 0);
   t.is(result.stdout, '1234\n');
   t.is(
@@ -52,7 +52,7 @@ test('set -v', t => {
 });
 
 test('set -ev', t => {
-  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'./global\'); set(\'-ev\'); ls(\'file_doesnt_exist\'); echo(1234);"');
+  const result = shell.exec(JSON.stringify(shell.config.execPath) + ` -e "require('./global'); set('-ev'); ls('file_doesnt_exist'); echo(1234);"`);
   t.is(result.code, uncaughtErrorExitCode);
   t.is(result.stdout, '');
   t.truthy(result.stderr.indexOf('Error: ls: no such file or directory: file_doesnt_exist') >= 0);
@@ -61,7 +61,7 @@ test('set -ev', t => {
 });
 
 test('set -e, set +e', t => {
-  const result = shell.exec(JSON.stringify(shell.config.execPath) + ' -e "require(\'./global\'); set(\'-e\'); set(\'+e\'); ls(\'file_doesnt_exist\'); echo(1234);"');
+  const result = shell.exec(JSON.stringify(shell.config.execPath) + ` -e "require('./global'); set('-e'); set('+e'); ls('file_doesnt_exist'); echo(1234);"`);
   t.is(result.code, 0);
   t.is(result.stdout, '1234\n');
   t.is(result.stderr, 'ls: no such file or directory: file_doesnt_exist\n');

--- a/test/sort.js
+++ b/test/sort.js
@@ -78,14 +78,14 @@ test('Globbed file', t => {
   t.is(result.toString(), doubleSorted);
 });
 
-test('With \'-n\' option', t => {
+test("With '-n' option", t => {
   const result = shell.sort('-n', 'test/resources/sort/file2');
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.toString(), shell.cat('test/resources/sort/sortedDashN').toString());
 });
 
-test('With \'-r\' option', t => {
+test("With '-r' option", t => {
   const result = shell.sort('-r', 'test/resources/sort/file2');
   t.falsy(shell.error());
   t.is(result.code, 0);
@@ -96,7 +96,7 @@ test('With \'-r\' option', t => {
     .join('\n') + '\n');
 });
 
-test('With \'-rn\' option', t => {
+test("With '-rn' option", t => {
   const result = shell.sort('-rn', 'test/resources/sort/file2');
   t.falsy(shell.error());
   t.is(result.code, 0);

--- a/test/tail.js
+++ b/test/tail.js
@@ -102,7 +102,7 @@ test('globbed file', t => {
       .join('\n') + '\n');
 });
 
-test('with `\'-n\' <num>` option', t => {
+test("with '-n <num>' option", t => {
   const result = shell.tail('-n', 4, 'test/resources/head/file2.txt',
     'test/resources/head/file1.txt');
   t.falsy(shell.error());
@@ -115,7 +115,7 @@ test('with `\'-n\' <num>` option', t => {
       .join('\n') + '\n');
 });
 
-test('with `\'-n\' +<num>` option', t => {
+test("with '-n +<num>' option", t => {
   const result = shell.tail('-n', '+48', 'test/resources/head/file2.txt',
     'test/resources/head/file1.txt');
   t.falsy(shell.error());
@@ -128,7 +128,7 @@ test('with `\'-n\' +<num>` option', t => {
       .join('\n') + '\n');
 });
 
-test('with `{\'-n\': <num>}` option', t => {
+test("with '{-n: <num>}' option", t => {
   const result = shell.tail({ '-n': 4 }, 'test/resources/head/file2.txt',
     'test/resources/head/file1.txt');
   t.falsy(shell.error());
@@ -141,7 +141,7 @@ test('with `{\'-n\': <num>}` option', t => {
       .join('\n') + '\n');
 });
 
-test('with `{\'-n\': +<num>}` option', t => {
+test("with '{-n: +<num>}' option", t => {
   const result = shell.tail({ '-n': '+48' }, 'test/resources/head/file2.txt',
     'test/resources/head/file1.txt');
   t.falsy(shell.error());

--- a/test/to.js
+++ b/test/to.js
@@ -20,7 +20,7 @@ test.afterEach.always(t => {
 // Invalids
 //
 
-test('Normal strings don\'t have \'.to()\' anymore', t => {
+test("Normal strings don't have '.to()' anymore", t => {
   const str = 'hello world';
   t.is(str.to, undefined);
 });

--- a/test/toEnd.js
+++ b/test/toEnd.js
@@ -20,7 +20,7 @@ test.afterEach.always(t => {
 // Invalids
 //
 
-test('Normal strings don\'t have \'.toEnd()\' anymore', t => {
+test("Normal strings don't have '.toEnd()' anymore", t => {
   const str = 'hello world';
   t.is(str.toEnd, undefined);
 });


### PR DESCRIPTION
This swaps out quote characters to limit how often we need to escape strings. This is just to improve code readability.

Almost all of the changes could be done without changes to .eslintrc, however this amends the lint rule to also permit backtick strings which can be useful to eliminate a few extra instances of quote escaping.

Fixes issue #788
Test: npm run lint