### PR TITLE
feat: expose new shell.cmd()

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,41 @@ Notable exceptions:
 Returns a [ShellString](#shellstringstr) indicating success or failure.
 
 
+### cmd(arg1[, arg2, ...] [, options])
+
+Available options:
+
++ `cwd: directoryPath`: change the current working directory only for this
+  cmd() invocation.
++ `maxBuffer: num`: Raise or decrease the default buffer size for
+  stdout/stderr.
++ `timeout`: Change the default timeout.
+
+Examples:
+
+```javascript
+var version = cmd('node', '--version').stdout;
+cmd('git', 'commit', '-am', `Add suport for node ${version}`);
+console.log(cmd('echo', '1st arg', '2nd arg', '3rd arg').stdout)
+console.log(cmd('echo', 'this handles ;, |, &, etc. as literal characters').stdout)
+```
+
+Executes the given command synchronously. This is intended as an easier
+alternative for [exec()](#execcommand--options--callback), with better
+security around globbing, comamnd injection, and variable expansion. This is
+guaranteed to only run one external command, and won't give special
+treatment for any shell characters (ex. this treats `|` as a literal
+character, not as a shell pipeline).
+This returns a [ShellString](#shellstringstr).
+
+By default, this performs globbing on all platforms, but you can disable
+this with `set('-f')`.
+
+This **does not** support asynchronous mode. If you need asynchronous
+command execution, check out [execa](https://www.npmjs.com/package/execa) or
+the node builtin `child_process.execFile()` instead.
+
+
 ### cp([options,] source [, source ...], dest)
 ### cp([options,] source_array, dest)
 

--- a/commands.js
+++ b/commands.js
@@ -2,8 +2,7 @@ module.exports = [
   'cat',
   'cd',
   'chmod',
-  // TODO(nfischer): uncomment this when shell.cmd() is finished.
-  // 'cmd',
+  'cmd',
   'cp',
   'dirs',
   'echo',

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -21,6 +21,40 @@ function commandNotFound(execaResult) {
   }
 }
 
+//@
+//@ ### cmd(arg1[, arg2, ...] [, options])
+//@
+//@ Available options:
+//@
+//@ + `cwd: directoryPath`: change the current working directory only for this
+//@   cmd() invocation.
+//@ + `maxBuffer: num`: Raise or decrease the default buffer size for
+//@   stdout/stderr.
+//@ + `timeout`: Change the default timeout.
+//@
+//@ Examples:
+//@
+//@ ```javascript
+//@ var version = cmd('node', '--version').stdout;
+//@ cmd('git', 'commit', '-am', `Add suport for node ${version}`);
+//@ console.log(cmd('echo', '1st arg', '2nd arg', '3rd arg').stdout)
+//@ console.log(cmd('echo', 'this handles ;, |, &, etc. as literal characters').stdout)
+//@ ```
+//@
+//@ Executes the given command synchronously. This is intended as an easier
+//@ alternative for [exec()](#execcommand--options--callback), with better
+//@ security around globbing, comamnd injection, and variable expansion. This is
+//@ guaranteed to only run one external command, and won't give special
+//@ treatment for any shell characters (ex. this treats `|` as a literal
+//@ character, not as a shell pipeline).
+//@ This returns a [ShellString](#shellstringstr).
+//@
+//@ By default, this performs globbing on all platforms, but you can disable
+//@ this with `set('-f')`.
+//@
+//@ This **does not** support asynchronous mode. If you need asynchronous
+//@ command execution, check out [execa](https://www.npmjs.com/package/execa) or
+//@ the node builtin `child_process.execFile()` instead.
 function _cmd(options, command, commandArgs, userOptions) {
   if (!command) {
     common.error('Must specify a non-empty string as a command');

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -4,10 +4,6 @@ import test from 'ava';
 
 import shell from '..';
 
-// TODO(nfischer): remove this when shell.cmd() is finished. For now, load it
-// like any other plugin.
-require('../src/cmd');
-
 const CWD = process.cwd();
 
 test.beforeEach(() => {


### PR DESCRIPTION
shell.cmd() was originally implemented in #866, however was not yet exposed. This command should be ready for people to try out, so this exposes the command by default.

This is still not a full implementation of everything in the https://shelljs.page.link/cmd-design design doc, however this completes the initial phase and is likely good enough to replace most use cases of synchronous shell.exec().

Fixes #495