### PR TITLE
refactor: move exec-child logic into main function

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -8,6 +8,7 @@ module.exports = [
   'dirs',
   'echo',
   'exec',
+  'exec-child',
   'find',
   'grep',
   'head',

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -15,7 +15,11 @@ var docs = grep('^//@', 'shell.js');
 docs = docs.replace(/\/\/@commands\n/g, function () {
   return require('../commands').map(function (commandName) {
     var file = './src/' + commandName + '.js';
-    return grep('^//@', file) + '\n';
+    var commandDoc = grep('^//@', file).toString();
+    if (commandDoc !== '') {
+      commandDoc += '\n';
+    }
+    return commandDoc;
   }).join('');
 });
 

--- a/src/exec-child.js
+++ b/src/exec-child.js
@@ -1,67 +1,71 @@
-if (require.main !== module) {
-  throw new Error('This file should not be required');
-}
-
 var childProcess = require('child_process');
 var fs = require('fs');
 
-var paramFilePath = process.argv[2];
+function main() {
+  var paramFilePath = process.argv[2];
 
-var serializedParams = fs.readFileSync(paramFilePath, 'utf8');
-var params = JSON.parse(serializedParams);
+  var serializedParams = fs.readFileSync(paramFilePath, 'utf8');
+  var params = JSON.parse(serializedParams);
 
-var cmd = params.command;
-var execOptions = params.execOptions;
-var pipe = params.pipe;
-var stdoutFile = params.stdoutFile;
-var stderrFile = params.stderrFile;
+  var cmd = params.command;
+  var execOptions = params.execOptions;
+  var pipe = params.pipe;
+  var stdoutFile = params.stdoutFile;
+  var stderrFile = params.stderrFile;
 
-function isMaxBufferError(err) {
-  var maxBufferErrorPattern = /^.*\bmaxBuffer\b.*exceeded.*$/;
-  if (err instanceof Error && err.message &&
-        err.message.match(maxBufferErrorPattern)) {
-    // < v10
-    // Error: stdout maxBuffer exceeded
-    return true;
-  } else if (err instanceof RangeError && err.message &&
-        err.message.match(maxBufferErrorPattern)) {
-    // >= v10
-    // RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stdout maxBuffer length
-    // exceeded
-    return true;
+  function isMaxBufferError(err) {
+    var maxBufferErrorPattern = /^.*\bmaxBuffer\b.*exceeded.*$/;
+    if (err instanceof Error && err.message &&
+          err.message.match(maxBufferErrorPattern)) {
+      // < v10
+      // Error: stdout maxBuffer exceeded
+      return true;
+    } else if (err instanceof RangeError && err.message &&
+          err.message.match(maxBufferErrorPattern)) {
+      // >= v10
+      // RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stdout maxBuffer length
+      // exceeded
+      return true;
+    }
+    return false;
   }
-  return false;
+
+  var stdoutStream = fs.createWriteStream(stdoutFile);
+  var stderrStream = fs.createWriteStream(stderrFile);
+
+  function appendError(message, code) {
+    stderrStream.write(message);
+    process.exitCode = code;
+  }
+
+  var c = childProcess.exec(cmd, execOptions, function (err) {
+    if (!err) {
+      process.exitCode = 0;
+    } else if (isMaxBufferError(err)) {
+      appendError('maxBuffer exceeded', 1);
+    } else if (err.code === undefined && err.message) {
+      /* istanbul ignore next */
+      appendError(err.message, 1);
+    } else if (err.code === undefined) {
+      /* istanbul ignore next */
+      appendError('Unknown issue', 1);
+    } else {
+      process.exitCode = err.code;
+    }
+  });
+
+  c.stdout.pipe(stdoutStream);
+  c.stderr.pipe(stderrStream);
+  c.stdout.pipe(process.stdout);
+  c.stderr.pipe(process.stderr);
+
+  if (pipe) {
+    c.stdin.end(pipe);
+  }
 }
 
-var stdoutStream = fs.createWriteStream(stdoutFile);
-var stderrStream = fs.createWriteStream(stderrFile);
-
-function appendError(message, code) {
-  stderrStream.write(message);
-  process.exitCode = code;
-}
-
-var c = childProcess.exec(cmd, execOptions, function (err) {
-  if (!err) {
-    process.exitCode = 0;
-  } else if (isMaxBufferError(err)) {
-    appendError('maxBuffer exceeded', 1);
-  } else if (err.code === undefined && err.message) {
-    /* istanbul ignore next */
-    appendError(err.message, 1);
-  } else if (err.code === undefined) {
-    /* istanbul ignore next */
-    appendError('Unknown issue', 1);
-  } else {
-    process.exitCode = err.code;
-  }
-});
-
-c.stdout.pipe(stdoutStream);
-c.stderr.pipe(stderrStream);
-c.stdout.pipe(process.stdout);
-c.stderr.pipe(process.stderr);
-
-if (pipe) {
-  c.stdin.end(pipe);
+// This file should only be executed. This module does not export anything.
+/* istanbul ignore else */
+if (require.main === module) {
+  main();
 }

--- a/test/exec.js
+++ b/test/exec.js
@@ -65,10 +65,9 @@ test('exec exits gracefully if we cannot find the execPath', t => {
   );
 });
 
-test('cannot require exec-child.js', t => {
-  t.throws(() => {
-    require('../src/exec-child');
-  }, /This file should not be required/);
+test('exec-child.js should not be imported', t => {
+  const execChild = require('../src/exec-child');
+  t.deepEqual([], Object.keys(execChild));
 });
 
 //


### PR DESCRIPTION
No change to logic. This refactors the exec-child.js script to move all of its main logic into a main() function. This function is only invoked if the script is executed, not when it is imported.

Importing the script is now a NOOP instead of throwing an exception. It's still not advisable to import the script, however this can be done if absolutely necessary to trick JavaScript bundlers which try to prune non-imported code files.

Partially related to issue #1160 and #1172.