### PR TITLE
refactor: prefer includes() over indexOf()

### DIFF
--- a/src/chmod.js
+++ b/src/chmod.js
@@ -136,16 +136,16 @@ function _chmod(options, mode, filePattern) {
           var operator = matches[2];
           var change = matches[3];
 
-          var changeOwner = applyTo.indexOf('u') !== -1 || applyTo === 'a' || applyTo === '';
-          var changeGroup = applyTo.indexOf('g') !== -1 || applyTo === 'a' || applyTo === '';
-          var changeOther = applyTo.indexOf('o') !== -1 || applyTo === 'a' || applyTo === '';
+          var changeOwner = applyTo.includes('u') || applyTo === 'a' || applyTo === '';
+          var changeGroup = applyTo.includes('g') || applyTo === 'a' || applyTo === '';
+          var changeOther = applyTo.includes('o') || applyTo === 'a' || applyTo === '';
 
-          var changeRead = change.indexOf('r') !== -1;
-          var changeWrite = change.indexOf('w') !== -1;
-          var changeExec = change.indexOf('x') !== -1;
-          var changeExecDir = change.indexOf('X') !== -1;
-          var changeSticky = change.indexOf('t') !== -1;
-          var changeSetuid = change.indexOf('s') !== -1;
+          var changeRead = change.includes('r');
+          var changeWrite = change.includes('w');
+          var changeExec = change.includes('x');
+          var changeExecDir = change.includes('X');
+          var changeSticky = change.includes('t');
+          var changeSetuid = change.includes('s');
 
           if (changeExecDir && isDir) {
             changeExec = true;

--- a/src/which.js
+++ b/src/which.js
@@ -64,7 +64,7 @@ function _which(options, cmd) {
   var queryMatches = [];
 
   // No relative/absolute paths provided?
-  if (cmd.indexOf('/') === -1) {
+  if (!cmd.includes('/')) {
     // Assume that there are no extensions to append to queries (this is the
     // case for unix)
     var pathExtArray = [''];
@@ -87,7 +87,7 @@ function _which(options, cmd) {
       }
 
       var match = attempt.match(/\.[^<>:"/|?*.]+$/);
-      if (match && pathExtArray.indexOf(match[0]) >= 0) { // this is Windows-only
+      if (match && pathExtArray.includes(match[0])) { // this is Windows-only
         // The user typed a query with the file extension, like
         // `which('node.exe')`
         if (checkPath(attempt)) {

--- a/test/config.js
+++ b/test/config.js
@@ -103,8 +103,8 @@ test('config.globOptions respects dot', t => {
   shell.config.globOptions = { dot: true };
   const result = common.expand(['test/resources/ls/*']);
   t.is(result.length, 8);
-  t.truthy(result.indexOf('test/resources/ls/.hidden_dir') > -1);
-  t.truthy(result.indexOf('test/resources/ls/.hidden_file') > -1);
+  t.truthy(result.includes('test/resources/ls/.hidden_dir'));
+  t.truthy(result.includes('test/resources/ls/.hidden_file'));
 });
 
 test('config.globOptions respects ignore', t => {
@@ -119,7 +119,7 @@ test('config.globOptions respects ignore', t => {
   ];
   t.deepEqual(result, expected);
   // Does not include the result that we chose to ignore
-  t.truthy(result.indexOf('test/resources/external') < 0);
+  t.falsy(result.includes('test/resources/external'));
 });
 
 test('config.globOptions respects absolute', t => {
@@ -153,9 +153,9 @@ test('config.globOptions respects nodir', t => {
   ];
   t.deepEqual(result, expected);
   // Does not include the directories.
-  t.truthy(result.indexOf('test/resources/cat') < 0);
-  t.truthy(result.indexOf('test/resources/head') < 0);
-  t.truthy(result.indexOf('test/resources/external') < 0);
+  t.falsy(result.includes('test/resources/cat'));
+  t.falsy(result.includes('test/resources/head'));
+  t.falsy(result.includes('test/resources/external'));
 });
 
 test('config.globOptions respects mark', t => {

--- a/test/find.js
+++ b/test/find.js
@@ -28,8 +28,8 @@ test('current path', t => {
   const result = shell.find('.');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('.hidden') > -1);
-  t.truthy(result.indexOf('dir1/dir11/a_dir11') > -1);
+  t.truthy(result.includes('.hidden'));
+  t.truthy(result.includes('dir1/dir11/a_dir11'));
   t.is(result.length, 12);
   shell.cd('../..');
 });
@@ -38,8 +38,8 @@ test('simple path', t => {
   const result = shell.find('test/resources/find');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/find/.hidden') > -1);
-  t.truthy(result.indexOf('test/resources/find/dir1/dir11/a_dir11') > -1);
+  t.truthy(result.includes('test/resources/find/.hidden'));
+  t.truthy(result.includes('test/resources/find/dir1/dir11/a_dir11'));
   t.is(result.length, 12);
 });
 
@@ -47,8 +47,8 @@ test('multiple paths - comma', t => {
   const result = shell.find('test/resources/find/dir1', 'test/resources/find/dir2');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/find/dir1/dir11/a_dir11') > -1);
-  t.truthy(result.indexOf('test/resources/find/dir2/a_dir1') > -1);
+  t.truthy(result.includes('test/resources/find/dir1/dir11/a_dir11'));
+  t.truthy(result.includes('test/resources/find/dir2/a_dir1'));
   t.is(result.length, 6);
 });
 
@@ -56,8 +56,8 @@ test('multiple paths - array', t => {
   const result = shell.find(['test/resources/find/dir1', 'test/resources/find/dir2']);
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/find/dir1/dir11/a_dir11') > -1);
-  t.truthy(result.indexOf('test/resources/find/dir2/a_dir1') > -1);
+  t.truthy(result.includes('test/resources/find/dir1/dir11/a_dir11'));
+  t.truthy(result.includes('test/resources/find/dir2/a_dir1'));
   t.is(result.length, 6);
 });
 
@@ -71,6 +71,6 @@ test('-L flag, folder is symlinked', t => {
   const result = shell.find('-L', 'test/resources/find');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/find/dir2_link/a_dir1') > -1);
+  t.truthy(result.includes('test/resources/find/dir2_link/a_dir1'));
   t.is(result.length, 13);
 });

--- a/test/ls.js
+++ b/test/ls.js
@@ -54,12 +54,12 @@ test('no args provides the correct result', t => {
   const result = shell.ls();
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('file1') > -1);
-  t.truthy(result.indexOf('file2') > -1);
-  t.truthy(result.indexOf('file1.js') > -1);
-  t.truthy(result.indexOf('file2.js') > -1);
-  t.truthy(result.indexOf('filename(with)[chars$]^that.must+be-escaped') > -1);
-  t.truthy(result.indexOf('a_dir') > -1);
+  t.truthy(result.includes('file1'));
+  t.truthy(result.includes('file2'));
+  t.truthy(result.includes('file1.js'));
+  t.truthy(result.includes('file2.js'));
+  t.truthy(result.includes('filename(with)[chars$]^that.must+be-escaped'));
+  t.truthy(result.includes('a_dir'));
   t.is(result.length, 6);
 });
 
@@ -67,12 +67,12 @@ test('simple arg', t => {
   const result = shell.ls('test/resources/ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('file1') > -1);
-  t.truthy(result.indexOf('file2') > -1);
-  t.truthy(result.indexOf('file1.js') > -1);
-  t.truthy(result.indexOf('file2.js') > -1);
-  t.truthy(result.indexOf('filename(with)[chars$]^that.must+be-escaped') > -1);
-  t.truthy(result.indexOf('a_dir') > -1);
+  t.truthy(result.includes('file1'));
+  t.truthy(result.includes('file2'));
+  t.truthy(result.includes('file1.js'));
+  t.truthy(result.includes('file2.js'));
+  t.truthy(result.includes('filename(with)[chars$]^that.must+be-escaped'));
+  t.truthy(result.includes('a_dir'));
   t.is(result.length, 6);
 });
 
@@ -80,12 +80,12 @@ test('simple arg, with a trailing slash', t => {
   const result = shell.ls('test/resources/ls/');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('file1') > -1);
-  t.truthy(result.indexOf('file2') > -1);
-  t.truthy(result.indexOf('file1.js') > -1);
-  t.truthy(result.indexOf('file2.js') > -1);
-  t.truthy(result.indexOf('filename(with)[chars$]^that.must+be-escaped') > -1);
-  t.truthy(result.indexOf('a_dir') > -1);
+  t.truthy(result.includes('file1'));
+  t.truthy(result.includes('file2'));
+  t.truthy(result.includes('file1.js'));
+  t.truthy(result.includes('file2.js'));
+  t.truthy(result.includes('filename(with)[chars$]^that.must+be-escaped'));
+  t.truthy(result.includes('a_dir'));
   t.is(result.length, 6);
 });
 
@@ -93,7 +93,7 @@ test('simple arg, a file', t => {
   const result = shell.ls('test/resources/ls/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/ls/file1') > -1);
+  t.truthy(result.includes('test/resources/ls/file1'));
   t.is(result.length, 1);
 });
 
@@ -102,14 +102,14 @@ test('no args, -A option', t => {
   const result = shell.ls('-A');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('file1') > -1);
-  t.truthy(result.indexOf('file2') > -1);
-  t.truthy(result.indexOf('file1.js') > -1);
-  t.truthy(result.indexOf('file2.js') > -1);
-  t.truthy(result.indexOf('filename(with)[chars$]^that.must+be-escaped') > -1);
-  t.truthy(result.indexOf('a_dir') > -1);
-  t.truthy(result.indexOf('.hidden_file') > -1);
-  t.truthy(result.indexOf('.hidden_dir') > -1);
+  t.truthy(result.includes('file1'));
+  t.truthy(result.includes('file2'));
+  t.truthy(result.includes('file1.js'));
+  t.truthy(result.includes('file2.js'));
+  t.truthy(result.includes('filename(with)[chars$]^that.must+be-escaped'));
+  t.truthy(result.includes('a_dir'));
+  t.truthy(result.includes('.hidden_file'));
+  t.truthy(result.includes('.hidden_dir'));
   t.is(result.length, 8);
 });
 
@@ -118,14 +118,14 @@ test('no args, deprecated -a option', t => {
   const result = shell.ls('-a'); // (deprecated) backwards compatibility test
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('file1') > -1);
-  t.truthy(result.indexOf('file2') > -1);
-  t.truthy(result.indexOf('file1.js') > -1);
-  t.truthy(result.indexOf('file2.js') > -1);
-  t.truthy(result.indexOf('filename(with)[chars$]^that.must+be-escaped') > -1);
-  t.truthy(result.indexOf('a_dir') > -1);
-  t.truthy(result.indexOf('.hidden_file') > -1);
-  t.truthy(result.indexOf('.hidden_dir') > -1);
+  t.truthy(result.includes('file1'));
+  t.truthy(result.includes('file2'));
+  t.truthy(result.includes('file1.js'));
+  t.truthy(result.includes('file2.js'));
+  t.truthy(result.includes('filename(with)[chars$]^that.must+be-escaped'));
+  t.truthy(result.includes('a_dir'));
+  t.truthy(result.includes('.hidden_file'));
+  t.truthy(result.includes('.hidden_dir'));
   t.is(result.length, 8);
 });
 
@@ -133,11 +133,11 @@ test('wildcard, very simple', t => {
   const result = shell.ls('test/resources/cat/*');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/cat/file1') > -1);
-  t.truthy(result.indexOf('test/resources/cat/file2') > -1);
-  t.truthy(result.indexOf('test/resources/cat/file3') > -1);
-  t.truthy(result.indexOf('test/resources/cat/file4') > -1);
-  t.truthy(result.indexOf('test/resources/cat/file5') > -1);
+  t.truthy(result.includes('test/resources/cat/file1'));
+  t.truthy(result.includes('test/resources/cat/file2'));
+  t.truthy(result.includes('test/resources/cat/file3'));
+  t.truthy(result.includes('test/resources/cat/file4'));
+  t.truthy(result.includes('test/resources/cat/file5'));
   t.is(result.length, 5);
 });
 
@@ -145,16 +145,16 @@ test('wildcard, simple', t => {
   const result = shell.ls('test/resources/ls/*');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/ls/file1') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
+  t.truthy(result.includes('test/resources/ls/file1'));
+  t.truthy(result.includes('test/resources/ls/file2'));
+  t.truthy(result.includes('test/resources/ls/file1.js'));
+  t.truthy(result.includes('test/resources/ls/file2.js'));
   t.truthy(
-    result.indexOf('test/resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
+    result.includes('test/resources/ls/filename(with)[chars$]^that.must+be-escaped')
   );
-  t.is(result.indexOf('test/resources/ls/a_dir'), -1); // this shouldn't be there
-  t.truthy(result.indexOf('nada') > -1);
-  t.truthy(result.indexOf('b_dir') > -1);
+  t.falsy(result.includes('test/resources/ls/a_dir')); // this shouldn't be there
+  t.truthy(result.includes('nada'));
+  t.truthy(result.includes('b_dir'));
   t.is(result.length, 7);
 });
 
@@ -162,14 +162,14 @@ test('wildcard, simple, with -d', t => {
   const result = shell.ls('-d', 'test/resources/ls/*');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/ls/file1') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
+  t.truthy(result.includes('test/resources/ls/file1'));
+  t.truthy(result.includes('test/resources/ls/file2'));
+  t.truthy(result.includes('test/resources/ls/file1.js'));
+  t.truthy(result.includes('test/resources/ls/file2.js'));
   t.truthy(
-    result.indexOf('test/resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
+    result.includes('test/resources/ls/filename(with)[chars$]^that.must+be-escaped')
   );
-  t.truthy(result.indexOf('test/resources/ls/a_dir') > -1);
+  t.truthy(result.includes('test/resources/ls/a_dir'));
   t.is(result.length, 6);
 });
 
@@ -177,8 +177,8 @@ test('wildcard, hidden only', t => {
   const result = shell.ls('-d', 'test/resources/ls/.*');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/ls/.hidden_file') > -1);
-  t.truthy(result.indexOf('test/resources/ls/.hidden_dir') > -1);
+  t.truthy(result.includes('test/resources/ls/.hidden_file'));
+  t.truthy(result.includes('test/resources/ls/.hidden_dir'));
   t.is(result.length, 2);
 });
 
@@ -187,12 +187,12 @@ test('wildcard, mid-file', t => {
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 5);
-  t.truthy(result.indexOf('test/resources/ls/file1') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
+  t.truthy(result.includes('test/resources/ls/file1'));
+  t.truthy(result.includes('test/resources/ls/file2'));
+  t.truthy(result.includes('test/resources/ls/file1.js'));
+  t.truthy(result.includes('test/resources/ls/file2.js'));
   t.truthy(
-    result.indexOf('test/resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
+    result.includes('test/resources/ls/filename(with)[chars$]^that.must+be-escaped')
   );
 });
 
@@ -201,8 +201,8 @@ test('wildcard, mid-file with dot (should escape dot for regex)', t => {
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 2);
-  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
+  t.truthy(result.includes('test/resources/ls/file1.js'));
+  t.truthy(result.includes('test/resources/ls/file2.js'));
 });
 
 test("one file that exists, one that doesn't", t => {
@@ -210,7 +210,7 @@ test("one file that exists, one that doesn't", t => {
   t.truthy(shell.error());
   t.is(result.code, 2);
   t.is(result.length, 1);
-  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
+  t.truthy(result.includes('test/resources/ls/file1.js'));
 });
 
 test("one file that exists, one that doesn't (other order)", t => {
@@ -218,7 +218,7 @@ test("one file that exists, one that doesn't (other order)", t => {
   t.truthy(shell.error());
   t.is(result.code, 2);
   t.is(result.length, 1);
-  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
+  t.truthy(result.includes('test/resources/ls/file1.js'));
 });
 
 test('wildcard, should not do partial matches', t => {
@@ -233,10 +233,10 @@ test('wildcard, all files with extension', t => {
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 3);
-  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
+  t.truthy(result.includes('test/resources/ls/file1.js'));
+  t.truthy(result.includes('test/resources/ls/file2.js'));
   t.truthy(
-    result.indexOf('test/resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
+    result.includes('test/resources/ls/filename(with)[chars$]^that.must+be-escaped')
   );
 });
 
@@ -245,10 +245,10 @@ test('wildcard, with additional path', t => {
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 4);
-  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
-  t.truthy(result.indexOf('b_dir') > -1); // no wildcard == no path prefix
-  t.truthy(result.indexOf('nada') > -1); // no wildcard == no path prefix
+  t.truthy(result.includes('test/resources/ls/file1.js'));
+  t.truthy(result.includes('test/resources/ls/file2.js'));
+  t.truthy(result.includes('b_dir')); // no wildcard == no path prefix
+  t.truthy(result.includes('nada')); // no wildcard == no path prefix
 });
 
 test('wildcard for both paths', t => {
@@ -256,10 +256,10 @@ test('wildcard for both paths', t => {
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 4);
-  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
-  t.truthy(result.indexOf('z') > -1);
-  t.truthy(result.indexOf('test/resources/ls/a_dir/nada') > -1);
+  t.truthy(result.includes('test/resources/ls/file1.js'));
+  t.truthy(result.includes('test/resources/ls/file2.js'));
+  t.truthy(result.includes('z'));
+  t.truthy(result.includes('test/resources/ls/a_dir/nada'));
 });
 
 test('wildcard for both paths, array', t => {
@@ -267,10 +267,10 @@ test('wildcard for both paths, array', t => {
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.length, 4);
-  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
-  t.truthy(result.indexOf('z') > -1);
-  t.truthy(result.indexOf('test/resources/ls/a_dir/nada') > -1);
+  t.truthy(result.includes('test/resources/ls/file1.js'));
+  t.truthy(result.includes('test/resources/ls/file2.js'));
+  t.truthy(result.includes('z'));
+  t.truthy(result.includes('test/resources/ls/a_dir/nada'));
 });
 
 test('recursive, no path', t => {
@@ -278,9 +278,9 @@ test('recursive, no path', t => {
   const result = shell.ls('-R');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('a_dir') > -1);
-  t.truthy(result.indexOf('a_dir/b_dir') > -1);
-  t.truthy(result.indexOf('a_dir/b_dir/z') > -1);
+  t.truthy(result.includes('a_dir'));
+  t.truthy(result.includes('a_dir/b_dir'));
+  t.truthy(result.includes('a_dir/b_dir/z'));
   t.is(result.length, 9);
 });
 
@@ -288,9 +288,9 @@ test('recursive, path given', t => {
   const result = shell.ls('-R', 'test/resources/ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('a_dir') > -1);
-  t.truthy(result.indexOf('a_dir/b_dir') > -1);
-  t.truthy(result.indexOf('a_dir/b_dir/z') > -1);
+  t.truthy(result.includes('a_dir'));
+  t.truthy(result.includes('a_dir/b_dir'));
+  t.truthy(result.includes('a_dir/b_dir/z'));
   t.is(result.length, 9);
 });
 
@@ -298,10 +298,10 @@ test('-RA flag, path given', t => {
   const result = shell.ls('-RA', 'test/resources/ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('a_dir') > -1);
-  t.truthy(result.indexOf('a_dir/b_dir') > -1);
-  t.truthy(result.indexOf('a_dir/b_dir/z') > -1);
-  t.truthy(result.indexOf('a_dir/.hidden_dir/nada') > -1);
+  t.truthy(result.includes('a_dir'));
+  t.truthy(result.includes('a_dir/b_dir'));
+  t.truthy(result.includes('a_dir/b_dir/z'));
+  t.truthy(result.includes('a_dir/.hidden_dir/nada'));
   t.is(result.length, 14);
 });
 
@@ -309,11 +309,11 @@ test('-RA flag, symlinks are not followed', t => {
   const result = shell.ls('-RA', 'test/resources/rm');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('a_dir') > -1);
-  t.truthy(result.indexOf('a_dir/a_file') > -1);
-  t.truthy(result.indexOf('link_to_a_dir') > -1);
-  t.is(result.indexOf('link_to_a_dir/a_file'), -1);
-  t.truthy(result.indexOf('fake.lnk') > -1);
+  t.truthy(result.includes('a_dir'));
+  t.truthy(result.includes('a_dir/a_file'));
+  t.truthy(result.includes('link_to_a_dir'));
+  t.falsy(result.includes('link_to_a_dir/a_file'));
+  t.truthy(result.includes('fake.lnk'));
   t.is(result.length, 4);
 });
 
@@ -322,11 +322,11 @@ test('-RAL flag, follows symlinks', t => {
     const result = shell.ls('-RAL', 'test/resources/rm');
     t.falsy(shell.error());
     t.is(result.code, 0);
-    t.truthy(result.indexOf('a_dir') > -1);
-    t.truthy(result.indexOf('a_dir/a_file') > -1);
-    t.truthy(result.indexOf('link_to_a_dir') > -1);
-    t.truthy(result.indexOf('link_to_a_dir/a_file') > -1);
-    t.truthy(result.indexOf('fake.lnk') > -1);
+    t.truthy(result.includes('a_dir'));
+    t.truthy(result.includes('a_dir/a_file'));
+    t.truthy(result.includes('link_to_a_dir'));
+    t.truthy(result.includes('link_to_a_dir/a_file'));
+    t.truthy(result.includes('fake.lnk'));
     t.is(result.length, 5);
   });
 });
@@ -336,7 +336,7 @@ test('-L flag, path is symlink', t => {
     const result = shell.ls('-L', 'test/resources/rm/link_to_a_dir');
     t.falsy(shell.error());
     t.is(result.code, 0);
-    t.truthy(result.indexOf('a_file') > -1);
+    t.truthy(result.includes('a_file'));
     t.is(result.length, 1);
   });
 });
@@ -346,7 +346,7 @@ test('follow links to directories by default', t => {
     const result = shell.ls('test/resources/rm/link_to_a_dir');
     t.falsy(shell.error());
     t.is(result.code, 0);
-    t.truthy(result.indexOf('a_file') > -1);
+    t.truthy(result.includes('a_file'));
     t.is(result.length, 1);
   });
 });
@@ -375,8 +375,8 @@ test('directory option, multiple args', t => {
   const result = shell.ls('-d', 'test/resources/ls/a_dir', 'test/resources/ls/file1');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/ls/a_dir') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file1') > -1);
+  t.truthy(result.includes('test/resources/ls/a_dir'));
+  t.truthy(result.includes('test/resources/ls/file1'));
   t.is(result.length, 2);
 });
 
@@ -384,14 +384,14 @@ test('directory option, globbed arg', t => {
   const result = shell.ls('-d', 'test/resources/ls/*');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/ls/a_dir') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file1') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file1.js') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2.js') > -1);
-  t.truthy(result.indexOf('test/resources/ls/file2') > -1);
+  t.truthy(result.includes('test/resources/ls/a_dir'));
+  t.truthy(result.includes('test/resources/ls/file1'));
+  t.truthy(result.includes('test/resources/ls/file1.js'));
+  t.truthy(result.includes('test/resources/ls/file2'));
+  t.truthy(result.includes('test/resources/ls/file2.js'));
+  t.truthy(result.includes('test/resources/ls/file2'));
   t.truthy(
-    result.indexOf('test/resources/ls/filename(with)[chars$]^that.must+be-escaped') > -1
+    result.includes('test/resources/ls/filename(with)[chars$]^that.must+be-escaped')
   );
   t.is(result.length, 6);
 });
@@ -483,7 +483,7 @@ test('still lists broken links', t => {
   const result = shell.ls('test/resources/badlink');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('test/resources/badlink') > -1);
+  t.truthy(result.includes('test/resources/badlink'));
   t.is(result.length, 1);
 });
 
@@ -491,14 +491,14 @@ test('Test new ShellString-like attributes', t => {
   const result = shell.ls('test/resources/ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.stdout.indexOf('file1') > -1);
-  t.truthy(result.stdout.indexOf('file2') > -1);
-  t.truthy(result.stdout.indexOf('file1.js') > -1);
-  t.truthy(result.stdout.indexOf('file2.js') > -1);
+  t.truthy(result.stdout.includes('file1'));
+  t.truthy(result.stdout.includes('file2'));
+  t.truthy(result.stdout.includes('file1.js'));
+  t.truthy(result.stdout.includes('file2.js'));
   t.truthy(
-    result.stdout.indexOf('filename(with)[chars$]^that.must+be-escaped') > -1
+    result.stdout.includes('filename(with)[chars$]^that.must+be-escaped')
   );
-  t.truthy(result.stdout.indexOf('a_dir') > -1);
+  t.truthy(result.stdout.includes('a_dir'));
   t.is(typeof result.stdout, 'string');
   t.truthy(result.to);
   t.truthy(result.toEnd);
@@ -528,8 +528,8 @@ test('non-normalized paths are still ok with -R', t => {
   const result = shell.ls('-R', 'test/resources/./ls/../ls');
   t.falsy(shell.error());
   t.is(result.code, 0);
-  t.truthy(result.indexOf('a_dir') > -1);
-  t.truthy(result.indexOf('a_dir/b_dir') > -1);
-  t.truthy(result.indexOf('a_dir/b_dir/z') > -1);
+  t.truthy(result.includes('a_dir'));
+  t.truthy(result.includes('a_dir/b_dir'));
+  t.truthy(result.includes('a_dir/b_dir/z'));
   t.is(result.length, 9);
 });

--- a/test/set.js
+++ b/test/set.js
@@ -38,7 +38,7 @@ test('set -e', t => {
   const result = shell.exec(JSON.stringify(shell.config.execPath) + ` -e "require('./global'); set('-e'); ls('file_doesnt_exist'); echo(1234);"`);
   t.is(result.code, uncaughtErrorExitCode);
   t.is(result.stdout, '');
-  t.truthy(result.stderr.indexOf('Error: ls: no such file or directory: file_doesnt_exist') >= 0);
+  t.truthy(result.stderr.includes('Error: ls: no such file or directory: file_doesnt_exist'));
 });
 
 test('set -v', t => {
@@ -55,9 +55,9 @@ test('set -ev', t => {
   const result = shell.exec(JSON.stringify(shell.config.execPath) + ` -e "require('./global'); set('-ev'); ls('file_doesnt_exist'); echo(1234);"`);
   t.is(result.code, uncaughtErrorExitCode);
   t.is(result.stdout, '');
-  t.truthy(result.stderr.indexOf('Error: ls: no such file or directory: file_doesnt_exist') >= 0);
-  t.truthy(result.stderr.indexOf('ls file_doesnt_exist\n') >= 0);
-  t.is(result.stderr.indexOf('echo 1234\n'), -1);
+  t.truthy(result.stderr.includes('Error: ls: no such file or directory: file_doesnt_exist'));
+  t.truthy(result.stderr.includes('ls file_doesnt_exist\n'));
+  t.falsy(result.stderr.includes('echo 1234\n'));
 });
 
 test('set -e, set +e', t => {

--- a/test/touch.js
+++ b/test/touch.js
@@ -77,8 +77,8 @@ test('handles globs correctly', t => {
   const result = shell.touch(`${t.context.tmp}/file*`);
   t.is(result.code, 0);
   const files = shell.ls(`${t.context.tmp}/file*`);
-  t.truthy(files.indexOf(`${t.context.tmp}/file.txt`) > -1);
-  t.truthy(files.indexOf(`${t.context.tmp}/file.js`) > -1);
+  t.truthy(files.includes(`${t.context.tmp}/file.txt`));
+  t.truthy(files.includes(`${t.context.tmp}/file.js`));
   t.is(files.length, 2);
 });
 

--- a/test/which.js
+++ b/test/which.js
@@ -90,7 +90,7 @@ test('None executable files does not appear in the result list', t => {
   t.truthy(resultForWhichA);
   t.truthy(resultForWhichA.length);
   t.not(resultForWhich.toString(), matchingFile);
-  t.is(resultForWhichA.indexOf(matchingFile), -1);
+  t.falsy(resultForWhichA.includes(matchingFile));
 
   process.env.PATH = pathEnv;
 });


### PR DESCRIPTION
No change to logic. This swaps out Array.prototype.indexOf in favor for Array.prototype.includes() to simplify logic. This does the same for the equivalent String.prototype functions.

Test: npm test