### PR TITLE
fix: add global.js and plugin.js to exports list

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,12 @@
   "main": "./shell.js",
   "exports": {
     ".": "./shell.js",
+    "./global": "./global.js",
+    "./global.js": "./global.js",
     "./make": "./make.js",
-    "./make.js": "./make.js"
+    "./make.js": "./make.js",
+    "./plugin": "./plugin.js",
+    "./plugin.js": "./plugin.js"
   },
   "files": [
     "global.js",


### PR DESCRIPTION
We intend for dependent projects to be able to import these files, so this adds them to the explicit list of supported exports.

Fixes #1195
Test: tested this by running shelljs-plugin-open's test suite.