### PR TITLE
test: add tests for shelljs glob expansion

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -84,6 +84,42 @@ test('config.globOptions expands directories by default', t => {
   t.deepEqual(result, expected);
 });
 
+test('config.globOptions handles non-wildcards by default', t => {
+  const result = common.expand(['test/resources/a.txt']);
+  const expected = [
+    'test/resources/a.txt',
+  ];
+  t.deepEqual(result, expected);
+});
+
+test('config.globOptions expands "?" symbol by default', t => {
+  const result = common.expand(['test/resources/file?.t*']);
+  const expected = [
+    'test/resources/file1.txt',
+    'test/resources/file2.txt',
+  ];
+  t.deepEqual(result, expected);
+});
+
+test('config.globOptions expands "*" in multiple path segments by default', t => {
+  const result = common.expand(['test/r*sources/file?.txt']);
+  const expected = [
+    'test/resources/file1.txt',
+    'test/resources/file2.txt',
+  ];
+  t.deepEqual(result, expected);
+});
+
+// https://github.com/shelljs/shelljs/issues/1197
+test.skip('config.globOptions expands "?" in folder path by default', t => {
+  const result = common.expand(['test/r?sources/file*.txt']);
+  const expected = [
+    'test/resources/file1.txt',
+    'test/resources/file2.txt',
+  ];
+  t.deepEqual(result, expected);
+});
+
 test('config.globOptions respects cwd', t => {
   // Both node-glob and fast-glob call this option 'cwd'.
   shell.config.globOptions = { cwd: 'test' };


### PR DESCRIPTION
No change to logic. This adds unit tests for glob expansion.

This includes one test case for behavior which was broken by v0.9.0 (probably due to the switch to fastglob). This behavior hasn't been fixed yet, so the test is marked as skipped.

Issue #1197