### PR TITLE
chore: remove unused env var

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: CI
 on:
   - push
   - pull_request
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:
   test:
     name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}


### PR DESCRIPTION
No change to logic. This env variable isn't relevant since we dropped support for older node versions.