### PR TITLE
fix: add package.json to exports list

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "./global.js": "./global.js",
     "./make": "./make.js",
     "./make.js": "./make.js",
+    "./package": "./package.json",
+    "./package.json": "./package.json",
     "./plugin": "./plugin.js",
     "./plugin.js": "./plugin.js"
   },


### PR DESCRIPTION
No change to logic. shx has a dependency on shelljs/package.json so that it can read the ShellJS version number. This is useful for shx and probably harmless for other packages (we need to ship the package.json file anyway), so this adds it to the exports list as an optional export.

Fixes #1195
Test: I ran `shx --version` with this copy of shelljs as the dependency