### PR TITLE
chore: update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,9 @@
         "js-yaml": "^4.1.0",
         "nyc": "^17.1.0",
         "shelljs-changelog": "^0.2.6",
-        "shelljs-release": "^0.5.2",
-        "shx": "^0.3.4",
-        "travis-check-changes": "^0.4.0"
+        "shelljs-release": "^0.5.3",
+        "shx": "^0.4.0",
+        "travis-check-changes": "^0.5.1"
       },
       "engines": {
         "node": ">=18"
@@ -6732,9 +6732,10 @@
       }
     },
     "node_modules/shelljs-release": {
-      "version": "0.5.2",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/shelljs-release/-/shelljs-release-0.5.3.tgz",
+      "integrity": "sha512-9L15opORTyWZSn7eIm+rmdo4hwgwf99bXqIAPS572KdX9KjqBcdex7FvOrCI8YxaAxosYfS73rVeJ22SkWIxGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^2.4.1",
         "minimist": "^1.2.0",
@@ -6772,18 +6773,37 @@
       }
     },
     "node_modules/shx": {
-      "version": "0.3.4",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.4.0.tgz",
+      "integrity": "sha512-Z0KixSIlGPpijKgcH6oCMCbltPImvaKy0sGH8AkLRXw1KyzpKtaCTizP2xen+hNDqVF4xxgvA0KXSb9o4Q6hnA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "minimist": "^1.2.3",
-        "shelljs": "^0.8.5"
+        "minimist": "^1.2.8",
+        "shelljs": "^0.9.2"
       },
       "bin": {
         "shx": "lib/cli.js"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=18"
+      }
+    },
+    "node_modules/shx/node_modules/shelljs": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.9.2.tgz",
+      "integrity": "sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^1.0.0",
+        "fast-glob": "^3.3.2",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/side-channel": {
@@ -7435,17 +7455,36 @@
       }
     },
     "node_modules/travis-check-changes": {
-      "version": "0.4.0",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/travis-check-changes/-/travis-check-changes-0.5.1.tgz",
+      "integrity": "sha512-nzhjOUiN8S+5lxzTV/208tQYkSSfB07sWrobSExj+/5hWOGFPxaz5DztZbku98ggsKXFd/wREOKVvWOyLl/JrQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "shelljs": "^0.8.5"
+        "shelljs": "^0.9.2"
       },
       "bin": {
         "travis-check-changes": "travis-check-changes.js"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      }
+    },
+    "node_modules/travis-check-changes/node_modules/shelljs": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.9.2.tgz",
+      "integrity": "sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^1.0.0",
+        "fast-glob": "^3.3.2",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-newlines": {

--- a/package.json
+++ b/package.json
@@ -85,9 +85,9 @@
     "js-yaml": "^4.1.0",
     "nyc": "^17.1.0",
     "shelljs-changelog": "^0.2.6",
-    "shelljs-release": "^0.5.2",
-    "shx": "^0.3.4",
-    "travis-check-changes": "^0.4.0"
+    "shelljs-release": "^0.5.3",
+    "shx": "^0.4.0",
+    "travis-check-changes": "^0.5.1"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
This updates shelljs-release, shx, and travis-check-changes to the latest versions.