### PR TITLE
refactor: avoid dependency cycle

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -7,6 +7,7 @@
 //
 
 var common = require('./src/common');
+module.exports = common.shell;
 
 //@
 //@ All commands run synchronously, unless otherwise stated.
@@ -58,7 +59,7 @@ require('./src/which');
 //@ ### exit(code)
 //@
 //@ Exits the current process with the given exit `code`.
-exports.exit = function exit(code) {
+module.exports.exit = function exit(code) {
   common.state.error = null;
   common.state.errorCode = 0;
   if (code) {
@@ -76,20 +77,20 @@ exports.exit = function exit(code) {
 };
 
 //@include ./src/error.js
-exports.error = require('./src/error');
+module.exports.error = require('./src/error');
 
 //@include ./src/errorCode.js
-exports.errorCode = require('./src/errorCode');
+module.exports.errorCode = require('./src/errorCode');
 
 //@include ./src/common.js
-exports.ShellString = common.ShellString;
+module.exports.ShellString = common.ShellString;
 
 //@
 //@ ### env['VAR_NAME']
 //@
 //@ Object containing environment variables (both getter and setter). Shortcut
 //@ to `process.env`.
-exports.env = process.env;
+module.exports.env = process.env;
 
 //@
 //@ ### Pipes
@@ -110,7 +111,7 @@ exports.env = process.env;
 //@ ## Configuration
 //@
 
-exports.config = common.config;
+module.exports.config = common.config;
 
 //@
 //@ ### config.silent

--- a/src/common.js
+++ b/src/common.js
@@ -7,7 +7,9 @@
 var os = require('os');
 var fs = require('fs');
 var glob = require('fast-glob');
-var shell = require('..');
+
+var shell = {};
+exports.shell = shell;
 
 var shellMethods = Object.create(shell);
 


### PR DESCRIPTION
Prior to this change, there was a dependency cycle between shell.js and common.js. This refactors code to avoid the cycle.

This was previously reported in #1133. Node.js already worked around the issue in v20.6.1, but it's simpler if we can avoid the dependency cycle on our end anyway.

I tested this with `npm test` and also by running my own script which uses a shelljs plugin. This seems to work correctly in both cases.