### PR TITLE
refactor: use promises for utils.runScript

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -310,16 +310,14 @@ test('Some basic tests on the ShellString type', t => {
   t.truthy(result.toEnd);
 });
 
-test.cb('Commands that fail will still output error messages to stderr', t => {
+test('Commands that fail will still output error messages to stderr', async t => {
   const script = "require('./global'); ls('noexist'); cd('noexist');";
-  utils.runScript(script, (err, stdout, stderr) => {
-    t.is(stdout, '');
-    t.is(
-      stderr,
-      'ls: no such file or directory: noexist\ncd: no such file or directory: noexist\n'
-    );
-    t.end();
-  });
+  const result = await utils.runScript(script);
+  t.is(result.stdout, '');
+  t.is(
+    result.stderr,
+    'ls: no such file or directory: noexist\ncd: no such file or directory: noexist\n'
+  );
 });
 
 test('execPath value makes sense', t => {

--- a/test/config.js
+++ b/test/config.js
@@ -32,21 +32,17 @@ test('config.silent can be set to false', t => {
 // config.fatal
 //
 
-test.cb('config.fatal = false', t => {
+test('config.fatal = false', async t => {
   t.falsy(shell.config.fatal);
   const script = `require('./global.js'); config.silent=true; config.fatal=false; cp("this_file_doesnt_exist", "."); echo("got here");`;
-  utils.runScript(script, (err, stdout) => {
-    t.truthy(stdout.match('got here'));
-    t.end();
-  });
+  const result = await utils.runScript(script);
+  t.truthy(result.stdout.match('got here'));
 });
 
-test.cb('config.fatal = true', t => {
+test('config.fatal = true', async t => {
   const script = `require('./global.js'); config.silent=true; config.fatal=true; cp("this_file_doesnt_exist", "."); echo("got here");`;
-  utils.runScript(script, (err, stdout) => {
-    t.falsy(stdout.match('got here'));
-    t.end();
-  });
+  await t.throwsAsync(utils.runScript(script),
+    { message: /this_file_doesnt_exist/ });
 });
 
 test('config.fatal = false with an exec() failure returns, does not throw', t => {

--- a/test/utils/utils.js
+++ b/test/utils/utils.js
@@ -1,5 +1,6 @@
 const child = require('child_process');
 const path = require('path');
+const { promisify } = require('node:util');
 
 const chalk = require('chalk');
 
@@ -33,8 +34,9 @@ function skipOnWinForEPERM(action, testCase) {
 }
 exports.skipOnWinForEPERM = skipOnWinForEPERM;
 
-function runScript(script, cb) {
-  child.execFile(common.config.execPath, ['-e', script], cb);
+function runScript(script) {
+  const promiseExec = promisify(child.execFile);
+  return promiseExec(common.config.execPath, ['-e', script]);
 }
 exports.runScript = runScript;
 


### PR DESCRIPTION
No change to logic. This swaps out utils.runScript() to return a Promise instead of taking a callback. This also moves some of `test.cb()` cases over to async functions instead.