### PR TITLE
refactor: use require instead of import

### DIFF
--- a/test/cat.js
+++ b/test/cat.js
@@ -1,8 +1,8 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
+const shell = require('..');
 
 shell.config.silent = true;
 

--- a/test/cd.js
+++ b/test/cd.js
@@ -1,11 +1,11 @@
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 const cur = shell.pwd().toString();
 

--- a/test/chmod.js
+++ b/test/chmod.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import common from '../src/common';
-import utils from './utils/utils';
+const shell = require('..');
+const common = require('../src/common');
+const utils = require('./utils/utils');
 
 let TMP;
 const BITMASK = parseInt('777', 8);

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,8 +1,8 @@
-import path from 'path';
+const path = require('path');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
+const shell = require('..');
 
 const CWD = process.cwd();
 

--- a/test/common.js
+++ b/test/common.js
@@ -1,8 +1,8 @@
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import common from '../src/common';
-import utils from './utils/utils';
+const shell = require('..');
+const common = require('../src/common');
+const utils = require('./utils/utils');
 
 test.beforeEach(() => {
   shell.config.silent = true;

--- a/test/config.js
+++ b/test/config.js
@@ -1,10 +1,10 @@
-import path from 'path';
+const path = require('path');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import common from '../src/common';
-import utils from './utils/utils';
+const shell = require('..');
+const common = require('../src/common');
+const utils = require('./utils/utils');
 
 //
 // Valids

--- a/test/cp.js
+++ b/test/cp.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import common from '../src/common';
-import utils from './utils/utils';
+const shell = require('..');
+const common = require('../src/common');
+const utils = require('./utils/utils');
 
 const oldMaxDepth = shell.config.maxdepth;
 const CWD = process.cwd();

--- a/test/dirs.js
+++ b/test/dirs.js
@@ -1,8 +1,8 @@
-import path from 'path';
+const path = require('path');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
+const shell = require('..');
 
 test.beforeEach(() => {
   shell.config.resetForTesting();

--- a/test/echo.js
+++ b/test/echo.js
@@ -1,8 +1,8 @@
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
-import mocks from './utils/mocks';
+const shell = require('..');
+const utils = require('./utils/utils');
+const mocks = require('./utils/mocks');
 
 shell.config.silent = true;
 

--- a/test/env.js
+++ b/test/env.js
@@ -1,6 +1,6 @@
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
+const shell = require('..');
 
 shell.config.silent = true;
 

--- a/test/exec.js
+++ b/test/exec.js
@@ -1,12 +1,12 @@
-import os from 'os';
-import path from 'path';
-import util from 'util';
+const os = require('os');
+const path = require('path');
+const util = require('util');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
-import mocks from './utils/mocks';
+const shell = require('..');
+const utils = require('./utils/utils');
+const mocks = require('./utils/mocks');
 
 const CWD = process.cwd();
 const ORIG_EXEC_PATH = shell.config.execPath;

--- a/test/exit.js
+++ b/test/exit.js
@@ -1,8 +1,8 @@
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
+const shell = require('..');
 
-import mocks from './utils/mocks';
+const mocks = require('./utils/mocks');
 
 //
 // Valids

--- a/test/find.js
+++ b/test/find.js
@@ -1,6 +1,6 @@
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
+const shell = require('..');
 
 const CWD = process.cwd();
 

--- a/test/global.js
+++ b/test/global.js
@@ -1,10 +1,10 @@
 /* globals cat, config, cp, env, error, mkdir, rm */
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import '../global';
-import utils from './utils/utils';
+require('../global');
+const utils = require('./utils/utils');
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();

--- a/test/grep.js
+++ b/test/grep.js
@@ -1,9 +1,9 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();

--- a/test/head.js
+++ b/test/head.js
@@ -1,9 +1,9 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import common from '../src/common';
+const shell = require('..');
+const common = require('../src/common');
 
 shell.config.silent = true;
 

--- a/test/ln.js
+++ b/test/ln.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
-import path from 'path';
+const fs = require('fs');
+const path = require('path');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 const CWD = process.cwd();
 

--- a/test/ls.js
+++ b/test/ls.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import common from '../src/common';
-import utils from './utils/utils';
+const shell = require('..');
+const common = require('../src/common');
+const utils = require('./utils/utils');
 
 const CWD = process.cwd();
 

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import common from '../src/common';
-import utils from './utils/utils';
+const shell = require('..');
+const common = require('../src/common');
+const utils = require('./utils/utils');
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();

--- a/test/mv.js
+++ b/test/mv.js
@@ -1,9 +1,9 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 const CWD = process.cwd();
 const numLines = utils.numLines;

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,6 +1,6 @@
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
+const shell = require('..');
 
 shell.config.silent = true;
 

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,8 +1,8 @@
-import test from 'ava';
+const test = require('ava');
 
 // This is the supported order for importing these files
-import plugin from '../plugin';
-import shell from '..';
+const plugin = require('../plugin');
+const shell = require('..');
 
 let data = 0;
 let fname;

--- a/test/popd.js
+++ b/test/popd.js
@@ -1,9 +1,9 @@
-import path from 'path';
+const path = require('path');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import mocks from './utils/mocks';
+const shell = require('..');
+const mocks = require('./utils/mocks');
 
 const rootDir = path.resolve();
 

--- a/test/pushd.js
+++ b/test/pushd.js
@@ -1,9 +1,9 @@
-import path from 'path';
+const path = require('path');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import mocks from './utils/mocks';
+const shell = require('..');
+const mocks = require('./utils/mocks');
 
 const rootDir = path.resolve();
 

--- a/test/pwd.js
+++ b/test/pwd.js
@@ -1,9 +1,9 @@
-import path from 'path';
+const path = require('path');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 const cur = process.cwd();
 

--- a/test/rm.js
+++ b/test/rm.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
-import path from 'path';
+const fs = require('fs');
+const path = require('path');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();

--- a/test/sed.js
+++ b/test/sed.js
@@ -1,9 +1,9 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();

--- a/test/set.js
+++ b/test/set.js
@@ -1,7 +1,7 @@
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 const oldConfigSilent = shell.config.silent;
 const uncaughtErrorExitCode = 1;

--- a/test/shjs.js
+++ b/test/shjs.js
@@ -1,8 +1,8 @@
-import path from 'path';
+const path = require('path');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
+const shell = require('..');
 
 const binPath = path.resolve(__dirname, '../bin/shjs');
 

--- a/test/sort.js
+++ b/test/sort.js
@@ -1,9 +1,9 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import common from '../src/common';
+const shell = require('..');
+const common = require('../src/common');
 
 shell.config.silent = true;
 

--- a/test/tail.js
+++ b/test/tail.js
@@ -1,9 +1,9 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import common from '../src/common';
+const shell = require('..');
+const common = require('../src/common');
 
 shell.config.silent = true;
 

--- a/test/tempdir.js
+++ b/test/tempdir.js
@@ -1,9 +1,9 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import { isCached, clearCache } from '../src/tempdir';
+const shell = require('..');
+const { isCached, clearCache } = require('../src/tempdir');
 
 shell.config.silent = true;
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 shell.config.silent = true;
 

--- a/test/to.js
+++ b/test/to.js
@@ -1,9 +1,9 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();

--- a/test/toEnd.js
+++ b/test/toEnd.js
@@ -1,9 +1,9 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();

--- a/test/touch.js
+++ b/test/touch.js
@@ -1,11 +1,11 @@
-import crypto from 'crypto';
-import fs from 'fs';
+const crypto = require('crypto');
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import common from '../src/common';
-import utils from './utils/utils';
+const shell = require('..');
+const common = require('../src/common');
+const utils = require('./utils/utils');
 
 test.beforeEach(t => {
   t.context.tmp = utils.getTempDir();

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -1,9 +1,9 @@
-import fs from 'fs';
+const fs = require('fs');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import common from '../src/common';
+const shell = require('..');
+const common = require('../src/common');
 
 shell.config.silent = true;
 

--- a/test/which.js
+++ b/test/which.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
-import path from 'path';
+const fs = require('fs');
+const path = require('path');
 
-import test from 'ava';
+const test = require('ava');
 
-import shell from '..';
-import utils from './utils/utils';
+const shell = require('..');
+const utils = require('./utils/utils');
 
 shell.config.silent = true;
 


### PR DESCRIPTION
No change to logic. This swaps over tests to use require() since everything is currently designed for the commonjs module system.