### PR TITLE
refactor: use expectations for t.throws

### DIFF
--- a/test/cmd.js
+++ b/test/cmd.js
@@ -30,7 +30,7 @@ test('config.fatal and unknown command', t => {
   shell.config.fatal = true;
   t.throws(() => {
     shell.cmd('asdfasdf'); // could not find command
-  }, /.*command not found.*/);
+  }, { message: /.*command not found.*/ });
 });
 
 // TODO(nfischer): enable only if we implement realtime output + captured

--- a/test/common.js
+++ b/test/common.js
@@ -21,13 +21,13 @@ test.afterEach(() => {
 test('too few args', t => {
   t.throws(() => {
     common.expand();
-  }, TypeError);
+  }, { instanceOf: TypeError });
 });
 
 test('should be a list', t => {
   t.throws(() => {
     common.expand('test/resources');
-  }, TypeError);
+  }, { instanceOf: TypeError });
 });
 
 test('parseOptions (invalid option in options object)', t => {
@@ -37,7 +37,7 @@ test('parseOptions (invalid option in options object)', t => {
       f: 'force',
       r: 'reverse',
     });
-  }, common.CommandError);
+  }, { instanceOf: common.CommandError });
 });
 
 test('parseOptions (without a hyphen in the string)', t => {
@@ -45,7 +45,7 @@ test('parseOptions (without a hyphen in the string)', t => {
     common.parseOptions('f', {
       f: 'force',
     });
-  }, Error);
+  }, { instanceOf: Error });
 });
 
 test('parseOptions (opt is not a string/object)', t => {
@@ -53,13 +53,13 @@ test('parseOptions (opt is not a string/object)', t => {
     common.parseOptions(1, {
       f: 'force',
     });
-  }, TypeError);
+  }, { instanceOf: TypeError });
 });
 
 test('parseOptions (map is not an object)', t => {
   t.throws(() => {
     common.parseOptions('-f', 27);
-  }, TypeError);
+  }, { instanceOf: TypeError });
 });
 
 test('parseOptions (errorOptions is not an object)', t => {
@@ -67,7 +67,7 @@ test('parseOptions (errorOptions is not an object)', t => {
     common.parseOptions('-f', {
       f: 'force',
     }, 'not a valid errorOptions');
-  }, TypeError);
+  }, { instanceOf: TypeError });
 });
 
 test('parseOptions (unrecognized string option)', t => {
@@ -75,7 +75,7 @@ test('parseOptions (unrecognized string option)', t => {
     common.parseOptions('-z', {
       f: 'force',
     });
-  }, common.CommandError);
+  }, { instanceOf: common.CommandError });
 });
 
 test('parseOptions (unrecognized option in Object)', t => {
@@ -99,17 +99,17 @@ test('parseOptions (invalid type)', t => {
 test('convertErrorOutput: no args', t => {
   t.throws(() => {
     common.convertErrorOutput();
-  }, TypeError);
+  }, { instanceOf: TypeError });
 });
 
 test('convertErrorOutput: input must be a vanilla string', t => {
   t.throws(() => {
     common.convertErrorOutput(3);
-  }, TypeError);
+  }, { instanceOf: TypeError });
 
   t.throws(() => {
     common.convertErrorOutput({});
-  }, TypeError);
+  }, { instanceOf: TypeError });
 });
 
 //
@@ -263,7 +263,7 @@ test('common.parseOptions using an object to hold options', t => {
 test('common.parseOptions throws when passed a string not starting with "-"', t => {
   t.throws(() => {
     common.parseOptions('a', { '-a': 'throws' });
-  }, Error, "Options string must start with a '-'");
+  }, { instanceOf: Error }, "Options string must start with a '-'");
 });
 
 test('common.parseOptions allows long options', t => {
@@ -286,7 +286,7 @@ test('common.parseOptions throws for unknown long option', t => {
     common.parseOptions({ throws: true }, {
       v: 'value',
     });
-  }, common.CommandError);
+  }, { instanceOf: common.CommandError });
 });
 
 test('common.parseOptions with -- argument', t => {

--- a/test/exec.js
+++ b/test/exec.js
@@ -43,7 +43,7 @@ test('config.fatal and unknown command', t => {
   shell.config.fatal = true;
   t.throws(() => {
     shell.exec('asdfasdf'); // could not find command
-  }, /asdfasdf/); // name of command should be in error message
+  }, { message: /asdfasdf/ }); // name of command should be in error message
   shell.config.fatal = oldFatal;
 });
 
@@ -52,7 +52,7 @@ test('options.fatal = true and unknown command', t => {
   shell.config.fatal = false;
   t.throws(() => {
     shell.exec('asdfasdf', { fatal: true }); // could not find command
-  }, /asdfasdf/); // name of command should be in error message
+  }, { message: /asdfasdf/ }); // name of command should be in error message
   shell.config.fatal = oldFatal; // TODO(nfischer): this setting won't get reset if the assertion above fails
 });
 

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -48,7 +48,7 @@ test('Unable to register a plugin with unknown options', t => {
     plugin.register('foo', fooImplementation, {
       foobar: true,
     });
-  }, Error);
+  }, { instanceOf: Error });
 });
 
 test('Unable to register a plugin with wrong option types', t => {
@@ -56,7 +56,7 @@ test('Unable to register a plugin with wrong option types', t => {
     plugin.register('foo', fooImplementation, {
       wrapOutput: 'true', // should be a boolean
     });
-  }, TypeError);
+  }, { instanceOf: TypeError });
 });
 
 //
@@ -162,6 +162,6 @@ test('Cannot overwrite an existing command', t => {
   const oldCat = shell.cat;
   t.throws(() => {
     plugin.register('cat', fooImplementation);
-  }, 'Command `cat` already exists');
+  }, { message: 'Command `cat` already exists' });
   t.is(shell.cat, oldCat);
 });

--- a/test/shjs.js
+++ b/test/shjs.js
@@ -59,5 +59,7 @@ test('Extension detection', t => {
 //
 
 test('disallow require-ing', t => {
-  t.throws(() => require(binPath), 'Executable-only module should not be required');
+  t.throws(() => require(binPath),
+    { instanceOf: Error },
+    'Executable-only module should not be required');
 });


### PR DESCRIPTION
No change to logic. This is a small refactor to use stricter "expectation" arguments for calls to t.throws().