### PR TITLE
refactor: allow es6 language features

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "env": {
     "node": true
   },
-  "extends": "airbnb-base/legacy",
+  "extends": "airbnb-base",
   "rules": {
     "comma-dangle": ["error", "always-multiline"],
     "consistent-return": "off",
@@ -11,6 +11,7 @@
     "function-call-argument-newline": "off",
     "function-paren-newline": "off",
     "global-require": "off",
+    "import/no-unresolved": "off",
     "indent": "off",
     "max-len": "off",
     "newline-per-chained-call": "off",
@@ -28,7 +29,15 @@
     "no-throw-literal": "off",
     "no-underscore-dangle": "off",
     "no-use-before-define": "off",
+    "no-var": "off",
     "operator-linebreak": "off",
+    "prefer-arrow-callback": "off",
+    "prefer-destructuring": "off",
+    "prefer-numeric-literals": "off",
+    "prefer-object-spread": "off",
+    "prefer-rest-params": "off",
+    "prefer-spread": "off",
+    "prefer-template": "off",
     "quote-props": "off",
     "spaced-comment": ["error", "always", { "markers": ["@", "@include"], "exceptions": ["@", "@commands"] }],
     "strict": "off",

--- a/global.js
+++ b/global.js
@@ -1,12 +1,15 @@
 /* eslint no-extend-native: 0 */
-var shell = require('./shell.js');
+var shell = require('./shell');
 var common = require('./src/common');
+
 Object.keys(shell).forEach(function (cmd) {
   global[cmd] = shell[cmd];
 });
 
 var _to = require('./src/to');
+
 String.prototype.to = common.wrap('to', _to);
 
 var _toEnd = require('./src/toEnd');
+
 String.prototype.toEnd = common.wrap('toEnd', _toEnd);

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 var path = require('path');
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 var yaml = require('js-yaml');
 
 var shell = require('..');
@@ -25,7 +26,7 @@ function checkReadme(minNodeVersion) {
   var stop = '<!-- stop minVersion -->';
   var formattedMinVersion = '`v' + minNodeVersion + '`';
   var expectedReadmeRegex = new RegExp(
-      start + '\\s*' + formattedMinVersion + '\\s*' + stop, ''
+      start + '\\s*' + formattedMinVersion + '\\s*' + stop, '',
   );
   var readme = path.join(__dirname, '..', 'README.md');
   var match = shell.grep(expectedReadmeRegex, readme);
@@ -36,9 +37,9 @@ function checkReadme(minNodeVersion) {
   }
 }
 
-function checkEngines(minNodeVersion, package) {
+function checkEngines(minNodeVersion, packageJson) {
   var expectedEnginesNode = '>=' + minNodeVersion;
-  if (package.engines.node !== expectedEnginesNode) {
+  if (packageJson.engines.node !== expectedEnginesNode) {
     var msg = 'Update package.json to fix the "engines" attribute';
     throw new Error(msg);
   }
@@ -76,8 +77,8 @@ function checkGithubActions(minNodeVersion, maxNodeVersion, githubActionsYaml) {
 try {
   checkReadme(MIN_NODE_VERSION);
 
-  var package = require('../package.json');
-  checkEngines(MIN_NODE_VERSION, package);
+  var packageJson = require('../package.json');
+  checkEngines(MIN_NODE_VERSION, packageJson);
 
   var githubActionsFileName = path.join(__dirname, '..', '.github', 'workflows',
       'main.yml');

--- a/shell.js
+++ b/shell.js
@@ -7,6 +7,7 @@
 //
 
 var common = require('./src/common');
+
 module.exports = common.shell;
 
 //@
@@ -65,7 +66,7 @@ module.exports.exit = function exit(code) {
   if (code) {
     common.error('exit', {
       continue: true,
-      code: code,
+      code,
       prefix: '',
       silent: true,
       fatal: false,

--- a/src/cat.js
+++ b/src/cat.js
@@ -1,5 +1,5 @@
-var common = require('./common');
 var fs = require('fs');
+var common = require('./common');
 
 common.register('cat', _cat, {
   canReceivePipe: true,

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -1,6 +1,6 @@
-var common = require('./common');
 var fs = require('fs');
 var path = require('path');
+var common = require('./common');
 
 var PERMS = (function (base) {
   return {

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -1,5 +1,5 @@
-var common = require('./common');
 var execa = require('execa');
+var common = require('./common');
 
 var DEFAULT_MAXBUFFER_SIZE = 20 * 1024 * 1024;
 var COMMAND_NOT_FOUND_ERROR_CODE = 127;

--- a/src/common.js
+++ b/src/common.js
@@ -31,13 +31,13 @@ var DEFAULT_CONFIG = {
 };
 
 var config = {
-  reset: function () {
+  reset() {
     Object.assign(this, DEFAULT_CONFIG);
     if (!isElectron) {
       this.execPath = process.execPath;
     }
   },
-  resetForTesting: function () {
+  resetForTesting() {
     this.reset();
     this.silent = true;
   },
@@ -190,7 +190,7 @@ function parseOptions(opt, map, errorOptions) {
     throw new TypeError('parseOptions() internal error: map must be an object');
   } else if (!isObject(errorOptions)) {
     throw new TypeError(
-        'parseOptions() internal error: errorOptions must be object'
+        'parseOptions() internal error: errorOptions must be object',
     );
   }
 

--- a/src/dirs.js
+++ b/src/dirs.js
@@ -1,6 +1,6 @@
+var path = require('path');
 var common = require('./common');
 var _cd = require('./cd');
-var path = require('path');
 
 common.register('dirs', _dirs, {
   wrapOutput: false,

--- a/src/exec.js
+++ b/src/exec.js
@@ -1,9 +1,9 @@
-var common = require('./common');
-var _tempDir = require('./tempdir').tempDir;
-var _pwd = require('./pwd');
 var path = require('path');
 var fs = require('fs');
 var child = require('child_process');
+var common = require('./common');
+var _tempDir = require('./tempdir').tempDir;
+var _pwd = require('./pwd');
 
 var DEFAULT_MAXBUFFER_SIZE = 20 * 1024 * 1024;
 var DEFAULT_ERROR_CODE = 1;
@@ -53,9 +53,9 @@ function execSync(cmd, opts, pipe) {
   var paramsToSerialize = {
     command: cmd,
     execOptions: opts,
-    pipe: pipe,
-    stdoutFile: stdoutFile,
-    stderrFile: stderrFile,
+    pipe,
+    stdoutFile,
+    stderrFile,
   };
 
   // Create the files and ensure these are locked down (for read and write) to

--- a/src/grep.js
+++ b/src/grep.js
@@ -1,5 +1,5 @@
-var common = require('./common');
 var fs = require('fs');
+var common = require('./common');
 
 common.register('grep', _grep, {
   globStart: 2, // don't glob-expand the regex

--- a/src/head.js
+++ b/src/head.js
@@ -1,5 +1,5 @@
-var common = require('./common');
 var fs = require('fs');
+var common = require('./common');
 
 common.register('head', _head, {
   canReceivePipe: true,

--- a/src/ls.js
+++ b/src/ls.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var fs = require('fs');
-var common = require('./common');
 var glob = require('fast-glob');
+var common = require('./common');
 
 // glob patterns use the UNIX path seperator
 var globPatternRecursive = '/**';

--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -1,6 +1,6 @@
-var common = require('./common');
 var fs = require('fs');
 var path = require('path');
+var common = require('./common');
 
 common.register('mkdir', _mkdir, {
   cmdOptions: {

--- a/src/rm.js
+++ b/src/rm.js
@@ -1,5 +1,5 @@
-var common = require('./common');
 var fs = require('fs');
+var common = require('./common');
 
 common.register('rm', _rm, {
   cmdOptions: {

--- a/src/sed.js
+++ b/src/sed.js
@@ -1,5 +1,5 @@
-var common = require('./common');
 var fs = require('fs');
+var common = require('./common');
 
 common.register('sed', _sed, {
   globStart: 3, // don't glob-expand regexes

--- a/src/sort.js
+++ b/src/sort.js
@@ -1,5 +1,5 @@
-var common = require('./common');
 var fs = require('fs');
+var common = require('./common');
 
 common.register('sort', _sort, {
   canReceivePipe: true,

--- a/src/tail.js
+++ b/src/tail.js
@@ -1,5 +1,5 @@
-var common = require('./common');
 var fs = require('fs');
+var common = require('./common');
 
 common.register('tail', _tail, {
   canReceivePipe: true,

--- a/src/tempdir.js
+++ b/src/tempdir.js
@@ -1,6 +1,6 @@
-var common = require('./common');
 var os = require('os');
 var fs = require('fs');
+var common = require('./common');
 
 common.register('tempdir', _tempDir, {
   allowGlobbing: false,

--- a/src/test.js
+++ b/src/test.js
@@ -1,5 +1,5 @@
-var common = require('./common');
 var fs = require('fs');
+var common = require('./common');
 
 common.register('test', _test, {
   cmdOptions: {

--- a/src/to.js
+++ b/src/to.js
@@ -1,6 +1,6 @@
-var common = require('./common');
 var fs = require('fs');
 var path = require('path');
+var common = require('./common');
 
 common.register('to', _to, {
   pipeOnly: true,

--- a/src/toEnd.js
+++ b/src/toEnd.js
@@ -1,6 +1,6 @@
-var common = require('./common');
 var fs = require('fs');
 var path = require('path');
+var common = require('./common');
 
 common.register('toEnd', _toEnd, {
   pipeOnly: true,

--- a/src/touch.js
+++ b/src/touch.js
@@ -1,5 +1,5 @@
-var common = require('./common');
 var fs = require('fs');
+var common = require('./common');
 
 common.register('touch', _touch, {
   cmdOptions: {

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -1,5 +1,5 @@
-var common = require('./common');
 var fs = require('fs');
+var common = require('./common');
 
 // add c spaces to the left of str
 function lpad(c, str) {

--- a/src/which.js
+++ b/src/which.js
@@ -1,6 +1,6 @@
-var common = require('./common');
 var fs = require('fs');
 var path = require('path');
+var common = require('./common');
 
 common.register('which', _which, {
   allowGlobbing: false,


### PR DESCRIPTION
This configures the eslint config to allow ES6 features. This fixes some lint errors caught in the new config, but this mostly suppresses new warnings.