### PR TITLE
fix: cmd is compatible with node 22.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         node-version:
           - 18
           - 20
-          - '22.9.0'
+          - 22
         os:
           - ubuntu-latest
           - macos-latest

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -18,7 +18,8 @@ var MAX_NODE_VERSION = 22;
 var pinnedNodeVersions = {
   // Format:
   // majorVersionInt: 'full.node.version',
-  22: '22.9.0',
+  // Example:
+  // 22: '22.9.0',
 };
 
 function checkReadme(minNodeVersion) {

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -11,13 +11,20 @@ common.register('cmd', _cmd, {
   wrapOutput: true,
 });
 
+function isNullOrUndefined(val) {
+  return val === null || val === undefined;
+}
+
 function commandNotFound(execaResult) {
   if (process.platform === 'win32') {
     var str = 'is not recognized as an internal or external command';
     return execaResult.code && execaResult.stderr.includes(str);
   } else {
+    // On node <= 22.9.0, stdout/stderr are 'null'.
+    // On node >= 22.10, stdout/stderr are 'undefined'.
     return execaResult.code &&
-      execaResult.stdout === null && execaResult.stderr === null;
+      isNullOrUndefined(execaResult.stdout) &&
+      isNullOrUndefined(execaResult.stderr);
   }
 }
 


### PR DESCRIPTION
Starting in node >= 22.10.0, a commandNotFound error will have `undefined` values for stdout/stderr, whereas in earlier versions these values were `null`.

Fixes #1180