### PR TITLE
refactor: explicit handling for execa errors

### DIFF
--- a/src/cmd.js
+++ b/src/cmd.js
@@ -116,10 +116,20 @@ function _cmd(options, command, commandArgs, userOptions) {
     stdout = '';
     stderr = "'" + command + "': command not found";
     code = COMMAND_NOT_FOUND_ERROR_CODE;
-  } else {
+  } else if (typeof result.stdout === 'string' &&
+             typeof result.stderr === 'string' &&
+             typeof result.code === 'number') {
+    // Normal exit: execa was able to execute `command` and get a return value.
     stdout = result.stdout.toString();
     stderr = result.stderr.toString();
     code = result.code;
+  } else {
+    // Catch-all: execa tried to run `command` but it encountered some error
+    // (ex. maxBuffer, timeout).
+    stdout = result.stdout || '';
+    stderr = result.stderr ||
+             `'${command}' encountered an error during execution`;
+    code = result.code > 0 ? result.code : 1;
   }
 
   // Pass `continue: true` so we can specify a value for stdout.

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -178,20 +178,26 @@ test('set cwd', t => {
 });
 
 test('set maxBuffer (very small)', t => {
-  const result = shell.cmd('shx', 'echo', '1234567890'); // default maxBuffer is ok
+  let result = shell.cmd('shx', 'echo', '1234567890'); // default maxBuffer is ok
   t.falsy(shell.error());
   t.is(result.code, 0);
   t.is(result.stdout, '1234567890\n');
-  shell.cmd('shx', 'echo', '1234567890', { maxBuffer: 6 });
+  result = shell.cmd('shx', 'echo', '1234567890', { maxBuffer: 6 });
   t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stdout, '1234567890\n');
 });
 
 test('set timeout option', t => {
-  const result = shell.cmd(shell.config.execPath, 'test/resources/exec/slow.js', '100'); // default timeout is ok
+  let result = shell.cmd(shell.config.execPath, 'test/resources/exec/slow.js', '100'); // default timeout is ok
   t.falsy(shell.error());
+  t.is(result.stdout, 'fast\nslow\n');
   t.is(result.code, 0);
-  shell.cmd(shell.config.execPath, 'test/resources/exec/slow.js', '2000', { timeout: 1000 }); // times out
+  result = shell.cmd(shell.config.execPath, 'test/resources/exec/slow.js', '2000', { timeout: 1000 }); // times out
   t.truthy(shell.error());
+  t.is(result.stdout, 'fast\n');
+  t.truthy(result.stderr);
+  t.is(result.code, 1);
 });
 
 test('check process.env works', t => {

--- a/test/exec.js
+++ b/test/exec.js
@@ -152,11 +152,14 @@ test('set maxBuffer (very small)', t => {
 });
 
 test('set timeout option', t => {
-  const result = shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`); // default timeout is ok
+  let result = shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 100`); // default timeout is ok
   t.falsy(shell.error());
   t.is(result.code, 0);
-  shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 2000`, { timeout: 1000 }); // times out
+  t.is(result.stdout, 'fast\nslow\n');
+  result = shell.exec(`${JSON.stringify(shell.config.execPath)} test/resources/exec/slow.js 2000`, { timeout: 1000 }); // times out
   t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stdout, 'fast\n');
 });
 
 test('check process.env works', t => {

--- a/test/resources/exec/slow.js
+++ b/test/resources/exec/slow.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+console.log('fast');
 setTimeout(function() {
     console.log('slow');
 }, parseInt(process.argv[2], 10));


### PR DESCRIPTION
This adds a dedicated if-condition to handle internal errors from execa (timeout, maxBuffer, etc.) and to distinguish these from "regular" errors (the command executed, but it failed with non-zero status).