### PR TITLE
refactor: change how internal errors are handled

### DIFF
--- a/test/cmd.js
+++ b/test/cmd.js
@@ -177,6 +177,14 @@ test('set cwd', t => {
   t.is(result.stdout, path.resolve('..') + '\n');
 });
 
+test('command fails silently with non-zero status', t => {
+  const result = shell.cmd('shx', 'false');
+  t.truthy(shell.error());
+  t.is(result.code, 1);
+  t.is(result.stdout, '');
+  t.is(result.stderr, '');
+});
+
 test('set maxBuffer (very small)', t => {
   let result = shell.cmd('shx', 'echo', '1234567890'); // default maxBuffer is ok
   t.falsy(shell.error());


### PR DESCRIPTION
This is an internal refactor to change how we handle execa errors inside of shell.cmd().

This also adds a test case for a command which fails silently to make sure that we handle this case correctly.