### PR TITLE
test(find): add test case for absolute path read

### DIFF
--- a/test/find.js
+++ b/test/find.js
@@ -43,7 +43,7 @@ test('simple path', t => {
   t.is(result.length, 12);
 });
 
-test('absolute path', t => {
+test('absolute path (directory)', t => {
   const result = shell.find(`${process.cwd()}/test/resources/find`);
   t.falsy(shell.error());
   t.is(result.code, 0);


### PR DESCRIPTION
Add test case for `shelljs.find` taking an absolute path.

The current tests are passing on windows but only cover relative cases, I suspect the bug on windows may be with the drive -letter at the start of an absolute path.

https://github.com/shelljs/shelljs/issues/1227