### PR TITLE
Add string comparison support to test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,11 +683,20 @@ Available expression primaries:
 + `'-p', 'path'`: true if path is a pipe (FIFO)
 + `'-S', 'path'`: true if path is a socket
 
+String expression primaries:
+
++ `'-n', 'string'`: true if string length is non-zero
++ `'-z', 'string'`: true if string length is zero
++ `'string1', '=', 'string2'`: true if the strings are equal
++ `'string1', '!=', 'string2'`: true if the strings are not equal
+
 Examples:
 
 ```javascript
 if (test('-d', path)) { /* do something with dir */ };
 if (!test('-f', path)) continue; // skip if it's not a regular file
+if (test(process.env.NODE_ENV, '=', 'production')) { /* production mode */ };
+if (test('-n', process.env.API_KEY)) { /* API key is set */ };
 ```
 
 Evaluates `expression` using the available primaries and returns

--- a/src/test.js
+++ b/src/test.js
@@ -1,19 +1,24 @@
 var fs = require('fs');
 var common = require('./common');
 
+var cmdOptions = {
+  'b': 'block',
+  'c': 'character',
+  'd': 'directory',
+  'e': 'exists',
+  'f': 'file',
+  'L': 'link',
+  'p': 'pipe',
+  'S': 'socket',
+  'n': 'nonzero',
+  'z': 'zero',
+};
+
 common.register('test', _test, {
-  cmdOptions: {
-    'b': 'block',
-    'c': 'character',
-    'd': 'directory',
-    'e': 'exists',
-    'f': 'file',
-    'L': 'link',
-    'p': 'pipe',
-    'S': 'socket',
-  },
+  cmdOptions: null, // We'll handle parsing manually
   wrapOutput: false,
   allowGlobbing: false,
+  unix: false, // Bypass the unix-style argument processing
 });
 
 
@@ -31,56 +36,104 @@ common.register('test', _test, {
 //@ + `'-p', 'path'`: true if path is a pipe (FIFO)
 //@ + `'-S', 'path'`: true if path is a socket
 //@
+//@ String expression primaries:
+//@
+//@ + `'-n', 'string'`: true if string length is non-zero
+//@ + `'-z', 'string'`: true if string length is zero
+//@ + `'string1', '=', 'string2'`: true if the strings are equal
+//@ + `'string1', '!=', 'string2'`: true if the strings are not equal
+//@
 //@ Examples:
 //@
 //@ ```javascript
 //@ if (test('-d', path)) { /* do something with dir */ };
 //@ if (!test('-f', path)) continue; // skip if it's not a regular file
+//@ if (test(process.env.NODE_ENV, '=', 'production')) { /* production mode */ };
+//@ if (test('-n', process.env.API_KEY)) { /* API key is set */ };
 //@ ```
 //@
 //@ Evaluates `expression` using the available primaries and returns
 //@ corresponding boolean value.
-function _test(options, path) {
-  if (!path) common.error('no path given');
-
-  var canInterpret = false;
-  Object.keys(options).forEach(function (key) {
-    if (options[key] === true) {
-      canInterpret = true;
+function _test(arg1, arg2, arg3) {
+  // Detect string comparison: test(str1, '=', str2) or test(str1, '!=', str2)
+  if (arguments.length === 3 && typeof arg1 === 'string' && typeof arg2 === 'string' && typeof arg3 === 'string') {
+    if (arg2 === '=') {
+      return arg1 === arg3;
+    } else if (arg2 === '!=') {
+      return arg1 !== arg3;
     }
-  });
-
-  if (!canInterpret) common.error('could not interpret expression');
-
-  if (options.link) {
-    try {
-      return common.statNoFollowLinks(path).isSymbolicLink();
-    } catch (e) {
-      return false;
-    }
+    common.error('could not interpret expression');
+    return false;
   }
 
-  if (!fs.existsSync(path)) return false;
+  // Detect option-based tests (file tests or string length tests)
+  if (arguments.length >= 2 && typeof arg1 === 'string' && arg1[0] === '-') {
+    var options;
+    try {
+      options = common.parseOptions(arg1, cmdOptions);
+    } catch (e) {
+      common.error('could not interpret expression');
+      return false;
+    }
 
-  if (options.exists) return true;
+    // Handle unary string tests: test('-n', str) or test('-z', str)
+    if (options.nonzero) {
+      if (typeof arg2 !== 'string') {
+        common.error('invalid argument for -n');
+        return false;
+      }
+      return arg2.length > 0;
+    }
 
-  var stats = common.statFollowLinks(path);
+    if (options.zero) {
+      if (typeof arg2 !== 'string') {
+        common.error('invalid argument for -z');
+        return false;
+      }
+      return arg2.length === 0;
+    }
 
-  if (options.block) return stats.isBlockDevice();
+    // Handle file system tests (existing behavior)
+    var path = arg2;
+    if (!path) {
+      common.error('no path given');
+      return false;
+    }
 
-  if (options.character) return stats.isCharacterDevice();
+    if (options.link) {
+      try {
+        return common.statNoFollowLinks(path).isSymbolicLink();
+      } catch (e) {
+        return false;
+      }
+    }
 
-  if (options.directory) return stats.isDirectory();
+    if (!fs.existsSync(path)) return false;
 
-  if (options.file) return stats.isFile();
+    if (options.exists) return true;
 
-  /* istanbul ignore next */
-  if (options.pipe) return stats.isFIFO();
+    var stats = common.statFollowLinks(path);
 
-  /* istanbul ignore next */
-  if (options.socket) return stats.isSocket();
+    if (options.block) return stats.isBlockDevice();
 
-  /* istanbul ignore next */
-  return false; // fallback
+    if (options.character) return stats.isCharacterDevice();
+
+    if (options.directory) return stats.isDirectory();
+
+    if (options.file) return stats.isFile();
+
+    /* istanbul ignore next */
+    if (options.pipe) return stats.isFIFO();
+
+    /* istanbul ignore next */
+    if (options.socket) return stats.isSocket();
+
+    /* istanbul ignore next */
+    return false; // fallback
+  }
+
+  // No valid expression found
+  common.error('could not interpret expression');
+  return false;
 } // test
 module.exports = _test;

--- a/test/test.js
+++ b/test/test.js
@@ -129,3 +129,101 @@ test('-L option fails for missing files', t => {
     t.falsy(result);
   });
 });
+
+//
+// String comparison tests
+//
+
+test('string equality with = operator', t => {
+  const result = shell.test('hello', '=', 'hello');
+  t.falsy(shell.error());
+  t.truthy(result);
+});
+
+test('string equality fails when strings differ', t => {
+  const result = shell.test('hello', '=', 'world');
+  t.falsy(shell.error());
+  t.falsy(result);
+});
+
+test('string inequality with != operator', t => {
+  const result = shell.test('hello', '!=', 'world');
+  t.falsy(shell.error());
+  t.truthy(result);
+});
+
+test('string inequality fails when strings are equal', t => {
+  const result = shell.test('hello', '!=', 'hello');
+  t.falsy(shell.error());
+  t.falsy(result);
+});
+
+test('-n option succeeds for non-empty string', t => {
+  const result = shell.test('-n', 'hello');
+  t.falsy(shell.error());
+  t.truthy(result);
+});
+
+test('-n option fails for empty string', t => {
+  const result = shell.test('-n', '');
+  t.falsy(shell.error());
+  t.falsy(result);
+});
+
+test('-z option succeeds for empty string', t => {
+  const result = shell.test('-z', '');
+  t.falsy(shell.error());
+  t.truthy(result);
+});
+
+test('-z option fails for non-empty string', t => {
+  const result = shell.test('-z', 'hello');
+  t.falsy(shell.error());
+  t.falsy(result);
+});
+
+test('environment variable equality check', t => {
+  process.env.TEST_VAR = 'production';
+  const result = shell.test(process.env.TEST_VAR, '=', 'production');
+  t.falsy(shell.error());
+  t.truthy(result);
+  delete process.env.TEST_VAR;
+});
+
+test('environment variable inequality check', t => {
+  process.env.TEST_VAR = 'development';
+  const result = shell.test(process.env.TEST_VAR, '!=', 'production');
+  t.falsy(shell.error());
+  t.truthy(result);
+  delete process.env.TEST_VAR;
+});
+
+test('environment variable non-zero length check', t => {
+  process.env.TEST_VAR = 'some_value';
+  const result = shell.test('-n', process.env.TEST_VAR);
+  t.falsy(shell.error());
+  t.truthy(result);
+  delete process.env.TEST_VAR;
+});
+
+test('empty strings are equal', t => {
+  const result = shell.test('', '=', '');
+  t.falsy(shell.error());
+  t.truthy(result);
+});
+
+test('string with spaces equality', t => {
+  const result = shell.test('hello world', '=', 'hello world');
+  t.falsy(shell.error());
+  t.truthy(result);
+});
+
+test('error when operator is at beginning', t => {
+  shell.test('=', 'hello', 'world');
+  t.truthy(shell.error());
+});
+
+test('error for invalid expression with three strings', t => {
+  shell.test('hello', 'world', 'test');
+  t.truthy(shell.error());
+});


### PR DESCRIPTION
## Summary

This PR adds support for testing environment variable values and string comparisons to the `test` command, as requested in issue #1230.

## Changes

Adds four new string comparison operators to the `test` command:

- `test(string1, '=', string2)` - String equality check
- `test(string1, '!=', string2)` - String inequality check  
- `test('-n', string)` - True if string length is non-zero
- `test('-z', string)` - True if string length is zero

All existing file system tests continue to work exactly as before, maintaining full backward compatibility.

## Implementation Details

- Modified `src/test.js` to handle both string comparisons and existing file system tests
- Disabled automatic option parsing to allow plain strings as first argument
- Added comprehensive test coverage for all new operators
- Updated README.md with documentation and examples

Fixes #1230