### PR TITLE
chore: update node on GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
           - 18
           - 20
           - 22
+          - 24
         os:
           - ubuntu-latest
           - macos-latest

--- a/scripts/check-node-support.js
+++ b/scripts/check-node-support.js
@@ -10,7 +10,7 @@ var shell = require('..');
 
 // This is the authoritative list of supported node versions.
 var MIN_NODE_VERSION = 18;
-var MAX_NODE_VERSION = 22;
+var MAX_NODE_VERSION = 24;
 
 // Ideally this map should be empty, however we can pin node releases to
 // specific versions if necessary to workaround bugs. See


### PR DESCRIPTION
No change to logic. This adds Node v24 to GitHub Actions CI. This drops official support for Node v18 because it was marked end-of-life in March 2025.