### PR TITLE
Fix handling of glob expansions for paths with a backslash

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -344,7 +344,7 @@ function expand(list) {
       var globOpts = globOptions();
       try {
         // Call convertPathToPattern to handle paths with backslashes
-        // See https://github.com/mrmlnc/fast-glob/blob/096a5b620f4224eb692bd8ff2c8de0e634e50d8e/README.md?plain=1#L658-L682
+        // See https://github.com/mrmlnc/fast-glob#convertpathtopatternpath
         ret = glob.sync(glob.convertPathToPattern(convertQuestionMarkForGlob(listEl)), globOpts);
       } catch (e) {
         // if glob fails, interpret the string literally

--- a/src/common.js
+++ b/src/common.js
@@ -343,7 +343,9 @@ function expand(list) {
       var ret;
       var globOpts = globOptions();
       try {
-        ret = glob.sync(convertQuestionMarkForGlob(listEl), globOpts);
+        // Call convertPathToPattern to handle paths with backslashes
+        // See https://github.com/mrmlnc/fast-glob/blob/096a5b620f4224eb692bd8ff2c8de0e634e50d8e/README.md?plain=1#L658-L682
+        ret = glob.sync(glob.convertPathToPattern(convertQuestionMarkForGlob(listEl)), globOpts);
       } catch (e) {
         // if glob fails, interpret the string literally
         ret = [listEl];

--- a/test/common.js
+++ b/test/common.js
@@ -204,8 +204,10 @@ test('non-string', t => {
 });
 
 test('glob with Windows-style backslash', (t) => {
-  const result = common.expand(['test\\resources\\file1.*']);
-  t.deepEqual(result, ['test/resources/file1.js', 'test/resources/file1.txt']);
+  utils.skipOnUnix(t, () => {
+    const result = common.expand(['test\\resources\\file1.*']);
+    t.deepEqual(result, ['test/resources/file1.js', 'test/resources/file1.txt']);
+  });
 });
 
 //

--- a/test/common.js
+++ b/test/common.js
@@ -203,6 +203,11 @@ test('non-string', t => {
   t.deepEqual(result, [5]);
 });
 
+test('glob with Windows-style backslash', (t) => {
+  const result = common.expand(['test\\resources\\file1.*']);
+  t.deepEqual(result, ['test/resources/file1.js', 'test/resources/file1.txt']);
+});
+
 //
 // common.buffer()
 //

--- a/test/cp.js
+++ b/test/cp.js
@@ -995,10 +995,12 @@ test('copy single file to itself should not erase content', t => {
 });
 
 test('cp with Windows-style backslash and glob pattern', (t) => {
+  utils.skipOnUnix(t, () => {
   const result = shell.cp('test\\resources\\file*.txt', t.context.tmp);
-  t.falsy(shell.error());
-  t.falsy(result.stderr);
-  t.is(result.code, 0);
-  t.truthy(fs.existsSync(`${t.context.tmp}/file1.txt`));
-  t.truthy(fs.existsSync(`${t.context.tmp}/file2.txt`));
+    t.falsy(shell.error());
+    t.falsy(result.stderr);
+    t.is(result.code, 0);
+    t.truthy(fs.existsSync(`${t.context.tmp}/file1.txt`));
+    t.truthy(fs.existsSync(`${t.context.tmp}/file2.txt`));
+  });
 });

--- a/test/cp.js
+++ b/test/cp.js
@@ -993,3 +993,12 @@ test('copy single file to itself should not erase content', t => {
   // File content must be preserved (no data loss)
   t.is(shell.cat(`${t.context.tmp}/myfile.txt`).toString(), 'important data');
 });
+
+test('cp with Windows-style backslash and glob pattern', (t) => {
+  const result = shell.cp('test\\resources\\file*.txt', t.context.tmp);
+  t.falsy(shell.error());
+  t.falsy(result.stderr);
+  t.is(result.code, 0);
+  t.truthy(fs.existsSync(`${t.context.tmp}/file1.txt`));
+  t.truthy(fs.existsSync(`${t.context.tmp}/file2.txt`));
+});

--- a/test/cp.js
+++ b/test/cp.js
@@ -996,11 +996,11 @@ test('copy single file to itself should not erase content', t => {
 
 test('cp with Windows-style backslash and glob pattern', (t) => {
   utils.skipOnUnix(t, () => {
-  const result = shell.cp('test\\resources\\file*.txt', t.context.tmp);
-    t.falsy(shell.error());
-    t.falsy(result.stderr);
-    t.is(result.code, 0);
-    t.truthy(fs.existsSync(`${t.context.tmp}/file1.txt`));
-    t.truthy(fs.existsSync(`${t.context.tmp}/file2.txt`));
-  });
+    const result = shell.cp('test\\resources\\file*.txt', t.context.tmp);
+      t.falsy(shell.error());
+      t.falsy(result.stderr);
+      t.is(result.code, 0);
+      t.truthy(fs.existsSync(`${t.context.tmp}/file1.txt`));
+      t.truthy(fs.existsSync(`${t.context.tmp}/file2.txt`));
+    });
 });


### PR DESCRIPTION
This PR adds `convertPathToPattern` to `expand` in `common.js` to fix the handling of glob patterns for Windows file paths.

The [switch to fast-glob](https://github.com/shelljs/shelljs/commit/13cfe8a258b891d865871b8b443358f04f0043af) broke the handling of paths with backslashes on Windows.

This is a limitation of the fast-glob library. From the [README](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#how-to-write-patterns-on-windows):

>Always use forward-slashes in glob expressions (patterns and [ignore](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#ignore) option).
Use backslashes for escaping characters.
[...]
Use the [.convertPathToPattern](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#convertpathtopatternpath) package to convert Windows-style path to a Unix-style path.

This PR includes tests for expand and cp that include paths with backslashes. Both of these tests fail without the fix and pass once the fix is added.

Fixes https://github.com/shelljs/shelljs/issues/1246