### PR TITLE
fix: report chdir errors from cd

### DIFF
--- a/src/cd.js
+++ b/src/cd.js
@@ -28,8 +28,12 @@ function _cd(options, dir) {
     // something went wrong, let's figure out the error
     var err;
     try {
-      common.statFollowLinks(dir); // if this succeeds, it must be some sort of file
-      err = 'not a directory: ' + dir;
+      var stat = common.statFollowLinks(dir);
+      if (!stat.isDirectory()) {
+        err = 'not a directory: ' + dir;
+      } else {
+        err = e.message;
+      }
     } catch (e2) {
       err = 'no such file or directory: ' + dir;
     }

--- a/test/cd.js
+++ b/test/cd.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { Worker } = require('worker_threads');
 
 const test = require('ava');
 
@@ -39,6 +40,40 @@ test('file not dir', t => {
   t.truthy(shell.error());
   t.is(result.code, 1);
   t.is(result.stderr, 'cd: not a directory: test/resources/file1');
+});
+
+test('reports process.chdir() errors for existing directories', async t => {
+  const repoDir = path.resolve(__dirname, '..');
+  const result = await new Promise((resolve, reject) => {
+    let message;
+    const worker = new Worker(`
+      const { parentPort } = require('worker_threads');
+      const shell = require(${JSON.stringify(repoDir)});
+      shell.config.resetForTesting();
+      const result = shell.cd(${JSON.stringify(repoDir)});
+      parentPort.postMessage({
+        code: result.code,
+        stderr: result.stderr,
+        error: shell.error(),
+      });
+    `, { eval: true });
+
+    worker.once('message', value => {
+      message = value;
+    });
+    worker.once('error', reject);
+    worker.once('exit', code => {
+      if (code !== 0) {
+        reject(new Error(`Worker stopped with exit code ${code}`));
+      } else {
+        resolve(message);
+      }
+    });
+  });
+
+  t.is(result.code, 1);
+  t.regex(result.stderr, /^cd: process\.chdir\(\) is not supported in workers$/);
+  t.is(result.error, result.stderr);
 });
 
 test('no previous dir', t => {


### PR DESCRIPTION
Fixes #1112.

When `process.chdir()` fails for an existing directory, `cd()` currently reclassifies the target as `not a directory`. In worker threads this hides Node's actual `process.chdir() is not supported in workers` error.

This keeps the existing `no such file or directory` and `not a directory` paths, but reports the original `process.chdir()` error when the target exists and is a directory.

Validation:
- `npx ava test/cd.js --match='reports process.chdir() errors for existing directories'`
- `npx ava test/cd.js`
- `npm run test-with-coverage -- test/cd.js`
- `npm run lint`
- `git diff --check`

I also ran `npm test`; the `cd` tests passed, and the remaining local failures reproduced on a clean checkout before this change: `chmod › Test setgid` and four `ls › long option` assertions where this environment reports gid `0`.
