### PR TITLE
test: add coverage for mkdir -p on existing directories

### DIFF
--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -201,3 +201,24 @@ test('non-normalized paths are still ok with -p', t => {
   t.is(result.code, 0);
   t.truthy(fs.existsSync(`${t.context.tmp}/asdf`));
 });
+
+test('-p flag: existing directory', t => {
+  shell.mkdir(`${t.context.tmp}/existing`);
+  t.falsy(shell.error());
+  t.truthy(fs.existsSync(`${t.context.tmp}/existing`));
+  const result = shell.mkdir('-p', `${t.context.tmp}/existing`);
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.truthy(fs.existsSync(`${t.context.tmp}/existing`));
+});
+
+test('-p flag: create new subdirectory within existing tree', t => {
+  shell.mkdir('-p', `${t.context.tmp}/grandparent`);
+  t.falsy(shell.error());
+  t.truthy(fs.existsSync(`${t.context.tmp}/grandparent`));
+  const result = shell.mkdir('-p', `${t.context.tmp}/grandparent/parent/child`);
+  t.falsy(shell.error());
+  t.is(result.code, 0);
+  t.truthy(fs.existsSync(`${t.context.tmp}/grandparent/parent`));
+  t.truthy(fs.existsSync(`${t.context.tmp}/grandparent/parent/child`));
+});


### PR DESCRIPTION
Adds test cases for  on directories that already exist:

1.  on a directory that already exists (should succeed silently)
2.  to create a new subdirectory within an already-existing tree

Fixes #1022